### PR TITLE
Tighten test assertions: drop dead asserts, relax cycle-rotation check, capture warnings, exercise union arm

### DIFF
--- a/tests/providers/test_alias.py
+++ b/tests/providers/test_alias.py
@@ -32,12 +32,6 @@ def test_alias_delegates_to_source() -> None:
     assert concrete is abstract
 
 
-def test_alias_resolve_provider() -> None:
-    container = Container(groups=[MyGroup])
-    instance = container.resolve_provider(MyGroup.abstract_repo)
-    assert isinstance(instance, PostgresRepository)
-
-
 def test_alias_without_caching_returns_fresh_instance_per_call() -> None:
     class G(Group):
         repo = providers.Factory(creator=PostgresRepository)

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -39,7 +39,6 @@ class MyGroup(Group):
         creator=SimpleCreator, skip_creator_parsing=True, bound_type=None
     )
     func_with_union_factory = providers.Factory(creator=func_with_union, bound_type=None)
-    func_with_broken_annotation = providers.Factory(creator=func_with_broken_annotation, bound_type=None)
     request_factory = providers.Factory(scope=Scope.REQUEST, creator=DependentCreator)
     request_factory_with_di_container = providers.Factory(scope=Scope.REQUEST, creator=AnotherCreator)
 
@@ -72,13 +71,17 @@ def test_app_factory_unresolvable() -> None:
 def test_func_with_union_factory() -> None:
     app_container = Container(groups=[MyGroup])
     instance1 = app_container.resolve_provider(MyGroup.func_with_union_factory)
-    assert instance1
+    assert instance1 == str(SimpleCreator(dep1="original"))
 
 
 def test_func_with_broken_annotation() -> None:
-    app_container = Container(groups=[MyGroup])
+    with pytest.warns(UserWarning, match="Failed to resolve type hints"):
+        factory = providers.Factory(creator=func_with_broken_annotation, bound_type=None)
+
+    app_container = Container()
+    app_container.providers_registry.add_providers(factory)
     with pytest.raises(ArgumentResolutionError, match="Argument dep1 of type None cannot be resolved"):
-        app_container.resolve_provider(MyGroup.func_with_broken_annotation)
+        app_container.resolve_provider(factory)
 
 
 def test_request_factory() -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -62,7 +62,7 @@ def test_container_resolve_missing_provider() -> None:
         ProviderNotRegisteredError,
         match=r"Provider of type <class 'str'> is not registered in providers registry.",
     ) as exc:
-        assert app_container.resolve(str) is None
+        app_container.resolve(str)
     assert exc.value.provider_type is str
 
 
@@ -143,7 +143,9 @@ def test_validate_detects_cycle() -> None:
         container.validate()
     [issue] = exc.value.errors
     assert isinstance(issue, CircularDependencyError)
-    assert issue.cycle_path == ["CycleA", "CycleB", "CycleA"]
+    cycle = issue.cycle_path
+    assert cycle[0] == cycle[-1]
+    assert set(cycle) == {"CycleA", "CycleB"}
 
 
 def test_validate_passes_for_valid_graph() -> None:


### PR DESCRIPTION
## Summary
Five test-quality improvements from the 2026-06-05 bug-hunt audit (nice-to-have items #5, #6, #9, #10, #14). No source code changes.

- **#5 \`test_container_resolve_missing_provider\`:** Dropped \`assert app_container.resolve(str) is None\` — the call raises before the comparison runs, so the assert was dead code that would have hidden a regression where \`resolve\` started returning None instead of raising.
- **#6 \`test_func_with_union_factory\`:** Replaced \`assert instance1\` (passes for any non-empty string) with \`assert instance1 == str(SimpleCreator(dep1='original'))\`. Now actually exercises which arm of the \`SimpleCreator | int\` union was selected — changing the creator to return \`'X'\` would correctly fail this test.
- **#9 \`test_func_with_broken_annotation\`:** Moved Factory construction inside the test body, wrapped in \`pytest.warns(UserWarning, match='Failed to resolve type hints')\`. Now verifies the \`UserWarning\` from \`parse_creator\`'s \`NameError\` branch is actually emitted — removing the \`warnings.warn(...)\` call in \`types_parser\` would now fail this test.
- **#10 \`test_validate_detects_cycle\`:** Replaced \`assert cycle_path == ['CycleA', 'CycleB', 'CycleA']\` (depends on Group declaration order) with rotation-independent checks: \`cycle[0] == cycle[-1]\` and \`set(cycle) == {'CycleA', 'CycleB'}\`. Swapping the declaration order of \`a\` and \`b\` in \`CycleGroup\` no longer breaks the test.
- **#14 \`test_alias_resolve_provider\`:** Deleted. The sibling \`test_alias_delegates_to_source\` already performs the load-bearing \`concrete is abstract\` identity check; this test only asserted \`isinstance\`, which would pass even with \`Alias.resolve\` broken to construct a fresh instance.

Also dropped the now-unused module-level \`func_with_broken_annotation\` Factory registration in \`MyGroup\` since #9 moved it into the test body.

## Test plan
- [x] Updated tests pass; deleted test gone; full suite green (146 passed).
- [x] 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)