### PR TITLE
Guard against self-reference in union-type parameter lookup

### DIFF
--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -73,7 +73,7 @@ class Factory(AbstractProvider[types.T_co]):
             return provider
         for x in v.args:
             provider = container.providers_registry.find_provider(x)
-            if provider:
+            if provider is not None and provider is not self:
                 return provider
         return None
 

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -180,6 +180,23 @@ def test_factory_self_reference() -> None:
     assert app_container.resolve_provider(second_factory) == "one two"
 
 
+def test_factory_self_reference_in_union_falls_through_to_default() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class SelfRef:
+        x: int = 1
+
+    def make(x: int | SelfRef = 1) -> SelfRef:
+        return SelfRef(x=x if isinstance(x, int) else x.x)
+
+    factory = providers.Factory(creator=make)
+    app_container = Container()
+    app_container.providers_registry.add_providers(factory)
+
+    result = app_container.resolve(SelfRef)
+    assert isinstance(result, SelfRef)
+    assert result.x == 1
+
+
 def test_factory_repr() -> None:
     provider = providers.Factory(creator=str, scope=Scope.APP)
     assert repr(provider) == "Factory(creator=<class 'str'>, scope=<Scope.APP: 1>, cached=False)"


### PR DESCRIPTION
## Summary
- For single-type parameters, \`Factory._find_dep_provider\` already guards against direct self-reference (\`if provider is self: return None\`). The union-type branch (\`for x in v.args:\`) had no equivalent guard: it returned the first matching provider regardless of whether that provider was the same \`Factory\`.
- When the matching provider was \`self\`, resolution stored \`self\` in the resolved kwargs and \`Factory.resolve\` recursed indefinitely on \`container.resolve_provider(self)\` — \`RecursionError\` instead of falling through to the parameter's default.
- This change adds \`and provider is not self\` to the union-loop predicate, mirroring the existing single-type guard.
- One regression test in \`tests/providers/test_factory.py\` covers the union-with-self-reference case via a creator typed \`int | SelfRef = 1\`.

Surfaced by the 2026-06-05 bug-hunt audit (\`planning/audits/2026-06-05-bug-hunt-audit-report.md\`, should-fix-soon #1).

## Test plan
- [x] New test \`test_factory_self_reference_in_union_falls_through_to_default\` passes locally; without the fix it raises \`RecursionError\`.
- [x] Full suite green, 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)