### PR TITLE
Support Group inheritance by collecting providers from MRO ancestors

### DIFF
--- a/modern_di/group.py
+++ b/modern_di/group.py
@@ -18,4 +18,15 @@ class Group:
 
     @classmethod
     def get_providers(cls) -> list[AbstractProvider[typing.Any]]:
-        return [x for x in cls.__dict__.values() if isinstance(x, AbstractProvider)]
+        seen_names: set[str] = set()
+        collected: list[AbstractProvider[typing.Any]] = []
+        for klass in cls.__mro__:
+            if klass is Group or klass is object:
+                continue
+            for name, value in klass.__dict__.items():
+                if name in seen_names:
+                    continue
+                seen_names.add(name)
+                if isinstance(value, AbstractProvider):
+                    collected.append(value)
+        return collected

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,6 +1,8 @@
+import dataclasses
+
 import pytest
 
-from modern_di import Group
+from modern_di import Container, Group, providers
 from modern_di.exceptions import GroupInstantiationError
 
 
@@ -10,3 +12,66 @@ def test_group_cannot_be_instantiated() -> None:
     with pytest.raises(GroupInstantiationError, match="Dependencies cannot be instantiated") as exc:
         Dependencies()
     assert exc.value.group_name == "Dependencies"
+
+
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class _A:
+    pass
+
+
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class _B:
+    pass
+
+
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class _C:
+    pass
+
+
+def test_group_inherits_providers_from_parent() -> None:
+    class Base(Group):
+        a = providers.Factory(creator=_A)
+
+    class Child(Base):
+        b = providers.Factory(creator=_B)
+
+    container = Container(groups=[Child])
+    assert isinstance(container.resolve(_A), _A)
+    assert isinstance(container.resolve(_B), _B)
+
+
+def test_group_subclass_overrides_parent_provider() -> None:
+    class Base(Group):
+        a = providers.Factory(creator=_A)
+
+    class Child(Base):
+        a = providers.Factory(creator=_A, bound_type=_B)  # override; resolve _B yields _A instance
+
+    container = Container(groups=[Child])
+    assert isinstance(container.resolve(_B), _A)
+
+
+def test_group_non_provider_override_masks_parent_provider() -> None:
+    class Base(Group):
+        a = providers.Factory(creator=_A)
+
+    class Child(Base):
+        a = "not a provider"
+
+    assert Child.get_providers() == []
+
+
+def test_group_diamond_inheritance_returns_each_provider_once() -> None:
+    class Base(Group):
+        a = providers.Factory(creator=_A)
+
+    class Left(Base): ...
+
+    class Right(Base): ...
+
+    class Diamond(Left, Right): ...
+
+    providers_list = Diamond.get_providers()
+    assert len(providers_list) == 1
+    assert providers_list[0] is Base.a


### PR DESCRIPTION
## Summary
\`Group.get_providers\` was iterating \`cls.__dict__.values()\` — the class's own attributes only — so a \`Group\` subclass silently dropped any provider declared on its parent. Surfaced by the 2026-06-05 bug-hunt audit (\`planning/audits/2026-06-05-bug-hunt-audit-report.md\`, nice-to-have #11).

This change makes \`get_providers\` walk \`cls.__mro__\` (excluding \`Group\` and \`object\`) and collect providers from each ancestor's \`__dict__\`, tracking attribute names so that:
- **A subclass override wins** over the parent's same-name attribute (matches Python's normal attribute lookup).
- **A non-provider override masks** the parent's provider (a subclass that sets \`x = "string"\` correctly excludes a parent's \`x = Factory(...)\` from the registered set).
- **Diamond inheritance is dedup-safe** — each provider is returned at most once even when reachable via multiple MRO paths.

Four new regression tests in \`tests/test_group.py\` cover: simple inheritance, subclass override, non-provider mask, and diamond inheritance.

## Behavior change for downstream users
A subclass like \`class TestDependencies(AppDependencies):\` now registers AppDependencies's providers in addition to its own. Anyone who was *intentionally* relying on the silent-drop behavior (unlikely — it produced \`ProviderNotRegisteredError\` at resolve time) would need to refactor. The audit found no project tests depending on the old behavior; full suite green after the fix.

## Test plan
- [x] 4 new tests pass; existing \`test_group_cannot_be_instantiated\` passes unchanged; full suite green (150 passed).
- [x] 100% coverage maintained.
- [x] \`just lint-ci\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)