### PR TITLE
Raise on async finalizer in close_sync; drop Group cache; slot exceptions

### DIFF
--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -14,12 +14,18 @@ class ResolutionStep:
 class ModernDIError(RuntimeError):
     """Base class for all modern-di errors. Inherits from RuntimeError for backwards compatibility."""
 
+    __slots__ = ()
+
 
 class ContainerError(ModernDIError):
     """Base class for container and scope errors."""
 
+    __slots__ = ()
+
 
 class InvalidChildScopeError(ContainerError):
+    __slots__ = ("allowed_scopes", "child_scope", "parent_scope")
+
     def __init__(self, *, parent_scope: enum.IntEnum, child_scope: enum.IntEnum, allowed_scopes: list[str]) -> None:
         self.parent_scope = parent_scope
         self.child_scope = child_scope
@@ -34,12 +40,16 @@ class InvalidChildScopeError(ContainerError):
 
 
 class MaxScopeReachedError(ContainerError):
+    __slots__ = ("parent_scope",)
+
     def __init__(self, *, parent_scope: enum.IntEnum) -> None:
         self.parent_scope = parent_scope
         super().__init__(errors.CONTAINER_MAX_SCOPE_REACHED_ERROR.format(parent_scope=parent_scope.name))
 
 
 class ScopeNotInitializedError(ContainerError):
+    __slots__ = ("container_scope", "provider_scope")
+
     def __init__(self, *, provider_scope: enum.IntEnum, container_scope: enum.IntEnum) -> None:
         self.provider_scope = provider_scope
         self.container_scope = container_scope
@@ -52,6 +62,8 @@ class ScopeNotInitializedError(ContainerError):
 
 
 class ScopeSkippedError(ContainerError):
+    __slots__ = ("container_scope", "provider_scope")
+
     def __init__(self, *, provider_scope: enum.IntEnum, container_scope: enum.IntEnum) -> None:
         self.provider_scope = provider_scope
         self.container_scope = container_scope
@@ -70,6 +82,8 @@ class ResolutionError(ModernDIError):
     the resolution chain, so the rendered message shows the full path from the
     initially requested type down to the failing dependency.
     """
+
+    __slots__ = ("_base_message", "dependency_path")
 
     def __init__(self, message: str) -> None:
         self._base_message = message
@@ -94,6 +108,8 @@ class ResolutionError(ModernDIError):
 
 
 class ProviderNotRegisteredError(ResolutionError):
+    __slots__ = ("provider_type", "suggestions")
+
     def __init__(
         self,
         *,
@@ -109,12 +125,16 @@ class ProviderNotRegisteredError(ResolutionError):
 
 
 class AliasSourceNotRegisteredError(ResolutionError):
+    __slots__ = ("source_type",)
+
     def __init__(self, *, source_type: type) -> None:
         self.source_type = source_type
         super().__init__(errors.ALIAS_SOURCE_NOT_REGISTERED_ERROR.format(source_type=source_type))
 
 
 class ArgumentResolutionError(ResolutionError):
+    __slots__ = ("arg_name", "arg_type", "bound_type", "suggestions")
+
     def __init__(
         self,
         *,
@@ -138,6 +158,8 @@ class ArgumentResolutionError(ResolutionError):
 
 
 class CircularDependencyError(ResolutionError):
+    __slots__ = ("cycle_path",)
+
     def __init__(self, *, cycle_path: list[str]) -> None:
         self.cycle_path = cycle_path
         super().__init__(errors.CYCLE_DEPENDENCY_ERROR.format(cycle_path=" -> ".join(cycle_path)))
@@ -146,14 +168,20 @@ class CircularDependencyError(ResolutionError):
 class RegistrationError(ModernDIError):
     """Base class for errors raised while registering providers."""
 
+    __slots__ = ()
+
 
 class DuplicateProviderTypeError(RegistrationError):
+    __slots__ = ("provider_type",)
+
     def __init__(self, *, provider_type: type) -> None:
         self.provider_type = provider_type
         super().__init__(errors.PROVIDER_DUPLICATE_TYPE_ERROR.format(provider_type=provider_type))
 
 
 class FinalizerError(ModernDIError):
+    __slots__ = ("finalizer_errors", "is_async")
+
     def __init__(self, *, finalizer_errors: list[BaseException], is_async: bool) -> None:
         self.finalizer_errors = finalizer_errors
         self.is_async = is_async
@@ -161,7 +189,22 @@ class FinalizerError(ModernDIError):
         super().__init__(f"Errors during {kind} cleanup: {finalizer_errors}")
 
 
+class AsyncFinalizerInSyncCloseError(ModernDIError):
+    """Raised when ``close_sync`` encounters a cached resource with an async finalizer."""
+
+    __slots__ = ("finalizer_type",)
+
+    def __init__(self, *, finalizer_type: type) -> None:
+        self.finalizer_type = finalizer_type
+        super().__init__(
+            f"Cannot run async finalizer for {finalizer_type.__name__} during sync close. "
+            f"Use `await container.close_async()` (or `async with container:`) instead."
+        )
+
+
 class GroupInstantiationError(ModernDIError):
+    __slots__ = ("group_name",)
+
     def __init__(self, *, group_name: str) -> None:
         self.group_name = group_name
         super().__init__(f"{group_name} cannot be instantiated")

--- a/modern_di/group.py
+++ b/modern_di/group.py
@@ -13,14 +13,9 @@ P = typing.ParamSpec("P")
 
 
 class Group:
-    providers: list[AbstractProvider[typing.Any]]
-
     def __new__(cls, *_: typing.Any, **__: typing.Any) -> "typing_extensions.Self":  # noqa: ANN401
         raise exceptions.GroupInstantiationError(group_name=cls.__name__)
 
     @classmethod
     def get_providers(cls) -> list[AbstractProvider[typing.Any]]:
-        if not hasattr(cls, "providers"):
-            cls.providers = [x for x in cls.__dict__.values() if isinstance(x, AbstractProvider)]
-
-        return list(cls.providers)
+        return [x for x in cls.__dict__.values() if isinstance(x, AbstractProvider)]

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -138,7 +138,7 @@ class Factory(AbstractProvider[types.T_co]):
         container = container.find_container(self.scope)
         cache_item = container.cache_registry.fetch_cache_item(self)
 
-        if self.cache_settings and cache_item.cache is not None:
+        if self.cache_settings and cache_item.cache is not types.UNSET:
             return cache_item.cache
 
         try:
@@ -157,7 +157,7 @@ class Factory(AbstractProvider[types.T_co]):
             container.lock.acquire()
 
         try:
-            if cache_item.cache is not None:
+            if cache_item.cache is not types.UNSET:
                 return cache_item.cache
 
             instance = self._creator(**resolved_kwargs)

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -1,6 +1,5 @@
 import dataclasses
 import typing
-import warnings
 
 from modern_di import exceptions, types
 from modern_di.providers import CacheSettings, Factory
@@ -30,12 +29,7 @@ class CacheItem:
     def close_sync(self) -> None:
         if self.cache and self.settings and self.settings.finalizer:
             if self.settings.is_async_finalizer:
-                warnings.warn(
-                    f"Calling `close_sync` for async finalizer, type={type(self.cache)}",
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-                return
+                raise exceptions.AsyncFinalizerInSyncCloseError(finalizer_type=type(self.cache))
             self.settings.finalizer(self.cache)
 
         self._clear()

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -8,17 +8,17 @@ from modern_di.providers import CacheSettings, Factory
 @dataclasses.dataclass(kw_only=True, slots=True)
 class CacheItem:
     settings: CacheSettings[typing.Any] | None
-    cache: typing.Any | None = None
+    cache: typing.Any = types.UNSET
     kwargs_compiled: bool = False
     provider_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
     static_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
 
     def _clear(self) -> None:
         if self.settings and self.settings.clear_cache:
-            self.cache = None
+            self.cache = types.UNSET
 
     async def close_async(self) -> None:
-        if self.cache and self.settings and self.settings.finalizer:
+        if self.cache is not types.UNSET and self.settings and self.settings.finalizer:
             if self.settings.is_async_finalizer:
                 await self.settings.finalizer(self.cache)  # ty: ignore[invalid-await]
             else:
@@ -27,7 +27,7 @@ class CacheItem:
         self._clear()
 
     def close_sync(self) -> None:
-        if self.cache and self.settings and self.settings.finalizer:
+        if self.cache is not types.UNSET and self.settings and self.settings.finalizer:
             if self.settings.is_async_finalizer:
                 raise exceptions.AsyncFinalizerInSyncCloseError(finalizer_type=type(self.cache))
             self.settings.finalizer(self.cache)
@@ -40,7 +40,7 @@ class CacheRegistry:
     _items: dict[int, CacheItem] = dataclasses.field(init=False, default_factory=dict)
 
     def cached_count(self) -> int:
-        return sum(1 for item in self._items.values() if item.cache is not None)
+        return sum(1 for item in self._items.values() if item.cache is not types.UNSET)
 
     def fetch_cache_item(self, provider: Factory[types.T_co]) -> CacheItem:
         return self._items.setdefault(provider.provider_id, CacheItem(settings=provider.cache_settings))

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -7,6 +7,7 @@ import pytest
 
 from modern_di import Container, Group, Scope, providers
 from modern_di.exceptions import AsyncFinalizerInSyncCloseError, FinalizerError
+from modern_di.types import UNSET
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
@@ -45,7 +46,7 @@ async def test_app_singleton() -> None:
     assert singleton1 is singleton2
     app_container.close_sync()
     cache_item = app_container.cache_registry.fetch_cache_item(MyGroup.app_singleton)
-    assert cache_item.cache
+    assert cache_item.cache is not UNSET
 
     app_container.resolve_provider(MyGroup.app_singleton)
     await app_container.close_async()
@@ -73,10 +74,10 @@ async def test_request_singleton() -> None:
     assert len(exc_info.value.finalizer_errors) == 1
     assert isinstance(exc_info.value.finalizer_errors[0], AsyncFinalizerInSyncCloseError)
 
-    assert cache_item.cache  # preserved — user can still recover via close_async
+    assert cache_item.cache is not UNSET  # preserved — user can still recover via close_async
     await request_container.close_async()
 
-    assert cache_item.cache is None
+    assert cache_item.cache is UNSET
 
 
 def test_app_singleton_in_request_scope() -> None:
@@ -158,6 +159,75 @@ async def test_async_finalizer_exception_does_not_abort_remaining_cleanup() -> N
     assert len(exc.value.finalizer_errors) == 1
 
     assert cleaned_up == ["done"]
+
+
+def test_finalizer_runs_for_falsy_cached_resource_sync() -> None:
+    cleaned_up: list[object] = []
+
+    def collect(value: object) -> None:
+        cleaned_up.append(value)
+
+    class FalsyGroup(Group):
+        empty_dict = providers.Factory(
+            creator=dict,
+            cache_settings=providers.CacheSettings(finalizer=collect),
+        )
+
+    app_container = Container(groups=[FalsyGroup])
+    instance = app_container.resolve_provider(FalsyGroup.empty_dict)
+    assert instance == {}
+
+    app_container.close_sync()
+    assert cleaned_up == [{}]
+
+
+async def test_finalizer_runs_for_falsy_cached_resource_async() -> None:
+    cleaned_up: list[object] = []
+
+    async def collect(value: object) -> None:
+        cleaned_up.append(value)
+
+    class FalsyGroup(Group):
+        empty_list = providers.Factory(
+            creator=list,
+            cache_settings=providers.CacheSettings(finalizer=collect),
+        )
+
+    app_container = Container(groups=[FalsyGroup])
+    instance = app_container.resolve_provider(FalsyGroup.empty_list)
+    assert instance == []
+
+    await app_container.close_async()
+    assert cleaned_up == [[]]
+
+
+def test_cached_none_is_returned_and_finalized() -> None:
+    """A creator that returns ``None`` should be treated as a real cached value."""
+    call_count = 0
+    cleaned_up: list[object] = []
+
+    def create_none() -> None:
+        nonlocal call_count
+        call_count += 1
+
+    def collect(value: object) -> None:
+        cleaned_up.append(value)
+
+    class NoneGroup(Group):
+        none_resource = providers.Factory(
+            creator=create_none,
+            cache_settings=providers.CacheSettings(finalizer=collect),
+        )
+
+    app_container = Container(groups=[NoneGroup])
+    app_container.resolve_provider(NoneGroup.none_resource)
+    app_container.resolve_provider(NoneGroup.none_resource)
+
+    assert call_count == 1  # cached after first call, not re-created
+    assert app_container.cache_registry.cached_count() == 1
+
+    app_container.close_sync()
+    assert cleaned_up == [None]
 
 
 @pytest.mark.repeat(10)

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import FinalizerError
+from modern_di.exceptions import AsyncFinalizerInSyncCloseError, FinalizerError
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
@@ -67,10 +67,13 @@ async def test_request_singleton() -> None:
 
     cache_item = request_container.cache_registry.fetch_cache_item(MyGroup.request_singleton)
 
-    with pytest.warns(RuntimeWarning, match="Calling `close_sync` for async finalizer"):
+    with pytest.raises(FinalizerError) as exc_info:
         request_container.close_sync()
+    assert exc_info.value.is_async is False
+    assert len(exc_info.value.finalizer_errors) == 1
+    assert isinstance(exc_info.value.finalizer_errors[0], AsyncFinalizerInSyncCloseError)
 
-    assert cache_item.cache
+    assert cache_item.cache  # preserved — user can still recover via close_async
     await request_container.close_async()
 
     assert cache_item.cache is None


### PR DESCRIPTION
## Summary

Four changes — items #1 and #9 from `plan.md`, plus two adjacent cleanups discovered during verification.

### #1 — `close_sync` raises on async finalizers
Previously `CacheItem.close_sync` emitted a `RuntimeWarning` and silently returned when it found a cached resource with an async finalizer. The cache was preserved, but users had no actionable signal — they'd have to know to call `close_async()` next. Most won't.

Now `CacheItem.close_sync` raises `AsyncFinalizerInSyncCloseError` (a new exception class). The existing `CacheRegistry.close_sync` aggregation loop already wraps per-item exceptions into `FinalizerError`, so users get one clean error containing the list of offending types and a clear actionable message:

```
FinalizerError: Errors during sync cleanup: [
  AsyncFinalizerInSyncCloseError('Cannot run async finalizer for Resource during sync close. Use `await container.close_async()` (or `async with container:`) instead.')
]
```

Cached resources are preserved on the raise path, so the recovery flow ("call `close_async()` to actually clean up") is unchanged — just made explicit instead of silent.

**Picked "raise" over "unified `close()`" per the plan.md options.** A unified `close()` would still have to refuse on async finalizers (you can't await from sync code), so it'd be sugar over a louder `close_sync()` — feature creep without solving the actual choice.

### #9 — drop `Group.providers` cache
`Group.get_providers()` snapshotted into a class attribute on first call. Dynamic mutation of a Group after the first introspection silently went unseen. Audit confirmed: only one caller (`Container.__init__`), trivial cost (a `cls.__dict__` iteration over 2-10 attributes), no tests depend on the freeze. Now it just returns a fresh list every call. Pure correctness.

### Bonus — `__slots__` on all exception classes
Marker classes (`ModernDIError`, `ContainerError`, `RegistrationError`, `ResolutionError`) get `__slots__ = ()`. Subclasses with instance attrs get explicit tuples. Matches the project's existing lean-memory style (`Container`, registries, dataclasses with `slots=True`).

### Bonus — `CacheItem.cache` uses `UNSET` sentinel
`None` was overloaded as both "not cached" and a potentially-valid cached value. Two consequences:

1. A creator returning `None` was treated as never-cached — re-created on every resolve, finalizer never ran.
2. `if self.cache and ...` skipped finalizers for any cached-but-falsy resource (empty dict, `0`, `False`, empty string). Same anti-pattern PR #184 fixed in `ContextRegistry`.

Migrated `CacheItem.cache` to use `types.UNSET` as the "not cached" sentinel. All four discriminating sites updated (`_clear`, `close_async`, `close_sync`, `cached_count` in `cache_registry.py`; the two cached-value short-circuit reads in `factory.py:resolve`). Three new regression tests cover falsy-sync, falsy-async, and the None-returning creator path.

## Test plan
- [x] `just lint` — clean (ruff + ty)
- [x] `just test` — 125 passed (3 new), 100% coverage
- [x] `tests/providers/test_singleton.py::test_request_singleton` updated to expect `FinalizerError` wrapping `AsyncFinalizerInSyncCloseError` and uses `is UNSET` for cleared-cache assertion
- [x] Sibling test `test_sync_finalizer_exception_does_not_abort_remaining_cleanup` continues to pass (same aggregation path)
- [x] Manual smoke checks: container with async-finalized resource → `FinalizerError(AsyncFinalizerInSyncCloseError)`; container with None-returning creator caches once and finalizes; container with empty-dict creator finalizes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)