### PR TITLE
Fall through to parameter default when ContextProvider value is unset

### DIFF
--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -83,15 +83,17 @@ class Factory(AbstractProvider[types.T_co]):
             provider = self._find_dep_provider(container, v)
             is_kwarg_not_found = not self._kwargs or k not in self._kwargs
             if provider:
-                result[k] = provider
                 if (
                     is_kwarg_not_found
                     and isinstance(provider, ContextProvider)
                     and provider._find_context_value(container) is types.UNSET  # noqa: SLF001
                 ):
-                    raise exceptions.ArgumentResolutionError(
-                        arg_name=k, arg_type=v.arg_type, bound_type=self.bound_type or self._creator
-                    )
+                    if v.default is types.UNSET:
+                        raise exceptions.ArgumentResolutionError(
+                            arg_name=k, arg_type=v.arg_type, bound_type=self.bound_type or self._creator
+                        )
+                    continue
+                result[k] = provider
                 continue
 
             if v.default == types.UNSET and is_kwarg_not_found:

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -100,3 +100,19 @@ def test_factory_resolves_with_none_context_value() -> None:
     app_container = Container(groups=[NoneGroup], context={datetime.datetime: None})
     instance = app_container.resolve(NoneHolder)
     assert instance.value is None
+
+
+def test_factory_uses_default_when_context_provider_value_unset() -> None:
+    default = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class TsHolder:
+        ts: datetime.datetime = default
+
+    class TsGroup(Group):
+        ctx = providers.ContextProvider(scope=Scope.APP, context_type=datetime.datetime)
+        holder = providers.Factory(creator=TsHolder)
+
+    app_container = Container(groups=[TsGroup])
+    instance = app_container.resolve(TsHolder)
+    assert instance.ts == default


### PR DESCRIPTION
## Summary
- \`Factory._compile_kwargs\` raised \`ArgumentResolutionError\` as soon as it found a registered \`ContextProvider\` whose underlying value was unset, **without checking whether the parameter had a default**. The symmetric branch immediately below (for "no provider found at all") correctly skipped raising when \`v.default != UNSET\`.
- The asymmetry meant: declare \`ts: datetime = SOME_DEFAULT\` on a creator, register a \`ContextProvider(context_type=datetime)\` somewhere, forget to inject the context value — and the factory refused to construct, even though Python would happily use the default. Removing the \`ContextProvider\` declaration restored the default fall-through, which is an unprincipled distinction.
- This change adds the \`v.default is UNSET\` check inside the ContextProvider-unset branch: if the parameter has a default, omit it from \`result\` so the creator's signature default is used at call time. If no default, the existing \`ArgumentResolutionError\` still raises.
- One regression test in \`tests/providers/test_context_provider.py\` covers the case. The existing \`test_context_provider_not_found_but_required\` test (where the parameter has no default) still passes — the raise path is preserved.

Surfaced by the 2026-06-05 bug-hunt audit (\`planning/audits/2026-06-05-bug-hunt-audit-report.md\`, should-fix-soon #3).

## Test plan
- [x] New test \`test_factory_uses_default_when_context_provider_value_unset\` passes locally.
- [x] Existing \`test_context_provider_not_found_but_required\` still raises \`ArgumentResolutionError\` (no default + unset context → still raises, behavior preserved).
- [x] Full suite green, 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)