### PR TITLE
Archive the portable-planning-convention bundle

### DIFF
--- a/planning/README.md
+++ b/planning/README.md
@@ -70,12 +70,13 @@ carry **no** frontmatter — living prose, dated by git.
 
 ### Active
 
-- **[portable-planning-convention](changes/active/2026-06-13.03-portable-planning-convention/design.md)**
-  (2026-06-13) — Adopt the two-axis convention: `architecture/` truth +
-  `changes/` bundles + portable README, copied from faststream-outbox.
+_None._
 
 ### Archived (shipped)
 
+- **[portable-planning-convention](changes/archive/2026-06-13.03-portable-planning-convention/design.md)**
+  (#210, 2026-06-13) — Adopt the two-axis convention: `architecture/` truth +
+  `changes/` bundles + portable README, copied from faststream-outbox.
 - **[alias-scope-transparency](changes/archive/2026-06-13.02-alias-scope-transparency/plan.md)**
   (#207, 2026-06-13) — Deprecate decorative `Alias(scope=...)`; `validate()`
   checks scope transitively via `effective_scope` (X-4). Plan-only; spec = the

--- a/planning/changes/archive/2026-06-13.03-portable-planning-convention/design.md
+++ b/planning/changes/archive/2026-06-13.03-portable-planning-convention/design.md
@@ -1,11 +1,11 @@
 ---
-status: draft
+status: shipped
 date: 2026-06-13
 slug: portable-planning-convention
 supersedes: null
 superseded_by: null
-pr: null
-outcome: null
+pr: "#210"
+outcome: Adopted the two-axis convention — architecture/ truth home (README + 6 capability docs) + planning/changes/{active,archive}/ bundles; migrated 11 historical spec/plan pairs into archive bundles; added portable README, _templates/, CLAUDE.md Workflow. Also aligned CLAUDE.md Architecture with the code.
 ---
 
 # Design: Adopt the portable planning convention

--- a/planning/changes/archive/2026-06-13.03-portable-planning-convention/plan.md
+++ b/planning/changes/archive/2026-06-13.03-portable-planning-convention/plan.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: shipped
 date: 2026-06-13
 slug: portable-planning-convention
 spec: design.md
-pr: null
+pr: "#210"
 ---
 
 # Portable planning convention — implementation plan


### PR DESCRIPTION
## Summary

On-merge promotion step for #210, prescribed by the convention it introduced (Task 15, deferred to merge):

- Move `planning/changes/active/2026-06-13.03-portable-planning-convention/` → `changes/archive/`.
- Set its frontmatter `status: shipped`, `pr: "#210"`, `outcome: …`.
- Move its `planning/README.md` Index line from **Active** to **Archived**; `### Active` is now `_None._`.

No `architecture/` capability promotion: this change is tooling/process, so its promotion target was the README + CLAUDE.md edits already shipped in #210 (per the spec's Non-goals).

## Test Plan

- [x] `active/` empty; bundle present under `archive/`
- [x] README Index link resolves to the archived path; no stale `active/` link
- [x] `just lint-ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)