### PR TITLE
Fix: guard typing_extensions import under TYPE_CHECKING (zero-dependency install)

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -2,8 +2,6 @@ import enum
 import threading
 import typing
 
-import typing_extensions
-
 from modern_di import exceptions, types
 from modern_di.group import Group
 from modern_di.providers.abstract import AbstractProvider
@@ -13,6 +11,10 @@ from modern_di.registries.context_registry import ContextRegistry
 from modern_di.registries.overrides_registry import OverridesRegistry
 from modern_di.registries.providers_registry import ProvidersRegistry
 from modern_di.scope import Scope
+
+
+if typing.TYPE_CHECKING:
+    import typing_extensions
 
 
 class Container:

--- a/planning/releases/2.16.1.md
+++ b/planning/releases/2.16.1.md
@@ -1,0 +1,16 @@
+# modern-di 2.16.1 — Restore zero-dependency install
+
+Patch release. No API or behavior changes.
+
+## Fix
+
+- **`import modern_di` no longer requires `typing_extensions` at runtime.** `modern_di/container.py` imported `typing_extensions` unconditionally at module load, even though it is used only for `typing_extensions.Self` in (non-evaluated) type annotations and is not declared as a runtime dependency. On a clean install with no transitively-present `typing_extensions`, `import modern_di` raised `ModuleNotFoundError: No module named 'typing_extensions'`. The import is now guarded by `if typing.TYPE_CHECKING:` (matching `modern_di/group.py`), restoring the documented zero-dependency install. Surfaced by checking the sibling integration repos against 2.16.0 (`modern-di-typer` / `modern-di-pytest` failed on a clean `uv sync`). Pre-existing since the import was introduced; not a 2.16.0 regression.
+
+## Internals
+
+- Regression guard: `tests/test_packaging.py` imports `modern_di` and builds a child container in a subprocess with `typing_extensions` blocked, so any future unconditional runtime import of it fails CI.
+- 193 tests; 100% line coverage on Python 3.10–3.14.
+
+## References
+
+- Release notes for the audit work this patches: [`planning/releases/2.16.0.md`](2.16.0.md)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+
+
+def test_modern_di_imports_without_typing_extensions() -> None:
+    """modern-di advertises zero runtime dependencies; `typing_extensions` must be type-checking only.
+
+    Runs in a fresh subprocess with `typing_extensions` import blocked, to catch any
+    unconditional runtime `import typing_extensions` (see container.py / group.py).
+    """
+    code = (
+        "import sys\n"
+        "sys.modules['typing_extensions'] = None\n"  # makes `import typing_extensions` raise ImportError
+        "import modern_di\n"
+        "from modern_di import Container, Scope\n"
+        "container = Container(scope=Scope.APP)\n"
+        "child = container.build_child_container(scope=Scope.REQUEST)\n"
+        "print('OK', child.scope.name)\n"
+    )
+    result = subprocess.run(  # noqa: S603 — fixed literal command, no untrusted input
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK REQUEST" in result.stdout


### PR DESCRIPTION
## Summary

`modern_di/container.py` imported `typing_extensions` unconditionally at module load, but it is used only for `typing_extensions.Self` in type annotations (none evaluated at runtime) and is **not** a declared runtime dependency — modern-di advertises zero dependencies. On a clean install with no transitively-present `typing_extensions`, `import modern_di` raised `ModuleNotFoundError: No module named 'typing_extensions'`.

This moves the import under `if typing.TYPE_CHECKING:` (matching `modern_di/group.py`, which already does this), restoring the zero-dependency install. The one non-string annotation referencing it (`Container.scope_map`) is an in-method attribute annotation, which Python does not evaluate at runtime (verified), so nothing breaks.

Surfaced by checking the sibling integration repos against 2.16.0: `modern-di-typer` and `modern-di-pytest` failed on a clean `uv sync` with the `ModuleNotFoundError`. The bug is **pre-existing** (the import predates the 2026-06 audit work), not a 2.16.0 regression — it was masked in practice because `typing_extensions` is almost always present transitively.

Adds `tests/test_packaging.py`: a subprocess regression test that imports `modern_di` and builds a child container with `typing_extensions` blocked, so any future unconditional runtime import fails CI.

Ships as **2.16.1**.

## Test Plan
- [x] `just lint-ci` — clean (ruff/ty)
- [x] `just test-ci` — 193 passed, 100% line coverage
- [x] Python 3.14 — 193 passed, 100%
- [x] New regression test fails before the fix (`container.py:5: import typing_extensions`), passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)