### PR TITLE
Bump GitHub Action versions to drop Node.js 20

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -6,9 +6,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -27,9 +27,9 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: just docs-deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: just publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Open or update tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Bumps the three actions used across `_checks.yml`, `scheduled.yml`, `docs.yml`, and `publish.yml` to versions that run on Node.js 24:

- `actions/checkout@v4` → `@v6`
- `extractions/setup-just@v2` → `@v4`
- `astral-sh/setup-uv@v3` → `@v8.2.0` (pinned; see note below)

GitHub removes Node.js 20 from runners on 2026-09-16 and emits deprecation warnings until then. Every CI run on `main` currently logs the warning.

## Why `setup-uv` is pinned to a minor instead of `@v8`
From v8.0.0 onward `astral-sh` stopped publishing major and minor tags ([release notes](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0)) — citing supply-chain hardening after the `tj-actions` incident. `@v8` would no longer resolve. Verified that the two inputs we use (`enable-cache`, `cache-dependency-glob`) still exist in v8.2.0 with compatible semantics.

## Test plan
- [x] YAML parses cleanly across all four files.
- [ ] `ci.yml` runs green on this PR (proves `_checks.yml` still works with bumped pins).
- [ ] After merge, the next `scheduled-dep-check` dispatch (or the Monday cron) runs without Node.js deprecation annotations.