### PR TITLE
Validate Factory kwargs against creator signature and use is-check against UNSET

### DIFF
--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -196,6 +196,33 @@ class DuplicateProviderTypeError(RegistrationError):
         super().__init__(errors.PROVIDER_DUPLICATE_TYPE_ERROR.format(provider_type=provider_type))
 
 
+class UnknownFactoryKwargError(RegistrationError):
+    __slots__ = ("creator", "known_keys", "suggestions", "unknown_keys")
+
+    def __init__(
+        self,
+        *,
+        creator: typing.Any,  # noqa: ANN401
+        unknown_keys: list[str],
+        known_keys: list[str],
+        suggestions: dict[str, str] | None = None,
+    ) -> None:
+        self.creator = creator
+        self.unknown_keys = unknown_keys
+        self.known_keys = known_keys
+        self.suggestions = suggestions or {}
+        creator_name = getattr(creator, "__name__", repr(creator))
+        parts = [f"Factory kwargs contain unknown key(s) not in {creator_name} signature:"]
+        for key in unknown_keys:
+            sug = self.suggestions.get(key)
+            line = f"  - {key!r}"
+            if sug:
+                line += f" (did you mean {sug!r}?)"
+            parts.append(line)
+        parts.append(f"Known parameters: {known_keys}")
+        super().__init__("\n".join(parts))
+
+
 class InvalidScopeDependencyError(RegistrationError):
     __slots__ = ("dep_provider", "parameter_name", "provider")
 

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -1,4 +1,5 @@
 import dataclasses
+import difflib
 import enum
 import inspect
 import typing
@@ -52,11 +53,41 @@ class Factory(AbstractProvider[types.T_co]):
         else:
             return_sig, parsed_kwargs = parse_creator(creator)
             parsed_type = return_sig.arg_type
+            if kwargs:
+                self._validate_kwargs_against_signature(creator, kwargs, parsed_kwargs)
         self._parsed_kwargs = parsed_kwargs
         super().__init__(scope=scope, bound_type=parsed_type if isinstance(bound_type, types.UnsetType) else bound_type)
         self._creator = creator
         self.cache_settings = cache_settings
         self._kwargs = kwargs
+
+    @staticmethod
+    def _validate_kwargs_against_signature(
+        creator: typing.Callable[..., typing.Any],
+        kwargs: dict[str, typing.Any],
+        parsed_kwargs: dict[str, SignatureItem],
+    ) -> None:
+        try:
+            sig = inspect.signature(creator)
+        except (ValueError, TypeError):
+            return
+        if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+            return
+        known = set(parsed_kwargs)
+        unknown = sorted(set(kwargs) - known)
+        if not unknown:
+            return
+        suggestions: dict[str, str] = {}
+        for bad in unknown:
+            matches = difflib.get_close_matches(bad, known, n=1)
+            if matches:
+                suggestions[bad] = matches[0]
+        raise exceptions.UnknownFactoryKwargError(
+            creator=creator,
+            unknown_keys=unknown,
+            known_keys=sorted(known),
+            suggestions=suggestions,
+        )
 
     def __repr__(self) -> str:
         return f"Factory(creator={self._creator!r}, scope={self.scope!r}, cached={self.cache_settings is not None})"
@@ -96,7 +127,7 @@ class Factory(AbstractProvider[types.T_co]):
                 result[k] = provider
                 continue
 
-            if v.default == types.UNSET and is_kwarg_not_found:
+            if v.default is types.UNSET and is_kwarg_not_found:
                 suggestions = (
                     container.providers_registry.build_suggestions(v.arg_type) if v.arg_type is not None else []
                 )

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -1,11 +1,12 @@
 import dataclasses
 import re
+import unittest.mock
 import warnings
 
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import ArgumentResolutionError, ScopeNotInitializedError
+from modern_di.exceptions import ArgumentResolutionError, ScopeNotInitializedError, UnknownFactoryKwargError
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
@@ -216,3 +217,51 @@ def test_factory_skip_creator_parsing_with_bound_type_no_warning() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         providers.Factory(creator=str, skip_creator_parsing=True, bound_type=str)
+
+
+def test_factory_rejects_unknown_kwarg_at_construction() -> None:
+    with pytest.raises(UnknownFactoryKwargError) as exc:
+        providers.Factory(creator=lambda a=1: a, kwargs={"a": 1, "nonexistent": "oops"})
+    assert "nonexistent" in str(exc.value)
+    assert "a" in exc.value.known_keys
+    assert "nonexistent" in exc.value.unknown_keys
+
+
+def test_factory_unknown_kwarg_suggests_close_match() -> None:
+    with pytest.raises(UnknownFactoryKwargError) as exc:
+        providers.Factory(
+            creator=lambda connection_string="default": connection_string, kwargs={"connetion_string": "x"}
+        )
+    assert "connection_string" in str(exc.value)
+
+
+def test_factory_kwarg_validation_skips_when_signature_unavailable() -> None:
+    # When inspect.signature raises (e.g. for some C-implemented callables),
+    # the validator silently skips rather than crashing.
+    with unittest.mock.patch("inspect.signature", side_effect=ValueError):
+        providers.Factory(creator=lambda x=1: x, kwargs={"anything": 1})
+
+
+def test_factory_allows_extra_kwargs_when_creator_accepts_var_keyword() -> None:
+    def make(**kwargs: object) -> dict[str, object]:
+        return kwargs
+
+    factory = providers.Factory(creator=make, kwargs={"anything": 1, "extra": 2})
+    container = Container()
+    container.providers_registry.add_providers(factory)
+    result = container.resolve(dict)
+    assert result == {"anything": 1, "extra": 2}
+
+
+def test_factory_default_value_compared_with_is_not_eq() -> None:
+    class SomeUnregisteredType:
+        pass
+
+    def make(x: SomeUnregisteredType = unittest.mock.ANY) -> str:
+        return repr(x)
+
+    factory = providers.Factory(creator=make)
+    container = Container()
+    container.providers_registry.add_providers(factory)
+    result = container.resolve(str)
+    assert result == repr(unittest.mock.ANY)


### PR DESCRIPTION
## Summary
Two \`Factory\` fixes from the 2026-06-05 bug-hunt audit (nice-to-have items #4 and #13).

- **\`Factory\` now validates static \`kwargs\` against the creator's signature at construction time.** A typo like \`{'connetion_string': ...}\` previously surfaced only at instantiation as a raw \`TypeError\` from Python with no provider identity. The new \`UnknownFactoryKwargError(RegistrationError)\` raises at \`Factory.__init__\` naming the offending keys and using \`difflib.get_close_matches\` to suggest the closest valid name. Validation is automatically skipped when the creator accepts \`**kwargs\` (\`VAR_KEYWORD\`) or when its signature is uninspectable.
- **\`_compile_kwargs\` now uses \`is\` against \`UNSET\` instead of \`==\`.** A parameter with \`default=unittest.mock.ANY\` (whose \`__eq__\` returns \`True\` for any comparand) used to spuriously match \`v.default == UNSET\`, raising \`ArgumentResolutionError\` instead of using the default. One-character fix; matches the \`UnsetType.__doc__\` guidance in \`modern_di/types.py\`.

Five new regression tests cover: unknown-kwarg raise, did-you-mean suggestion, \`**kwargs\` bypass, uninspectable-signature bypass, and \`mock.ANY\`-style default with custom \`__eq__\`.

## Test plan
- [x] 5 new tests pass; full suite green (144 passed).
- [x] 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)