### PR TITLE
fix(docs): enable admonition extension so !!! blocks render

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,8 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - admonition
+  - pymdownx.details
   - def_list
   - codehilite:
       use_pygments: true


### PR DESCRIPTION
## Problem

While verifying the docs site renders correctly after the UX audit work, I found a **pre-existing site-wide bug**: the `admonition` Markdown extension was never enabled in `mkdocs.yml`. Every `!!! note` / `!!! warning` / `!!! caution` block — used on 7 pages (`to-1.x`, `to-2.x`, `alias`, `context`, `factories`, `lifecycle`, `fixtures`) — rendered as **literal text** instead of a styled callout. As a downstream effect, code fences nested inside those admonitions (e.g. the context-propagation example) rendered as broken `language-text` blocks showing literal ` ```python `.

## Fix

Add `admonition` and the standard `pymdownx.details` pairing to `markdown_extensions`.

## Verification (local `mkdocs build --strict`)

- Build exit 0, no broken-link/nav warnings.
- **Before:** 7 pages had literal `<p>!!! …` admonitions; context.md had 4 broken code fences.
- **After:** 0 literal admonitions, 0 broken fences across all 32 pages; **14** admonition blocks and **11** tabbed code-sets render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)