### PR TITLE
DX polish: repr, keyword-only build_child_container, typed UNSET, error hints

### DIFF
--- a/docs/providers/container.md
+++ b/docs/providers/container.md
@@ -44,3 +44,30 @@ class Dependencies(Group):
         kwargs={"di_container": providers.container_provider}
     )
 ```
+
+## Context Propagation
+
+`ContextRegistry` is **per-container**. Calling `set_context` on a parent container does not propagate to child containers that were already built — each container keeps its own context map.
+
+!!! warning "set_context only affects this container"
+    The following does **not** work as written:
+
+    ```python
+    app_container = Container()
+    request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    app_container.set_context(MyContext, value)  # invisible to request_container
+    ```
+
+    Either set context **before** building the child, or pass it via `build_child_container`:
+
+    ```python
+    # Option A: set on the parent first
+    app_container = Container()
+    app_container.set_context(MyContext, value)
+    request_container = app_container.build_child_container(scope=Scope.REQUEST)
+
+    # Option B: pass context directly to the child
+    request_container = app_container.build_child_container(
+        scope=Scope.REQUEST, context={MyContext: value}
+    )
+    ```

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -60,7 +60,10 @@ class Container:
             self.validate()
 
     def build_child_container(
-        self, context: dict[type[typing.Any], typing.Any] | None = None, scope: enum.IntEnum | None = None
+        self,
+        *,
+        scope: enum.IntEnum | None = None,
+        context: dict[type[typing.Any], typing.Any] | None = None,
     ) -> "typing_extensions.Self":
         if scope and scope <= self.scope:
             raise exceptions.InvalidChildScopeError(
@@ -81,7 +84,7 @@ class Container:
         if scope not in self.scope_map:
             if scope > self.scope:
                 raise exceptions.ScopeNotInitializedError(provider_scope=scope, container_scope=self.scope)
-            raise exceptions.ScopeSkippedError(provider_scope=scope)
+            raise exceptions.ScopeSkippedError(provider_scope=scope, container_scope=self.scope)
         return self.scope_map[scope]
 
     def resolve(self, dependency_type: type[types.T]) -> types.T:
@@ -139,19 +142,27 @@ class Container:
             self.overrides_registry.reset_override()
         self.cache_registry.close_sync()
 
-    def override(self, provider: AbstractProvider[types.T], override_object: object) -> None:
+    def override(self, provider: AbstractProvider[types.T], override_object: types.T) -> None:
         self.overrides_registry.override(provider.provider_id, override_object)
 
     def reset_override(self, provider: AbstractProvider[types.T] | None = None) -> None:
         self.overrides_registry.reset_override(provider.provider_id if provider else None)
 
     def set_context(self, context_type: type[types.T], obj: types.T) -> None:
+        """Register a runtime context value on *this* container only.
+
+        ``ContextRegistry`` is per-container. Values set here are not seen by
+        child containers that were already built. Either set context before
+        calling :meth:`build_child_container`, or pass ``context={...}`` to
+        :meth:`build_child_container` directly.
+        """
         self.context_registry.set_context(context_type, obj)
 
     def __repr__(self) -> str:
         n_providers = len(self.providers_registry)
         n_cached = self.cache_registry.cached_count()
-        return f"Container(scope={self.scope!r}, providers={n_providers}, cached={n_cached})"
+        parent = self.parent_container.scope.name if self.parent_container else None
+        return f"Container(scope={self.scope.name}, parent={parent}, providers={n_providers}, cached={n_cached})"
 
     def __enter__(self) -> "typing_extensions.Self":
         return self

--- a/modern_di/errors.py
+++ b/modern_di/errors.py
@@ -1,12 +1,20 @@
 CONTAINER_SCOPE_IS_LOWER_ERROR = (
-    "Scope of child container cannot be {child_scope} if parent scope is {parent_scope}. "
+    "Scope of child container cannot be {child_scope} if parent scope is {parent_scope} "
+    "(child scope value must be strictly greater than parent scope value). "
     "Possible scopes are {allowed_scopes}."
 )
-CONTAINER_MAX_SCOPE_REACHED_ERROR = "Max scope of {parent_scope} is reached."
+CONTAINER_MAX_SCOPE_REACHED_ERROR = (
+    "Max scope of {parent_scope} is reached. "
+    "To go deeper, build a child container with a custom IntEnum scope whose value is higher."
+)
 CONTAINER_NOT_INITIALIZED_SCOPE_ERROR = (
     "Provider of scope {provider_scope} cannot be resolved in container of scope {container_scope}."
 )
-CONTAINER_SCOPE_IS_SKIPPED_ERROR = "Provider of scope {provider_scope} is skipped in the chain of containers."
+CONTAINER_SCOPE_IS_SKIPPED_ERROR = (
+    "No {provider_scope}-scope container exists in this chain; "
+    "this chain starts at {container_scope}. "
+    "Build a {provider_scope}-scope container as the root."
+)
 CONTAINER_MISSING_PROVIDER_ERROR = "Provider of type {provider_type} is not registered in providers registry."
 SUGGESTION_HEADER = "Did you mean:"
 SUGGESTION_SUBCLASS = "  - {type_name} (registered subclass, scope={scope})"

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -52,9 +52,15 @@ class ScopeNotInitializedError(ContainerError):
 
 
 class ScopeSkippedError(ContainerError):
-    def __init__(self, *, provider_scope: enum.IntEnum) -> None:
+    def __init__(self, *, provider_scope: enum.IntEnum, container_scope: enum.IntEnum) -> None:
         self.provider_scope = provider_scope
-        super().__init__(errors.CONTAINER_SCOPE_IS_SKIPPED_ERROR.format(provider_scope=provider_scope.name))
+        self.container_scope = container_scope
+        super().__init__(
+            errors.CONTAINER_SCOPE_IS_SKIPPED_ERROR.format(
+                provider_scope=provider_scope.name,
+                container_scope=container_scope.name,
+            )
+        )
 
 
 class ResolutionError(ModernDIError):

--- a/modern_di/providers/alias.py
+++ b/modern_di/providers/alias.py
@@ -18,9 +18,9 @@ class Alias(AbstractProvider[types.T_co]):
         *,
         source_type: type[types.T_co],
         scope: enum.IntEnum = Scope.APP,
-        bound_type: type | None = types.UNSET,  # ty: ignore[invalid-parameter-default]
+        bound_type: type | None | types.UnsetType = types.UNSET,
     ) -> None:
-        super().__init__(scope=scope, bound_type=bound_type if bound_type != types.UNSET else source_type)
+        super().__init__(scope=scope, bound_type=source_type if isinstance(bound_type, types.UnsetType) else bound_type)
         self._source_type = source_type
 
     def __repr__(self) -> str:

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -18,9 +18,11 @@ class ContextProvider(AbstractProvider[types.T_co]):
         *,
         scope: enum.IntEnum = Scope.APP,
         context_type: type[types.T_co],
-        bound_type: type | None = types.UNSET,  # ty: ignore[invalid-parameter-default]
+        bound_type: type | None | types.UnsetType = types.UNSET,
     ) -> None:
-        super().__init__(scope=scope, bound_type=bound_type if bound_type != types.UNSET else context_type)
+        super().__init__(
+            scope=scope, bound_type=context_type if isinstance(bound_type, types.UnsetType) else bound_type
+        )
         self._context_type = context_type
 
     def __repr__(self) -> str:

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -34,7 +34,7 @@ class Factory(AbstractProvider[types.T_co]):
         *,
         scope: enum.IntEnum = Scope.APP,
         creator: typing.Callable[..., types.T_co],
-        bound_type: type | None = types.UNSET,  # ty: ignore[invalid-parameter-default]
+        bound_type: type | None | types.UnsetType = types.UNSET,
         kwargs: dict[str, typing.Any] | None = None,
         cache_settings: CacheSettings[types.T_co] | None = None,
         skip_creator_parsing: bool = False,
@@ -53,7 +53,7 @@ class Factory(AbstractProvider[types.T_co]):
             return_sig, parsed_kwargs = parse_creator(creator)
             parsed_type = return_sig.arg_type
         self._parsed_kwargs = parsed_kwargs
-        super().__init__(scope=scope, bound_type=bound_type if bound_type != types.UNSET else parsed_type)
+        super().__init__(scope=scope, bound_type=parsed_type if isinstance(bound_type, types.UnsetType) else bound_type)
         self._creator = creator
         self.cache_settings = cache_settings
         self._kwargs = kwargs

--- a/modern_di/types.py
+++ b/modern_di/types.py
@@ -4,4 +4,20 @@ import typing
 T_co = typing.TypeVar("T_co", covariant=True)
 T = typing.TypeVar("T")
 P = typing.ParamSpec("P")
-UNSET = object()
+
+
+class UnsetType:
+    """Sentinel type for parameters that distinguish 'not passed' from 'explicitly None'.
+
+    The :data:`UNSET` module-level instance is the canonical sentinel. Use
+    ``isinstance(value, UnsetType)`` or ``value is UNSET`` to detect it.
+    """
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET: typing.Final[UnsetType] = UnsetType()

--- a/modern_di/types.py
+++ b/modern_di/types.py
@@ -16,8 +16,5 @@ class UnsetType:
     def __repr__(self) -> str:
         return "UNSET"
 
-    def __bool__(self) -> bool:
-        return False
-
 
 UNSET: typing.Final[UnsetType] = UnsetType()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -25,7 +25,7 @@ def test_container_prevent_copy() -> None:
 def test_container_scope_skipped() -> None:
     app_factory = providers.Factory(creator=lambda: "test")
     container = Container(scope=Scope.REQUEST)
-    with pytest.raises(ScopeSkippedError, match=r"Provider of scope APP is skipped in the chain of containers.") as exc:
+    with pytest.raises(ScopeSkippedError, match=r"No APP-scope container exists in this chain") as exc:
         container.resolve_provider(app_factory)
     assert exc.value.provider_scope == Scope.APP
 
@@ -80,7 +80,10 @@ async def test_container_async_context_manager() -> None:
 
 def test_container_repr() -> None:
     container = Container()
-    assert repr(container) == "Container(scope=<Scope.APP: 1>, providers=1, cached=0)"
+    assert repr(container) == "Container(scope=APP, parent=None, providers=1, cached=0)"
+
+    request_container = container.build_child_container(scope=Scope.REQUEST)
+    assert repr(request_container) == "Container(scope=REQUEST, parent=APP, providers=1, cached=0)"
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)


### PR DESCRIPTION
## Summary

Six Tier-1/2 items from `plan.md` (#4, #6, #7, #8, #10, #15–#17). Each is small and topically diverse; bundled into one PR because they share verification (lint + full test suite) and individually wouldn't warrant their own review cycle.

### #4 — `set_context` propagation docs
`ContextRegistry` is per-container. Calling `set_context` on a parent after `build_child_container` doesn't propagate to the already-built child. Added a docstring on `Container.set_context` and a "Context Propagation" `!!! warning` section in `docs/providers/container.md` showing the broken pattern plus both fixes (set first, or pass `context={...}` to `build_child_container`).

### #6 — `override` generic typing
`Container.override(provider, override_object: object)` lost the generic `T`. Tightened to `override_object: types.T` so type checkers catch shape mismatches in tests. All existing call sites (tests + docs) pass real subclass instances; no breakage.

### #7 — `__repr__` shows parent
Old: `Container(scope=<Scope.APP: 1>, providers=1, cached=0)`
New: `Container(scope=APP, parent=APP, providers=1, cached=0)` (child container example).
Replaces the verbose enum repr with `scope.name` and adds the parent's scope. Useful for nested debugging.

### #8 — `build_child_container` keyword-only, swap order
Old: `(self, context=None, scope=None)` — positional, with the inconvenient order.
New: `(self, *, scope=None, context=None)` — keyword-only, scope-first.

**Audited every caller across the ecosystem:** 38 sites in this repo + all 5 sibling integration repos (`modern-di-fastapi`, `modern-di-faststream`, `modern-di-litestar`, `modern-di-pytest`, `modern-di-typer`). Zero positional callers. Safe across the modern-python ecosystem.

**External breaking change:** downstream users passing positionally will need to update.

### #10 — typed UNSET sentinel removes `# ty: ignore`
`UNSET = object()` had no useful type, so `bound_type: type | None = types.UNSET` needed `# ty: ignore[invalid-parameter-default]` on three provider constructors. Replaced with a real `UnsetType` class; three constructors now declare `bound_type: type | None | types.UnsetType = types.UNSET` and the suppression comments are gone. Body sites use `isinstance(bound_type, types.UnsetType)` for proper narrowing.

### #15-17 — error message polish
- `InvalidChildScopeError`: appends "(child scope value must be strictly greater than parent scope value)".
- `MaxScopeReachedError`: appends "To go deeper, build a child container with a custom IntEnum scope whose value is higher." (custom scopes are documented but invisible in this error).
- `ScopeSkippedError`: gained `container_scope` field and a much clearer message: "No APP-scope container exists in this chain; this chain starts at {container_scope}. Build an APP-scope container as the root."

## Test plan
- [x] `just lint` — clean (ruff format + check, ty)
- [x] `just test` — 122 passed
- [x] Manual repr smoke check: root + child reprs match new format
- [x] Updated `tests/test_container.py:repr` and `:scope_skipped` for new strings; `tests/test_custom_scope.py:68` substring match still passes; `MaxScopeReachedError` / `InvalidChildScopeError` substring assertions in `test_container.py` still pass since the new messages embed the old phrasing
- [x] `skip_creator_parsing` warning test in `test_factory.py` still passes — guards UNSET-vs-explicit-bound_type semantics in #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)