### PR TITLE
Dedupe finalizer calls when clear_cache=False, verify in singleton and context-manager tests

### DIFF
--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -10,27 +10,31 @@ class CacheItem:
     settings: CacheSettings[typing.Any] | None
     cache: typing.Any = types.UNSET
     kwargs_compiled: bool = False
+    finalized: bool = False
     provider_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
     static_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
 
     def _clear(self) -> None:
         if self.settings and self.settings.clear_cache:
             self.cache = types.UNSET
+            self.finalized = False
 
     async def close_async(self) -> None:
-        if self.cache is not types.UNSET and self.settings and self.settings.finalizer:
+        if self.cache is not types.UNSET and not self.finalized and self.settings and self.settings.finalizer:
             if self.settings.is_async_finalizer:
                 await self.settings.finalizer(self.cache)  # ty: ignore[invalid-await]
             else:
                 self.settings.finalizer(self.cache)
+            self.finalized = True
 
         self._clear()
 
     def close_sync(self) -> None:
-        if self.cache is not types.UNSET and self.settings and self.settings.finalizer:
+        if self.cache is not types.UNSET and not self.finalized and self.settings and self.settings.finalizer:
             if self.settings.is_async_finalizer:
                 raise exceptions.AsyncFinalizerInSyncCloseError(finalizer_type=type(self.cache))
             self.settings.finalizer(self.cache)
+            self.finalized = True
 
         self._clear()
 

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -20,10 +20,6 @@ class DependentCreator:
     dep1: SimpleCreator
 
 
-def sync_finalizer(_: SimpleCreator) -> None:
-    pass
-
-
 async def async_finalizer(_: DependentCreator) -> None:
     pass
 
@@ -32,7 +28,7 @@ class MyGroup(Group):
     app_singleton = providers.Factory(
         creator=SimpleCreator,
         kwargs={"dep1": "original"},
-        cache_settings=providers.CacheSettings(clear_cache=False, finalizer=sync_finalizer),
+        cache_settings=providers.CacheSettings(),
     )
     request_singleton = providers.Factory(
         scope=Scope.REQUEST, creator=DependentCreator, cache_settings=providers.CacheSettings(finalizer=async_finalizer)
@@ -40,16 +36,82 @@ class MyGroup(Group):
 
 
 async def test_app_singleton() -> None:
-    app_container = Container(groups=[MyGroup])
-    singleton1 = app_container.resolve_provider(MyGroup.app_singleton)
-    singleton2 = app_container.resolve_provider(MyGroup.app_singleton)
-    assert singleton1 is singleton2
-    app_container.close_sync()
-    cache_item = app_container.cache_registry.fetch_cache_item(MyGroup.app_singleton)
-    assert cache_item.cache is not UNSET
+    sync_calls: list[SimpleCreator] = []
 
-    app_container.resolve_provider(MyGroup.app_singleton)
+    class LocalGroup(Group):
+        singleton = providers.Factory(
+            creator=SimpleCreator,
+            kwargs={"dep1": "original"},
+            cache_settings=providers.CacheSettings(clear_cache=False, finalizer=sync_calls.append),
+        )
+
+    app_container = Container(groups=[LocalGroup])
+    singleton1 = app_container.resolve_provider(LocalGroup.singleton)
+    singleton2 = app_container.resolve_provider(LocalGroup.singleton)
+    assert singleton1 is singleton2
+
+    app_container.close_sync()
+    cache_item = app_container.cache_registry.fetch_cache_item(LocalGroup.singleton)
+    assert cache_item.cache is not UNSET
+    assert sync_calls == [singleton1]
+
+    singleton3 = app_container.resolve_provider(LocalGroup.singleton)
+    assert singleton3 is singleton1
+
     await app_container.close_async()
+    assert sync_calls == [singleton1]
+
+
+def test_close_does_not_re_finalize_with_clear_cache_false() -> None:
+    calls: list[str] = []
+
+    class G(Group):
+        f = providers.Factory(
+            creator=lambda: "r",
+            bound_type=str,
+            cache_settings=providers.CacheSettings(clear_cache=False, finalizer=calls.append),
+        )
+
+    container = Container(groups=[G])
+    container.resolve(str)
+    container.close_sync()
+    container.close_sync()
+    container.close_sync()
+    assert calls == ["r"]
+
+
+def test_close_re_finalizes_after_re_resolve_with_clear_cache_true() -> None:
+    calls: list[str] = []
+
+    class G(Group):
+        f = providers.Factory(
+            creator=lambda: "r",
+            bound_type=str,
+            cache_settings=providers.CacheSettings(clear_cache=True, finalizer=calls.append),
+        )
+
+    container = Container(groups=[G])
+    container.resolve(str)
+    container.close_sync()
+    container.resolve(str)
+    container.close_sync()
+    assert calls == ["r", "r"]
+
+
+async def test_close_async_runs_sync_finalizer() -> None:
+    calls: list[str] = []
+
+    class G(Group):
+        f = providers.Factory(
+            creator=lambda: "r",
+            bound_type=str,
+            cache_settings=providers.CacheSettings(finalizer=calls.append),
+        )
+
+    container = Container(groups=[G])
+    container.resolve(str)
+    await container.close_async()
+    assert calls == ["r"]
 
 
 async def test_request_singleton() -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -67,16 +67,41 @@ def test_container_resolve_missing_provider() -> None:
 
 
 def test_container_sync_context_manager() -> None:
-    with Container() as container:
+    cleaned_up: list[str] = []
+
+    class G(Group):
+        resource = providers.Factory(
+            creator=lambda: "r",
+            bound_type=str,
+            cache_settings=providers.CacheSettings(finalizer=cleaned_up.append),
+        )
+
+    with Container(groups=[G]) as container:
         assert container.scope == Scope.APP
+        assert container.resolve(str) == "r"
+    assert cleaned_up == ["r"]
 
     with container.build_child_container(scope=Scope.REQUEST) as request_container:
         assert request_container.scope == Scope.REQUEST
 
 
 async def test_container_async_context_manager() -> None:
-    async with Container() as container:
+    cleaned_up: list[str] = []
+
+    async def collect(value: str) -> None:
+        cleaned_up.append(value)
+
+    class G(Group):
+        resource = providers.Factory(
+            creator=lambda: "r",
+            bound_type=str,
+            cache_settings=providers.CacheSettings(finalizer=collect),
+        )
+
+    async with Container(groups=[G]) as container:
         assert container.scope == Scope.APP
+        assert container.resolve(str) == "r"
+    assert cleaned_up == ["r"]
 
     async with container.build_child_container(scope=Scope.REQUEST) as request_container:
         assert request_container.scope == Scope.REQUEST


### PR DESCRIPTION
## Summary
Three audit findings shipped together because they interact (nice-to-have #12 logic fix + #8 + #7 test improvements).

- **\`CacheItem\` no longer re-runs the finalizer on repeated \`close_sync\` / \`close_async\` calls when \`clear_cache=False\`.** A new \`finalized: bool\` flag guards the finalizer call; \`_clear()\` resets the flag when it actually clears the cache (\`clear_cache=True\`), so a re-resolved cache can be finalized again on the next close. Before: the canonical Resource-replacement pattern (docs/migration/to-2.x.md:96-107) would double-close DB connections on repeated container shutdown.
- **\`test_app_singleton\` now verifies the finalizer actually runs.** The previous test wired a no-op \`sync_finalizer\` and only asserted \`cache is not UNSET\` — replacing \`close_sync\` / \`close_async\` bodies with \`pass\` would have left it passing. Rewritten to use a local list-tracking finalizer, asserts the finalizer fires exactly once across a \`close_sync\` + re-resolve + \`close_async\` sequence (also exercises the new dedup).
- **\`test_container_sync_context_manager\` and \`test_container_async_context_manager\` now verify close side-effects.** The previous tests only asserted \`container.scope == Scope.APP\` inside the \`with\` block — they did not catch failed \`__exit__\` / \`__aexit__\` implementations. Each now registers a list-tracking finalizer and asserts the finalizer ran after the \`with\` block exits.

Two new dedicated regression tests in \`test_singleton.py\` lock in the new behavior:
- \`test_close_does_not_re_finalize_with_clear_cache_false\` — three back-to-back closes; finalizer fires exactly once.
- \`test_close_re_finalizes_after_re_resolve_with_clear_cache_true\` — resolve, close, resolve, close; finalizer fires twice (once per cached value).
- \`test_close_async_runs_sync_finalizer\` covers the sync-finalizer-via-\`close_async\` path.

Surfaced by the 2026-06-05 bug-hunt audit (\`planning/audits/2026-06-05-bug-hunt-audit-report.md\`, nice-to-have #7, #8, #12).

## Test plan
- [x] 3 new tests pass; 3 updated tests pass; full suite green (147 passed).
- [x] 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)