### PR TITLE
Distinguish missing scope from zero-valued IntEnum in build_child_container

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -65,14 +65,14 @@ class Container:
         scope: enum.IntEnum | None = None,
         context: dict[type[typing.Any], typing.Any] | None = None,
     ) -> "typing_extensions.Self":
-        if scope and scope <= self.scope:
+        if scope is not None and scope <= self.scope:
             raise exceptions.InvalidChildScopeError(
                 parent_scope=self.scope,
                 child_scope=scope,
                 allowed_scopes=[x.name for x in type(self.scope) if x > self.scope],
             )
 
-        if not scope:
+        if scope is None:
             try:
                 scope = self.scope.__class__(self.scope.value + 1)
             except ValueError as exc:

--- a/tests/test_custom_scope.py
+++ b/tests/test_custom_scope.py
@@ -108,3 +108,14 @@ def test_auto_derive_within_custom_enum() -> None:
     tenant_container = Container(scope=MyScope.TENANT)
     bg_container = tenant_container.build_child_container()
     assert bg_container.scope is MyScope.BACKGROUND_JOB
+
+
+def test_build_child_container_rejects_zero_valued_custom_scope() -> None:
+    class ZeroEnum(enum.IntEnum):
+        ZERO = 0
+        ONE = 1
+        TWO = 2
+
+    parent = Container(scope=ZeroEnum.ONE)
+    with pytest.raises(InvalidChildScopeError):
+        parent.build_child_container(scope=ZeroEnum.ZERO)


### PR DESCRIPTION
## Summary
- `Container.build_child_container` was using `if scope and …` / `if not scope:` to distinguish "scope passed" from "scope omitted". Custom IntEnum members with value 0 are falsy in Python, so a caller passing `MyScope.ZERO` (where `MyScope.ZERO < parent.scope`) silently bypassed the `InvalidChildScopeError` guard and was treated as "scope omitted", falling through to the auto-increment branch. The child was constructed with `parent.scope + 1` instead of raising.
- This change switches the sentinel check from truthiness to `is None`. The `scope` parameter is already typed `enum.IntEnum | None = None`, so this is a tightening of the existing contract.
- One regression test in `tests/test_custom_scope.py` covers the documented custom-scope use case (which is the only realistic way to encounter this — the default `Scope` enum starts at 1).

Surfaced by the 2026-06-05 bug-hunt audit (\`planning/audits/2026-06-05-bug-hunt-audit-report.md\`, should-fix-soon #2).

## Test plan
- [x] New test \`test_build_child_container_rejects_zero_valued_custom_scope\` passes locally.
- [x] Full suite green, 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)