### PR TITLE
Add context manager support, __repr__, and skip_creator_parsing warning

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -125,6 +125,23 @@ class Container:
     def set_context(self, context_type: type[types.T], obj: types.T) -> None:
         self.context_registry.set_context(context_type, obj)
 
+    def __repr__(self) -> str:
+        n_providers = len(self.providers_registry)
+        n_cached = self.cache_registry.cached_count()
+        return f"Container(scope={self.scope!r}, providers={n_providers}, cached={n_cached})"
+
+    def __enter__(self) -> "typing_extensions.Self":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close_sync()
+
+    async def __aenter__(self) -> "typing_extensions.Self":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close_async()
+
     def __deepcopy__(self, *_: object, **__: object) -> "typing_extensions.Self":
         """Prevent cloning object."""
         return self

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -22,9 +22,12 @@ class ContextProvider(AbstractProvider[types.T_co]):
         super().__init__(scope=scope, bound_type=bound_type if bound_type != types.UNSET else context_type)
         self._context_type = context_type
 
+    def __repr__(self) -> str:
+        return f"ContextProvider(context_type={self._context_type!r}, scope={self.scope!r})"
+
     def validate(self, container: "Container") -> dict[str, typing.Any]:  # noqa: ARG002
         return {"bound_type": self.bound_type, "self": self}
 
     def resolve(self, container: "Container") -> types.T_co | None:
         container = container.find_container(self.scope)
-        return container.context_registry.find_context(typing.cast(type[types.T_co], self._context_type))
+        return container.context_registry.find_context(self._context_type)

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -1,6 +1,7 @@
 import dataclasses
 import inspect
 import typing
+import warnings
 
 from modern_di import errors, types
 from modern_di.providers import ContextProvider
@@ -37,6 +38,13 @@ class Factory(AbstractProvider[types.T_co]):
         skip_creator_parsing: bool = False,
     ) -> None:
         if skip_creator_parsing:
+            if bound_type is types.UNSET:
+                warnings.warn(
+                    "skip_creator_parsing=True without an explicit bound_type means this provider "
+                    "cannot be resolved by type. Pass bound_type=MyClass if you need type resolution.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             parsed_type: type | None = None
             parsed_kwargs: dict[str, SignatureItem] = {}
         else:
@@ -48,12 +56,17 @@ class Factory(AbstractProvider[types.T_co]):
         self.cache_settings = cache_settings
         self._kwargs = kwargs
 
+    def __repr__(self) -> str:
+        return f"Factory(creator={self._creator!r}, scope={self.scope!r}, cached={self.cache_settings is not None})"
+
     def _compile_kwargs(self, container: "Container") -> dict[str, typing.Any]:
         result: dict[str, typing.Any] = {}
         for k, v in self._parsed_kwargs.items():
             provider: AbstractProvider[types.T_co] | None = None
             if v.arg_type:
-                provider = container.providers_registry.find_provider(v.arg_type)
+                provider = typing.cast(
+                    AbstractProvider[types.T_co] | None, container.providers_registry.find_provider(v.arg_type)
+                )
                 if provider is self:
                     provider = None
             else:

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -43,6 +43,9 @@ class CacheItem:
 class CacheRegistry:
     _items: dict[str, CacheItem] = dataclasses.field(init=False, default_factory=dict)
 
+    def cached_count(self) -> int:
+        return sum(1 for item in self._items.values() if item.cache is not None)
+
     def fetch_cache_item(self, provider: Factory[types.T_co]) -> CacheItem:
         return self._items.setdefault(provider.provider_id, CacheItem(settings=provider.cache_settings))
 

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -10,6 +10,9 @@ class ProvidersRegistry:
     def __init__(self) -> None:
         self._providers: dict[type, AbstractProvider[typing.Any]] = {}
 
+    def __len__(self) -> int:
+        return len(self._providers)
+
     def find_provider(self, dependency_type: type[types.T]) -> AbstractProvider[types.T] | None:
         return self._providers.get(dependency_type)
 

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -55,3 +55,8 @@ def test_context_provider_in_request_scope() -> None:
     instance1 = request_container.resolve_provider(request_context_provider)
     instance2 = request_container.resolve_provider(request_context_provider)
     assert instance1 is instance2 is now
+
+
+def test_context_provider_repr() -> None:
+    provider = providers.ContextProvider(context_type=str, scope=Scope.REQUEST)
+    assert repr(provider) == "ContextProvider(context_type=<class 'str'>, scope=<Scope.REQUEST: 3>)"

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -1,5 +1,6 @@
 import dataclasses
 import re
+import warnings
 
 import pytest
 
@@ -32,7 +33,9 @@ def func_with_broken_annotation(dep1: "SomeWrongClass") -> None: ...  # ty: igno
 class MyGroup(Group):
     app_factory = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "original"})
     app_factory_unresolvable = providers.Factory(creator=SimpleCreator, bound_type=None)
-    app_factory_skip_creator_parsing = providers.Factory(creator=SimpleCreator, skip_creator_parsing=True)
+    app_factory_skip_creator_parsing = providers.Factory(
+        creator=SimpleCreator, skip_creator_parsing=True, bound_type=None
+    )
     func_with_union_factory = providers.Factory(creator=func_with_union, bound_type=None)
     func_with_broken_annotation = providers.Factory(creator=func_with_broken_annotation, bound_type=None)
     request_factory = providers.Factory(scope=Scope.REQUEST, creator=DependentCreator)
@@ -168,3 +171,24 @@ def test_factory_self_reference() -> None:
     app_container.providers_registry.add_providers(first_factory, second_factory)
 
     assert app_container.resolve_provider(second_factory) == "one two"
+
+
+def test_factory_repr() -> None:
+    provider = providers.Factory(creator=str, scope=Scope.APP)
+    assert repr(provider) == "Factory(creator=<class 'str'>, scope=<Scope.APP: 1>, cached=False)"
+
+
+def test_factory_repr_cached() -> None:
+    provider = providers.Factory(creator=str, scope=Scope.APP, cache_settings=providers.CacheSettings())
+    assert repr(provider) == "Factory(creator=<class 'str'>, scope=<Scope.APP: 1>, cached=True)"
+
+
+def test_factory_skip_creator_parsing_without_bound_type_warns() -> None:
+    with pytest.warns(UserWarning, match="skip_creator_parsing=True without an explicit bound_type"):
+        providers.Factory(creator=str, skip_creator_parsing=True)
+
+
+def test_factory_skip_creator_parsing_with_bound_type_no_warning() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        providers.Factory(creator=str, skip_creator_parsing=True, bound_type=str)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -42,3 +42,24 @@ def test_container_resolve_missing_provider() -> None:
     app_container = Container()
     with pytest.raises(RuntimeError, match=r"Provider of type <class 'str'> is not registered in providers registry."):
         assert app_container.resolve(str) is None
+
+
+def test_container_sync_context_manager() -> None:
+    with Container() as container:
+        assert container.scope == Scope.APP
+
+    with container.build_child_container(scope=Scope.REQUEST) as request_container:
+        assert request_container.scope == Scope.REQUEST
+
+
+async def test_container_async_context_manager() -> None:
+    async with Container() as container:
+        assert container.scope == Scope.APP
+
+    async with container.build_child_container(scope=Scope.REQUEST) as request_container:
+        assert request_container.scope == Scope.REQUEST
+
+
+def test_container_repr() -> None:
+    container = Container()
+    assert repr(container) == "Container(scope=<Scope.APP: 1>, providers=1, cached=0)"


### PR DESCRIPTION
- Container supports `with`/`async with` via __enter__/__exit__/__aenter__/__aexit__
- Factory and ContextProvider have informative __repr__
- Container.__repr__ shows scope, provider count, and cached count
- Warn when skip_creator_parsing=True without explicit bound_type
- Add __len__ to ProvidersRegistry and cached_count() to CacheRegistry