### PR TITLE
docs: action 2026-06-14 audit batch-1 rulings (B-4/B-5/S-1/S-2/A-1)

### DIFF
--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -76,6 +76,11 @@ sorts each parameter into one of three buckets stored on the `CacheItem`:
    excluded. A matching `ContextProvider` goes to `context_kwargs` (resolved live, see Step 5); any other provider goes
    to `provider_kwargs`.
 
+   > **Union vs. single parameterized generics.** A bare parameterized generic (e.g. `list[str]`) is *rejected at
+   > declaration* — it cannot be resolved by type. Inside a union, however, each member degrades to its origin for
+   > matching, so `int | list[str]` matches a provider registered for plain `list`. The element type is not enforced
+   > (Python ignores it at runtime); this asymmetry is intentional, not a wiring guarantee.
+
 3. **No provider found** — this is a static graph fact, decided once here:
    - If the parameter has a default, it is omitted (the creator's own default applies).
    - If `SignatureItem.is_nullable` is `True` (the annotation included `None`, e.g. `X | None` or `Optional[X]`), it is

--- a/architecture/validation.md
+++ b/architecture/validation.md
@@ -40,6 +40,11 @@ During the DFS, a provider encountered a second time while it is still on the ac
 type names showing the loop (e.g., `["A", "B", "A"]`). The recursive walk does **not** continue into the cycle,
 but the rest of the graph continues to be checked.
 
+> **Runtime resolution has no cycle guard.** Cycle detection lives only here. To keep the resolve hot path free of
+> per-resolve bookkeeping, `resolve()` does not track in-flight providers — a circular graph that is never validated
+> raises a raw `RecursionError` on first resolve. Run with `validate=True` (or call `container.validate()`) in
+> development to surface cycles as a clear `CircularDependencyError` instead.
+
 ### Inverted scope dependencies
 
 For every dependency edge `provider → dep`, `validate()` compares their **effective scopes** (see below). If

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -118,3 +118,12 @@ These don't fit the register/resolve/validate grouping:
   later `await close_async()` can finalize it. See [Lifecycle](lifecycle.md#close-failure-semantics).
 - **`GroupInstantiationError`** — raised when a `Group` subclass is instantiated. Groups are
   namespaces and must never be created as objects.
+
+## Security note
+
+`modern-di` exception messages are intended for developers (logs, tracebacks during wiring). A
+`CreatorCallError` embeds the wrapped exception's text, and a `FinalizerError` embeds the repr of every
+finalizer exception — so if a creator or finalizer raises an error whose message contains sensitive
+runtime data, that text becomes part of the `modern-di` message. The DI-specific errors themselves are
+conservative (type names and provider reprs only; context values are keyed by type and never repr'd).
+Applications must not echo raw exception strings to untrusted clients.

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -174,6 +174,10 @@ class Factory(AbstractProvider[types.T_co]):
     def _ensure_kwargs_cached(
         self, container: "Container", cache_item: "CacheItem"
     ) -> tuple[dict[str, "AbstractProvider[typing.Any]"], dict[str, typing.Any], dict[str, typing.Any]]:
+        # Compilation runs outside the container lock (the lock guards only singleton creation).
+        # Under the GIL this is safe: the buckets are a deterministic function of the fixed providers
+        # registry, so concurrent compiles produce identical results and at worst recompute once.
+        # (Free-threaded/nogil caveat tracked in planning/deferred.md.)
         if not cache_item.kwargs_compiled:
             provider_kwargs, static_kwargs, context_kwargs = self._compile_kwargs(container)
             cache_item.provider_kwargs = provider_kwargs

--- a/planning/changes/active/2026-06-14.03-audit-doc-rulings-batch1/plan.md
+++ b/planning/changes/active/2026-06-14.03-audit-doc-rulings-batch1/plan.md
@@ -1,0 +1,83 @@
+---
+status: draft
+date: 2026-06-14
+slug: audit-doc-rulings-batch1
+spec: ../../../audits/2026-06-14-deep-audit-report.md
+pr: null
+---
+
+# audit-doc-rulings-batch1 — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Action the approved batch-1 rulings from the 2026-06-14 deep audit —
+the doc/test/comment-only findings (**B-4, B-5, S-1, S-2, A-1**); **A-2** closes
+with no action. No production behavior changes.
+
+**Spec:** [2026-06-14 deep audit report](../../../audits/2026-06-14-deep-audit-report.md)
+
+**Branch:** `fix/audit-doc-rulings-batch1`
+
+**Commit strategy:** Single commit (batch of trivial doc/test edits).
+
+**Rulings (approved 2026-06-14):**
+
+| ID | Ruling | Action |
+|----|--------|--------|
+| B-4 | document (done) + pin | Add a test asserting an override resolves a deeper-scoped provider from a shallower container |
+| B-5 | document | Note the union parameterized-generic → origin degradation asymmetry |
+| S-1 | document | Note that runtime resolution has no cycle guard; use `validate()` in dev |
+| S-2 | document | Note wrapped creator/finalizer error text; don't echo raw exceptions to untrusted clients |
+| A-1 | accept + comment | Comment the GIL-benign compile-outside-lock; record the free-threading caveat in `deferred.md` |
+| A-2 | close | Already documented intentional (2026-06-12 X-1); no action |
+
+---
+
+### Task 1: Pin B-4 (override bypasses scope validation)
+
+**Files:**
+- Modify: `tests/providers/test_factory.py`
+
+- [ ] **Step 1:** Add a test: a REQUEST-scoped factory raises `ScopeNotInitializedError`
+  on `app_container.resolve(...)`; after `app_container.override(provider, mock)` the same
+  call returns the mock. Reference `architecture/testing-and-overrides.md` "Scope behaviour
+  under overrides" in a comment.
+- [ ] **Step 2:** `just test tests/providers/test_factory.py` — passes.
+
+### Task 2: Document B-5, S-1, S-2
+
+**Files:**
+- Modify: `architecture/resolution.md` (B-5 — union origin-degradation note)
+- Modify: `architecture/validation.md` (S-1 — runtime has no cycle guard; use `validate()`)
+- Modify: `docs/providers/errors-and-exceptions.md` (S-2 — wrapped error text note)
+
+- [ ] **Step 1:** B-5 — in the union/`_find_dep_provider` discussion, note that a
+  parameterized generic inside a union degrades to its origin for matching (whereas a bare
+  single parameterized generic is rejected at declaration).
+- [ ] **Step 2:** S-1 — note that runtime resolution does not detect cycles (raises
+  `RecursionError`); use `validate=True` / `container.validate()` in development.
+- [ ] **Step 3:** S-2 — note that messages may embed wrapped creator/finalizer exception
+  text; applications must not echo raw exceptions to untrusted clients.
+
+### Task 3: A-1 comment + deferred caveat
+
+**Files:**
+- Modify: `modern_di/providers/factory.py` (comment at the compile site)
+- Modify: `planning/deferred.md` (free-threading caveat)
+
+- [ ] **Step 1:** Add a comment explaining the kwargs compilation runs outside the lock and
+  why that is safe under the GIL (deterministic, idempotent buckets).
+- [ ] **Step 2:** Add a `deferred.md` entry: under free-threaded (nogil) CPython,
+  `kwargs_compiled` set after the bucket rebinds could expose stale-empty buckets; revisit if
+  free-threading support becomes a goal.
+
+### Task 4: Verify and ship
+
+- [ ] **Step 1:** `just test-ci` — 100% coverage, green.
+- [ ] **Step 2:** `just lint-ci` — clean.
+- [ ] **Step 3:** `uv run mkdocs build --strict` — OK.
+- [ ] **Step 4:** Commit, push, open PR. On merge: set `status: shipped` + `pr:`, move bundle
+  to `archive/`, move Index line in `planning/README.md`, and mark B-4/B-5/S-1/S-2/A-1/A-2 as
+  resolved in the audit report's Status line.

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -2,4 +2,16 @@
 
 Items intentionally not actioned in the current work, kept here so they aren't lost. Each has enough context to pick up cold.
 
-_No deferred items at present._
+## Free-threaded (nogil) safety of kwargs compilation — from 2026-06-14 audit (A-1)
+
+`Factory._ensure_kwargs_cached` compiles the kwargs buckets outside the container lock
+(`modern_di/providers/factory.py`). Under the GIL this is safe — the buckets are a deterministic
+function of the fixed providers registry, so concurrent compiles are idempotent. Under free-threaded
+CPython, however, `cache_item.kwargs_compiled` is set *after* the bucket fields are rebound; without a
+memory barrier another thread could observe `kwargs_compiled is True` while the bucket dicts are still
+empty/partial, and resolve with wrong kwargs.
+
+**Revisit trigger:** if/when free-threading (PEP 703 / `--disable-gil`) support becomes a goal. Fix
+options: set `kwargs_compiled` last under an explicit barrier, compile under the existing lock, or use
+an immutable compiled-kwargs object published atomically. Until then, document modern-di as
+GIL-assuming for compilation. See [2026-06-14 audit A-1](audits/2026-06-14-deep-audit-report.md).

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -161,6 +161,19 @@ def test_factory_overridden_request_scope() -> None:
     assert instance3 is not instance1
 
 
+def test_override_bypasses_scope_check_from_shallower_container() -> None:
+    # Documented intentional: an override is returned before the scope check, so a
+    # deeper-scoped provider can be resolved from a shallower container — see
+    # architecture/testing-and-overrides.md "Scope behaviour under overrides".
+    app_container = Container(groups=[MyGroup])
+    with pytest.raises(ScopeNotInitializedError):
+        app_container.resolve_provider(MyGroup.request_factory)
+
+    override = DependentCreator(dep1=SimpleCreator(dep1="override"))
+    app_container.override(MyGroup.request_factory, override)
+    assert app_container.resolve_provider(MyGroup.request_factory) is override
+
+
 def test_factory_scope_is_not_initialized() -> None:
     app_container = Container(groups=[MyGroup])
     with pytest.raises(


### PR DESCRIPTION
## Summary

Actions the approved **batch-1** rulings from the [2026-06-14 deep audit](planning/audits/2026-06-14-deep-audit-report.md) — the doc/test/comment-only findings. **No production behavior changes.**

| ID | Ruling | Change |
|----|--------|--------|
| **B-4** | document (done) + pin | Test: an override resolves a deeper-scoped provider from a shallower container (intentional, per `testing-and-overrides.md`) |
| **B-5** | document | `resolution.md`: union parameterized-generic degrades to its origin for matching (vs. a bare generic rejected at declaration) |
| **S-1** | document | `validation.md`: runtime resolution has no cycle guard (raw `RecursionError`); use `validate()` in dev |
| **S-2** | document | `errors-and-exceptions.md`: messages may embed wrapped creator/finalizer error text; don't echo raw exceptions to untrusted clients |
| **A-1** | accept + comment | `factory.py` comment on the GIL-benign compile-outside-lock; nogil caveat recorded in `deferred.md` |
| **A-2** | close | Already documented intentional (2026-06-12 X-1); no action |

Bundle (plan-only, spec = the audit report): `planning/changes/active/2026-06-14.03-audit-doc-rulings-batch1/`.

## Test Plan
- [x] New B-4 pinning test passes; full suite 206 passed, 100% coverage (`just test-ci`)
- [x] `just lint-ci` clean (ruff + ty)
- [x] `mkdocs build --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)