### PR TITLE
Tighten Container init: propagate use_lock, register container_provider under base, reject non-IntEnum scope

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -36,6 +36,8 @@ class Container:
         use_lock: bool = True,
         validate: bool = False,
     ) -> None:
+        if not isinstance(scope, enum.IntEnum):
+            raise exceptions.InvalidScopeTypeError(scope_value=scope)
         self.lock = threading.RLock() if use_lock else None
         self.scope = scope
         self.parent_container = parent_container
@@ -51,7 +53,7 @@ class Container:
             self.overrides_registry = parent_container.overrides_registry
         else:
             self.providers_registry = ProvidersRegistry()
-            self.providers_registry.register(type(self), container_provider)
+            self.providers_registry.register(Container, container_provider)
             self.overrides_registry = OverridesRegistry()
         if groups:
             for one_group in groups:
@@ -78,7 +80,7 @@ class Container:
             except ValueError as exc:
                 raise exceptions.MaxScopeReachedError(parent_scope=self.scope) from exc
 
-        return self.__class__(scope=scope, parent_container=self, context=context)
+        return self.__class__(scope=scope, parent_container=self, context=context, use_lock=self.lock is not None)
 
     def find_container(self, scope: enum.IntEnum) -> "typing_extensions.Self":
         if scope not in self.scope_map:

--- a/modern_di/errors.py
+++ b/modern_di/errors.py
@@ -40,3 +40,4 @@ INVALID_SCOPE_DEPENDENCY_ERROR = (
     "{parameter_name!r} typed as a provider of {dep_name} at deeper scope "
     "{dep_scope}. A provider cannot depend on a deeper-scoped provider."
 )
+INVALID_SCOPE_TYPE_ERROR = "Container scope must be an enum.IntEnum member; got {scope_repr} ({scope_type})."

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -79,6 +79,19 @@ class ScopeSkippedError(ContainerError):
         )
 
 
+class InvalidScopeTypeError(ContainerError):
+    __slots__ = ("scope_value",)
+
+    def __init__(self, *, scope_value: typing.Any) -> None:  # noqa: ANN401
+        self.scope_value = scope_value
+        super().__init__(
+            errors.INVALID_SCOPE_TYPE_ERROR.format(
+                scope_repr=repr(scope_value),
+                scope_type=type(scope_value).__name__,
+            )
+        )
+
+
 class ResolutionError(ModernDIError):
     """Base class for errors raised while resolving a provider.
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -10,6 +10,7 @@ from modern_di.exceptions import (
     CircularDependencyError,
     InvalidChildScopeError,
     InvalidScopeDependencyError,
+    InvalidScopeTypeError,
     MaxScopeReachedError,
     ProviderNotRegisteredError,
     ScopeSkippedError,
@@ -294,3 +295,32 @@ def test_validation_failed_error_str_renders_inner_errors() -> None:
     rendered = str(exc.value)
     assert "found 1 issue(s)" in rendered
     assert "Circular dependency detected" in rendered
+
+
+def test_build_child_container_propagates_use_lock_false() -> None:
+    root = Container(use_lock=False)
+    child = root.build_child_container(scope=Scope.REQUEST)
+    assert root.lock is None
+    assert child.lock is None
+
+
+def test_container_provider_resolves_on_subclasses() -> None:
+    class MyContainer(Container):
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Service:
+        di_container: Container
+
+    class G(Group):
+        svc = providers.Factory(creator=Service)
+
+    container = MyContainer(groups=[G])
+    instance = container.resolve(Service)
+    assert instance.di_container is container
+
+
+def test_container_rejects_non_intenum_scope_at_init() -> None:
+    with pytest.raises(InvalidScopeTypeError) as exc:
+        Container(scope=99)  # ty: ignore[invalid-argument-type]
+    assert "99" in str(exc.value)


### PR DESCRIPTION
## Summary
Three small \`Container\` fixes surfaced by the 2026-06-05 bug-hunt audit (nice-to-have items #1, #2, #3 in \`planning/audits/2026-06-05-bug-hunt-audit-report.md\`).

- **\`build_child_container\` now propagates \`use_lock\`.** \`Container(use_lock=False)\` previously got locking back the moment the user descended into a child container, silently undoing the opt-out documented at \`docs/providers/factories.md:99-105\`. Fixed by forwarding \`use_lock=self.lock is not None\` to the child constructor.
- **\`container_provider\` now registers under \`Container\` (base), not \`type(self)\`.** Subclassing \`Container\` previously broke the documented auto-injection pattern (\`docs/providers/container.md:14-27\`): a creator annotated with the literal \`Container\` class could not be resolved on a subclassed root container, even though the \`Self\` return types on \`build_child_container\` / \`find_container\` indicate subclassing is supported.
- **\`Container.__init__\` now rejects non-IntEnum \`scope\` values up front** via a new \`InvalidScopeTypeError(ContainerError)\`. The signature was already typed \`enum.IntEnum\` but unenforced; passing \`Container(scope=99)\` previously succeeded and exploded later from \`__repr__\` (or any other site that touched \`scope.name\`) with a bare \`AttributeError\`.

Three new regression tests in \`tests/test_container.py\` cover all three behaviors.

## Test plan
- [x] 3 new tests pass; full suite green (139 passed).
- [x] 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)