### PR TITLE
ci: add mkdocs --strict docs build as a required check

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -36,3 +36,14 @@ jobs:
       - run: uv python install ${{ matrix.python-version }}
       - run: just install
       - run: just test-ci
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+      - run: just docs-build

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,10 @@ publish:
     uv build
     uv publish --token $PYPI_TOKEN
 
+# Build the docs site, failing on broken links / nav warnings; CI runs this on every PR.
+docs-build:
+    uvx --with-requirements docs/requirements.txt mkdocs build --strict
+
 # Force-pushes built site to gh-pages; CI runs this on push to main.
 # Manual invocation from a stale checkout will roll the live site back.
 docs-deploy:


### PR DESCRIPTION
## What

Adds docs-build verification to CI so documentation breakage fails the build.

- New `just docs-build` recipe: `uvx --with-requirements docs/requirements.txt mkdocs build --strict` (mirrors `docs-deploy`).
- New `docs` job in the reusable `.github/workflows/_checks.yml`, so it runs on every PR/push (via `ci.yml`) and in the weekly scheduled dep-check (via `scheduled.yml`).

## Why

CI ran only `lint` + `pytest` and never built the docs. The site-wide admonition-rendering regression fixed in #214 (and any future broken link / missing nav entry / bad mkdocs config) would pass CI undetected. `--strict` turns those into build failures.

## Verification

- `just docs-build` passes locally (exit 0).
- This PR's own CI exercises the new `docs` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)