### PR TITLE
add faststream integration link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,8 @@ class Dependencies(BaseGraph):
 For now there are integration for the following frameworks:
 
 1. [FastAPI](integrations/fastapi)
-2. [LiteStar](integrations/litestar)
+2. [FastStream](integrations/faststream)
+3. [LiteStar](integrations/litestar)
 
 ## 4.2. Or use `modern-di` without integrations
 


### PR DESCRIPTION
Hi!

I was reviewing the docs, and I guess the faststream link was missed.