### PR TITLE
fix: resolve ContextProvider values live so late set_context propagates

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -140,7 +140,10 @@ creation time, or call `container.validate()` explicitly at any point. It raises
 container.set_context(MyRequest, request_obj)
 ```
 
-Registers a runtime value directly into the container's `ContextRegistry`. Also invalidates all
-compiled kwargs in the container's `CacheRegistry` (resets `kwargs_compiled`, `provider_kwargs`,
-and `static_kwargs` on every `CacheItem`) so that subsequent resolutions pick up the new context
-value rather than using a stale compiled-kwargs snapshot.
+Registers a runtime value directly into the container's `ContextRegistry`. Context values are
+resolved **live** on every resolve (see [resolution](resolution.md)), so a value set here is
+picked up by subsequent resolves of **non-cached** providers — including factories in deeper-scoped
+child containers that read this container's context — with no cache invalidation needed.
+
+A **cached** provider (`Factory(cache_settings=...)`) is built once and its instance is *not*
+rebuilt by a later `set_context`; set the context before its first resolve.

--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -62,28 +62,29 @@ If no cached instance is returned, `Factory` compiles the keyword arguments need
 once per container per provider via `_ensure_kwargs_cached`, which stores the split result on `CacheItem` so subsequent
 calls (within the same container lifetime) skip recompilation.
 
-`_compile_kwargs` iterates over `_parsed_kwargs` — the `SignatureItem` map produced at provider-declaration time by
-`types_parser.parse_creator`. For each parameter:
+Compilation is **type matching only** — it decides *which* provider (if any) backs each parameter, not what value that
+provider currently holds. It therefore never goes stale and is never invalidated. `_compile_kwargs` iterates over
+`_parsed_kwargs` — the `SignatureItem` map produced at provider-declaration time by `types_parser.parse_creator` — and
+sorts each parameter into one of three buckets stored on the `CacheItem`:
 
-1. **Provider lookup** — `_find_dep_provider` searches `providers_registry` for a provider matching the parameter's
-   resolved type (`arg_type`) or, for union types, any of the union members (`args`). Self-references are excluded.
+1. **Static kwarg shadows** — if the parameter was supplied via the provider's declaration-time `kwargs`, it is taken
+   from there. Provider-valued static kwargs go to `provider_kwargs`; plain values go to `static_kwargs`. These bypass
+   type-based wiring.
 
-2. **Context provider with missing value** — if the found provider is a `ContextProvider` and it has no value set in
-   the current context registry, the parameter falls through to the nullable/default logic below rather than resolving
-   the provider.
+2. **Provider lookup** — otherwise `_find_dep_provider` searches `providers_registry` for a provider matching the
+   parameter's resolved type (`arg_type`) or, for union types, any of the union members (`args`); self-references are
+   excluded. A matching `ContextProvider` goes to `context_kwargs` (resolved live, see Step 5); any other provider goes
+   to `provider_kwargs`.
 
-3. **No provider found / missing context value** — resolution falls back in this order:
-   - If the parameter has a default, it is omitted from the compiled kwargs (the creator's own default applies).
-   - If `SignatureItem.is_nullable` is `True` (the annotation included `None` in a union, e.g. `X | None` or
-     `Optional[X]`), the parameter is set to `None`.
+3. **No provider found** — this is a static graph fact, decided once here:
+   - If the parameter has a default, it is omitted (the creator's own default applies).
+   - If `SignatureItem.is_nullable` is `True` (the annotation included `None`, e.g. `X | None` or `Optional[X]`), it is
+     set to `None` in `static_kwargs`.
    - Otherwise, `ArgumentResolutionError` is raised.
 
-4. **Static kwargs override** — after the loop, `result.update(self._kwargs)` applies any static kwargs supplied at
-   provider-declaration time. These are written last, so they overwrite any provider resolved for the same key. This
-   is the mechanism for supplying literal values that bypass type-based wiring.
-
-The compiled result is split into `provider_kwargs` (values that are `AbstractProvider` instances, to be resolved
-recursively) and `static_kwargs` (plain values including `None` injected for nullable parameters).
+The three buckets — `provider_kwargs` (regular providers, resolved recursively), `static_kwargs` (plain values), and
+`context_kwargs` (`ContextProvider` + its `SignatureItem`, resolved live) — are memoized so subsequent resolves within
+the same container lifetime skip recompilation.
 
 ## Step 5 — Recursive resolution
 
@@ -93,10 +94,21 @@ With compiled kwargs in hand:
 resolved_kwargs = dict(static_kwargs)
 for k, v in provider_kwargs.items():
     resolved_kwargs[k] = container.resolve_provider(v)
+for k, (context_provider, item) in context_kwargs.items():
+    value = self._resolve_context_value(container, k, context_provider, item)
+    if value is not types.UNSET:
+        resolved_kwargs[k] = value
 ```
 
-Each dependency provider is resolved by calling back into `container.resolve_provider`, which re-enters this same
-sequence from Step 1 — override check, then `provider.resolve(container)`. The recursion bottoms out at providers with
+Regular dependency providers are resolved by calling back into `container.resolve_provider`, which re-enters this same
+sequence from Step 1 — override check, then `provider.resolve(container)`.
+
+Context-backed parameters are resolved **live on every resolve**, so a `set_context` after a factory has already
+resolved is always picked up (across scopes, for non-cached factories). `_resolve_context_value` mirrors
+`resolve_provider`'s override check, then reads the live context value; when the value is absent it applies the same
+fallback as Step 4's no-provider case — omit (default applies), `None` (nullable), or raise `ArgumentResolutionError`.
+
+The recursion bottoms out at providers with
 no dependencies or at already-cached instances.
 
 ## Step 6 — Creator call and caching

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -228,7 +228,6 @@ class Container:
         are picked up by subsequent resolves.
         """
         self.context_registry.set_context(context_type, obj)
-        self.cache_registry.invalidate_compiled_kwargs()
 
     def __repr__(self) -> str:
         n_providers = len(self.providers_registry)

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -224,8 +224,14 @@ class Container:
         containers. Set the value on the container whose scope matches the
         ``ContextProvider`` (for request-scoped context, pass ``context={...}``
         to :meth:`build_child_container` or call ``set_context`` on the request
-        container). Values set after a dependent factory has already resolved
-        are picked up by subsequent resolves.
+        container).
+
+        Context values are resolved live, so a value set here is picked up by
+        subsequent resolves of **non-cached** providers — including factories in
+        deeper-scoped child containers that read this container's context. A
+        **cached** provider (``Factory(cache_settings=...)``) is built once and
+        its instance is *not* rebuilt by a later ``set_context``; set the context
+        before its first resolve.
         """
         self.context_registry.set_context(context_type, obj)
 

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -120,66 +120,89 @@ class Factory(AbstractProvider[types.T_co]):
                 return provider
         return None
 
-    def _compile_kwargs(self, container: "Container") -> dict[str, typing.Any]:
-        result: dict[str, typing.Any] = {}
+    def _argument_resolution_error(
+        self, arg_name: str, item: SignatureItem, suggestions: list[str]
+    ) -> exceptions.ArgumentResolutionError:
+        return exceptions.ArgumentResolutionError(
+            arg_name=arg_name,
+            arg_type=item.arg_type,
+            bound_type=self.bound_type or self._creator,
+            suggestions=suggestions,
+            member_types=item.args,
+        )
+
+    def _compile_kwargs(
+        self, container: "Container"
+    ) -> tuple[dict[str, "AbstractProvider[typing.Any]"], dict[str, typing.Any], dict[str, typing.Any]]:
+        """Partition parameters into live providers, static values, and live context lookups.
+
+        ``context_kwargs`` holds parameters backed by a ``ContextProvider``; their value is
+        looked up on every resolve (so a late ``set_context`` is always picked up) and the
+        value-absent decision (default / None / raise) is deferred to resolve time. A
+        parameter with no registered provider is a static graph fact, decided once here.
+        """
+        provider_kwargs: dict[str, AbstractProvider[typing.Any]] = {}
+        static_kwargs: dict[str, typing.Any] = {}
+        context_kwargs: dict[str, typing.Any] = {}
         for k, v in self._parsed_kwargs.items():
+            if self._kwargs and k in self._kwargs:
+                continue  # supplied as a static kwarg below
             provider = self._find_dep_provider(container, v)
-            is_kwarg_not_found = not self._kwargs or k not in self._kwargs
-            if provider:
-                if (
-                    is_kwarg_not_found
-                    and isinstance(provider, ContextProvider)
-                    and provider._find_context_value(container) is types.UNSET  # noqa: SLF001
-                ):
-                    if v.default is not types.UNSET:
-                        continue
-                    if v.is_nullable:
-                        result[k] = None
-                        continue
-                    raise exceptions.ArgumentResolutionError(
-                        arg_name=k,
-                        arg_type=v.arg_type,
-                        bound_type=self.bound_type or self._creator,
-                        member_types=v.args,
-                    )
-                result[k] = provider
+            if provider is not None:
+                if isinstance(provider, ContextProvider):
+                    context_kwargs[k] = (provider, v)
+                else:
+                    provider_kwargs[k] = provider
                 continue
 
-            if v.default is types.UNSET and is_kwarg_not_found:
-                if v.is_nullable:
-                    result[k] = None
-                    continue
-                suggestions = (
-                    container.providers_registry.build_suggestions(v.arg_type) if v.arg_type is not None else []
-                )
-                raise exceptions.ArgumentResolutionError(
-                    arg_name=k,
-                    arg_type=v.arg_type,
-                    bound_type=self.bound_type or self._creator,
-                    suggestions=suggestions,
-                    member_types=v.args,
-                )
+            if v.default is not types.UNSET:
+                continue
+            if v.is_nullable:
+                static_kwargs[k] = None
+                continue
+            suggestions = container.providers_registry.build_suggestions(v.arg_type) if v.arg_type is not None else []
+            raise self._argument_resolution_error(k, v, suggestions)
 
         if self._kwargs:
-            result.update(self._kwargs)
-        return result
+            for k, static_value in self._kwargs.items():
+                if isinstance(static_value, AbstractProvider):
+                    provider_kwargs[k] = static_value
+                else:
+                    static_kwargs[k] = static_value
+        return provider_kwargs, static_kwargs, context_kwargs
 
     def _ensure_kwargs_cached(
         self, container: "Container", cache_item: "CacheItem"
-    ) -> tuple[dict[str, "AbstractProvider[typing.Any]"], dict[str, typing.Any]]:
+    ) -> tuple[dict[str, "AbstractProvider[typing.Any]"], dict[str, typing.Any], dict[str, typing.Any]]:
         if not cache_item.kwargs_compiled:
-            kwargs = self._compile_kwargs(container)
-            provider_kwargs: dict[str, AbstractProvider[typing.Any]] = {}
-            static_kwargs: dict[str, typing.Any] = {}
-            for k, v in kwargs.items():
-                if isinstance(v, AbstractProvider):
-                    provider_kwargs[k] = v
-                else:
-                    static_kwargs[k] = v
+            provider_kwargs, static_kwargs, context_kwargs = self._compile_kwargs(container)
             cache_item.provider_kwargs = provider_kwargs
             cache_item.static_kwargs = static_kwargs
+            cache_item.context_kwargs = context_kwargs
             cache_item.kwargs_compiled = True
-        return cache_item.provider_kwargs, cache_item.static_kwargs
+        return cache_item.provider_kwargs, cache_item.static_kwargs, cache_item.context_kwargs
+
+    def _resolve_context_value(
+        self, container: "Container", arg_name: str, provider: ContextProvider[typing.Any], item: SignatureItem
+    ) -> typing.Any:  # noqa: ANN401
+        """Resolve a context-backed parameter live. Returns ``types.UNSET`` to omit the kwarg.
+
+        Mirrors ``Container.resolve_provider``'s override handling, then reads the live context
+        value; an absent value falls back to the creator default (omit), ``None`` (nullable),
+        or raises ``ArgumentResolutionError`` (required).
+        """
+        if container.overrides_registry.overrides:
+            override = container.overrides_registry.fetch_override(provider.provider_id)
+            if override is not types.UNSET:
+                return override
+        value = provider._find_context_value(container)  # noqa: SLF001
+        if value is not types.UNSET:
+            return value
+        if item.default is not types.UNSET:
+            return types.UNSET
+        if item.is_nullable:
+            return None
+        raise self._argument_resolution_error(arg_name, item, [])
 
     def get_dependencies(self, container: "Container") -> dict[str, "AbstractProvider[typing.Any]"]:
         """Return parameter-name → dependency-provider mapping using only the providers registry.
@@ -231,6 +254,17 @@ class Factory(AbstractProvider[types.T_co]):
             error.prepend_step(self._resolution_step())
             raise error from exc
 
+    def _resolve_kwargs(self, container: "Container", cache_item: "CacheItem") -> dict[str, typing.Any]:
+        provider_kwargs, static_kwargs, context_kwargs = self._ensure_kwargs_cached(container, cache_item)
+        resolved_kwargs = dict(static_kwargs)
+        for k, v in provider_kwargs.items():
+            resolved_kwargs[k] = container.resolve_provider(v)
+        for k, (context_provider, item) in context_kwargs.items():
+            value = self._resolve_context_value(container, k, context_provider, item)
+            if value is not types.UNSET:
+                resolved_kwargs[k] = value
+        return resolved_kwargs
+
     def resolve(self, container: "Container") -> types.T_co:
         container = container.find_container(self.scope)
         if container.closed:
@@ -241,10 +275,7 @@ class Factory(AbstractProvider[types.T_co]):
             return cache_item.cache
 
         try:
-            provider_kwargs, static_kwargs = self._ensure_kwargs_cached(container, cache_item)
-            resolved_kwargs = dict(static_kwargs)
-            for k, v in provider_kwargs.items():
-                resolved_kwargs[k] = container.resolve_provider(v)
+            resolved_kwargs = self._resolve_kwargs(container, cache_item)
         except exceptions.ResolutionError as exc:
             exc.prepend_step(self._resolution_step())
             raise

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -59,12 +59,6 @@ class CacheRegistry:
         """Record creation completion; close finalizes in reverse of this order (LIFO)."""
         self._creation_order.append(cache_item)
 
-    def invalidate_compiled_kwargs(self) -> None:
-        for cache_item in self._items.values():
-            cache_item.kwargs_compiled = False
-            cache_item.provider_kwargs = {}
-            cache_item.static_kwargs = {}
-
     async def close_async(self) -> None:
         finalizer_errors: list[BaseException] = []
         for cache_item in reversed(self._creation_order):

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -14,6 +14,7 @@ class CacheItem:
     finalized: bool = False
     provider_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
     static_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
+    context_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
 
     def _clear(self) -> None:
         if self.settings and self.settings.clear_cache:

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -169,3 +169,103 @@ def test_context_provider_reads_registry_at_its_own_scope_not_resolving_containe
     # context set on the container at the provider's scope is what counts
     app.set_context(_ScopedCtx, value)
     assert request.resolve(_ScopedCtx) is value
+
+
+# --- set_context cross-scope staleness (2026-06-14 deep audit) ---
+#
+# An APP-scoped ContextProvider consumed by a deeper (REQUEST) scoped Factory:
+# the factory's compiled kwargs live in the request child's cache_registry, so a
+# late app.set_context must still be picked up by subsequent resolves from that
+# child. Context values are resolved live, not baked in at first resolve.
+
+
+class _CrossCtx: ...
+
+
+class _CrossDefaultSvc:
+    def __init__(self, ctx: _CrossCtx | None = None) -> None:
+        self.ctx = ctx
+
+
+class _CrossNullableSvc:
+    def __init__(self, ctx: _CrossCtx | None) -> None:
+        self.ctx = ctx
+
+
+class _CrossRequiredSvc:
+    def __init__(self, ctx: _CrossCtx) -> None:
+        self.ctx = ctx
+
+
+class _CrossDefaultGroup(Group):
+    ctx = providers.ContextProvider(scope=Scope.APP, context_type=_CrossCtx)
+    svc = providers.Factory(scope=Scope.REQUEST, creator=_CrossDefaultSvc)
+
+
+class _CrossNullableGroup(Group):
+    ctx = providers.ContextProvider(scope=Scope.APP, context_type=_CrossCtx)
+    svc = providers.Factory(scope=Scope.REQUEST, creator=_CrossNullableSvc)
+
+
+class _CrossRequiredGroup(Group):
+    ctx = providers.ContextProvider(scope=Scope.APP, context_type=_CrossCtx)
+    svc = providers.Factory(scope=Scope.REQUEST, creator=_CrossRequiredSvc)
+
+
+def test_late_app_context_seen_by_request_factory_defaulted_param() -> None:
+    app = Container(scope=Scope.APP, groups=[_CrossDefaultGroup])
+    request = app.build_child_container(scope=Scope.REQUEST)
+    assert request.resolve(_CrossDefaultSvc).ctx is None  # context unset at first resolve
+    value = _CrossCtx()
+    app.set_context(_CrossCtx, value)
+    assert request.resolve(_CrossDefaultSvc).ctx is value  # picked up live across scopes
+
+
+def test_late_app_context_seen_by_request_factory_nullable_param() -> None:
+    app = Container(scope=Scope.APP, groups=[_CrossNullableGroup])
+    request = app.build_child_container(scope=Scope.REQUEST)
+    assert request.resolve(_CrossNullableSvc).ctx is None
+    value = _CrossCtx()
+    app.set_context(_CrossCtx, value)
+    assert request.resolve(_CrossNullableSvc).ctx is value
+
+
+def test_late_app_context_required_param_raises_then_resolves_across_scopes() -> None:
+    app = Container(scope=Scope.APP, groups=[_CrossRequiredGroup])
+    request = app.build_child_container(scope=Scope.REQUEST)
+    with pytest.raises(ArgumentResolutionError):
+        request.resolve(_CrossRequiredSvc)
+    value = _CrossCtx()
+    app.set_context(_CrossCtx, value)
+    assert request.resolve(_CrossRequiredSvc).ctx is value
+
+
+def test_override_of_context_param_applies_after_first_resolve_across_scopes() -> None:
+    app = Container(scope=Scope.APP, groups=[_CrossDefaultGroup])
+    request = app.build_child_container(scope=Scope.REQUEST)
+    assert request.resolve(_CrossDefaultSvc).ctx is None
+    override_value = _CrossCtx()
+    app.override(_CrossDefaultGroup.ctx, override_value)
+    assert request.resolve(_CrossDefaultSvc).ctx is override_value
+
+
+class _CachedCtxSvc:
+    def __init__(self, ctx: _CrossCtx | None = None) -> None:
+        self.ctx = ctx
+
+
+class _CachedCtxGroup(Group):
+    ctx = providers.ContextProvider(scope=Scope.APP, context_type=_CrossCtx)
+    svc = providers.Factory(scope=Scope.APP, creator=_CachedCtxSvc, cache_settings=providers.CacheSettings())
+
+
+def test_late_context_does_not_rebuild_cached_singleton() -> None:
+    # Documented limitation: a cached factory's instance is fixed at first build;
+    # a later set_context does not retroactively rebuild it.
+    app = Container(scope=Scope.APP, groups=[_CachedCtxGroup])
+    first = app.resolve(_CachedCtxSvc)
+    assert first.ctx is None
+    app.set_context(_CrossCtx, _CrossCtx())
+    second = app.resolve(_CachedCtxSvc)
+    assert second is first
+    assert second.ctx is None

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -202,6 +202,25 @@ def test_factory_self_reference_in_union_falls_through_to_default() -> None:
     assert result.x == 1
 
 
+def test_factory_self_reference_by_type_falls_through_to_default() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class SelfRefByType:
+        nested: "SelfRefByType | None" = None
+
+    def make(nested: SelfRefByType = SelfRefByType()) -> SelfRefByType:  # noqa: B008
+        return nested
+
+    factory = providers.Factory(creator=make)
+    app_container = Container()
+    app_container.providers_registry.add_providers(factory)
+
+    # `nested` is typed as the factory's own bound type: it must not wire to itself,
+    # and with no other provider it falls through to the creator default.
+    result = app_container.resolve(SelfRefByType)
+    assert isinstance(result, SelfRefByType)
+    assert result.nested is None
+
+
 def test_factory_repr() -> None:
     provider = providers.Factory(creator=str, scope=Scope.APP)
     assert repr(provider) == "Factory(creator=<class 'str'>, scope=<Scope.APP: 1>, cached=False)"


### PR DESCRIPTION
## Summary

Fixes the sole ship-blocker from the 2026-06-14 deep audit: an `APP`-scoped `ContextProvider` consumed by a deeper (`REQUEST`) scoped `Factory` would silently serve a stale value when `set_context` was called after the factory first resolved.

**Root cause:** `set_context` invalidated only the *calling* container's compiled-kwargs memo, but a deeper-scoped factory caches its memo in the child container. When the context was unset at first resolve, the absence (`None`/default/skip) got baked into that child memo and never invalidated → permanently stale, no error. The present-value path was already live; only the *absence* was frozen.

**Fix:** `ContextProvider`-backed params now go into a dedicated `context_kwargs` bucket and are resolved **live on every resolve** — value lookup + default/`None`/raise + override handling deferred to resolve time. The compiled memo is now type-matching only, so it never goes stale and `invalidate_compiled_kwargs` is **deleted** (net simplification). Cached (singleton) factories are built once and can't pick up late context — documented, not changed.

Changes:
- `factory.py`: three-bucket kwargs compilation (`provider`/`static`/`context`); live `_resolve_context_value`
- `cache_registry.py`: add `context_kwargs`; remove `invalidate_compiled_kwargs`
- `container.py`: `set_context` no longer invalidates; docstring scoped to non-cached providers
- `architecture/`: promoted into `containers.md` + `resolution.md`
- Planning bundle: `planning/changes/active/2026-06-14.02-set-context-cross-scope-staleness/`

Side effects (improvements): an override on a context param applied after first resolve now takes effect; a required context param raises until set, then resolves.

## Test Plan
- [x] New regression tests (cross-scope defaulted/nullable/required, override-after-resolve, cached-singleton limitation) — fail on `main`, pass here
- [x] Full suite: 205 passed, 100% coverage (`just test-ci`)
- [x] `just lint-ci` (ruff format + ruff check + ty) clean
- [x] `mkdocs build --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)