### PR TITLE
refactor: provider display_name (R-1) + public fetch_context_value (R-2)

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -158,7 +158,7 @@ class Container:
                 return
             if pid in visiting:
                 cycle_start = next(i for i, p in enumerate(path) if p.provider_id == pid)
-                cycle_names = [p.bound_type.__name__ if p.bound_type else repr(p) for p in path[cycle_start:]]
+                cycle_names = [p.display_name for p in path[cycle_start:]]
                 cycle_names.append(cycle_names[0])
                 validation_errors.append(exceptions.CircularDependencyError(cycle_path=cycle_names))
                 return

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -278,8 +278,8 @@ class InvalidScopeDependencyError(RegistrationError):
         self.provider = provider
         self.parameter_name = parameter_name
         self.dep_provider = dep_provider
-        provider_name = provider.bound_type.__name__ if provider.bound_type else repr(provider)
-        dep_name = dep_provider.bound_type.__name__ if dep_provider.bound_type else repr(dep_provider)
+        provider_name = provider.display_name
+        dep_name = dep_provider.display_name
         super().__init__(
             errors.INVALID_SCOPE_DEPENDENCY_ERROR.format(
                 provider_name=provider_name,

--- a/modern_di/providers/abstract.py
+++ b/modern_di/providers/abstract.py
@@ -25,6 +25,15 @@ class AbstractProvider(abc.ABC, typing.Generic[types.T_co]):
         self.bound_type = bound_type
         self.provider_id: typing.Final = next(_provider_id_counter)
 
+    @property
+    def display_name(self) -> str:
+        """Human-readable name for error messages and resolution steps.
+
+        The bound type's name when known, else the provider's repr. ``Factory`` overrides
+        this to fall back to the creator's name.
+        """
+        return self.bound_type.__name__ if self.bound_type else repr(self)
+
     @abc.abstractmethod
     def resolve(self, container: "Container") -> typing.Any: ...  # noqa: ANN401
 

--- a/modern_di/providers/alias.py
+++ b/modern_di/providers/alias.py
@@ -46,8 +46,7 @@ class Alias(AbstractProvider[types.T_co]):
         return source
 
     def _resolution_step(self) -> "exceptions.ResolutionStep":
-        name = self.bound_type.__name__ if self.bound_type else repr(self)
-        return exceptions.ResolutionStep(scope=self.scope, name=name)
+        return exceptions.ResolutionStep(scope=self.scope, name=self.display_name)
 
     def get_dependencies(self, container: "Container") -> dict[str, "AbstractProvider[typing.Any]"]:
         return {"source": self._find_source(container)}

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -38,12 +38,12 @@ class ContextProvider(AbstractProvider[types.T_co]):
         return f"ContextProvider(context_type={self._context_type!r}, scope={self.scope!r})"
 
     def resolve(self, container: "Container") -> types.T_co | None:
-        value = self._find_context_value(container)
+        value = self.fetch_context_value(container)
         if value is types.UNSET:
             return None
         return typing.cast(types.T_co, value)
 
-    def _find_context_value(self, container: "Container") -> types.T_co | object:
+    def fetch_context_value(self, container: "Container") -> types.T_co | object:
         container = container.find_container(self.scope)
         if container.closed:
             raise exceptions.ContainerClosedError(container_scope=container.scope)

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -104,9 +104,14 @@ class Factory(AbstractProvider[types.T_co]):
     def __repr__(self) -> str:
         return f"Factory(creator={self._creator!r}, scope={self.scope!r}, cached={self.cache_settings is not None})"
 
+    @property
+    def display_name(self) -> str:
+        if self.bound_type:
+            return self.bound_type.__name__
+        return getattr(self._creator, "__name__", repr(self._creator))
+
     def _resolution_step(self) -> exceptions.ResolutionStep:
-        name = self.bound_type.__name__ if self.bound_type else getattr(self._creator, "__name__", repr(self._creator))
-        return exceptions.ResolutionStep(scope=self.scope, name=name)
+        return exceptions.ResolutionStep(scope=self.scope, name=self.display_name)
 
     def _find_dep_provider(self, container: "Container", v: SignatureItem) -> "AbstractProvider[typing.Any] | None":
         if v.arg_type:
@@ -199,7 +204,7 @@ class Factory(AbstractProvider[types.T_co]):
             override = container.overrides_registry.fetch_override(provider.provider_id)
             if override is not types.UNSET:
                 return override
-        value = provider._find_context_value(container)  # noqa: SLF001
+        value = provider.fetch_context_value(container)
         if value is not types.UNSET:
             return value
         if item.default is not types.UNSET:

--- a/planning/changes/active/2026-06-14.05-audit-fixes-batch3/plan.md
+++ b/planning/changes/active/2026-06-14.05-audit-fixes-batch3/plan.md
@@ -1,0 +1,69 @@
+---
+status: draft
+date: 2026-06-14
+slug: audit-fixes-batch3
+spec: ../../../audits/2026-06-14-deep-audit-report.md
+pr: null
+---
+
+# audit-fixes-batch3 — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Refactor batch from the 2026-06-14 deep audit — **R-1** (dedupe the
+provider display-name idiom) and **R-2** (drop the `SLF001` private-method
+reach-in). Behavior-preserving; no new tests (existing suite + 100% coverage
+exercise all branches).
+
+**Spec:** [2026-06-14 deep audit report](../../../audits/2026-06-14-deep-audit-report.md)
+
+**Branch:** `fix/audit-fixes-batch3`
+
+**Commit strategy:** Single commit.
+
+## Design decision (R-2 API shape, approved 2026-06-14)
+
+R-2 was scoped to the **minimal** option: rename `ContextProvider._find_context_value` →
+public `fetch_context_value` (removing the `SLF001` noqa at the Factory call site), but **keep**
+`isinstance(provider, ContextProvider)` for compile-time routing — an `isinstance` against a
+concrete sibling provider is acceptable, and this keeps new public surface to one method. The
+fuller "ClassVar capability flag + base method" decoupling was considered and declined. Note:
+the `enforces_dependency_scope` ClassVar referenced in the 2026-06-12 audit is not in the live
+code (superseded by `effective_scope()`), so the established extension pattern is method/property
+overrides on `AbstractProvider`.
+
+R-4/R-5/R-6 are **deferred** (marginal internal tidiness; the compile vs. validate predicates in
+Factory genuinely diverge, so R-5 cannot be cleanly unified).
+
+---
+
+### Task 1: R-1 — `display_name` on AbstractProvider
+
+**Files:**
+- Modify: `modern_di/providers/abstract.py` (base `display_name` property)
+- Modify: `modern_di/providers/factory.py` (override + use in `_resolution_step`)
+- Modify: `modern_di/providers/alias.py`, `modern_di/container.py`, `modern_di/exceptions.py` (use it)
+
+- [x] **Step 1:** Add `AbstractProvider.display_name` → `bound_type.__name__ if bound_type else repr(self)`.
+- [x] **Step 2:** Override in `Factory` to fall back to the creator's `__name__`.
+- [x] **Step 3:** Replace the duplicated idiom at the ~5 sites (`_resolution_step` in Factory and
+  Alias, the cycle-path list in `container.validate()`, and both names in
+  `InvalidScopeDependencyError`).
+
+### Task 2: R-2 (minimal) — public `fetch_context_value`
+
+**Files:**
+- Modify: `modern_di/providers/context_provider.py` (rename method; update internal `resolve`)
+- Modify: `modern_di/providers/factory.py` (call public method; drop `# noqa: SLF001`)
+
+- [x] **Step 1:** Rename `_find_context_value` → `fetch_context_value` (public).
+- [x] **Step 2:** Update `Factory._resolve_context_value` to call it without the SLF001 suppression.
+
+### Task 3: Verify and ship
+
+- [ ] **Step 1:** `just test-ci` — 100% coverage, green.
+- [ ] **Step 2:** `just lint-ci` — clean (the SLF001 noqa is gone).
+- [ ] **Step 3:** Commit, push, open PR. On merge: archive bundle (`status: shipped` + `pr:`),
+  move Index line, mark R-1/R-2 resolved in the audit report Status line.


### PR DESCRIPTION
## Summary

Batch 3 of the [2026-06-14 deep audit](planning/audits/2026-06-14-deep-audit-report.md) — two behavior-preserving refactors that reduce duplication and remove a private-method reach-in.

- **R-1** — add `AbstractProvider.display_name` (`bound_type.__name__` else `repr(self)`; `Factory` overrides to fall back to the creator name). Replaces the duplicated `bound_type.__name__ if … else repr(…)` idiom at ~5 sites: `_resolution_step` in `Factory` and `Alias`, the cycle-path list in `validate()`, and both names in `InvalidScopeDependencyError`.
- **R-2 (minimal)** — rename `ContextProvider._find_context_value` → public `fetch_context_value`; `Factory` calls it without the `# noqa: SLF001` suppression.

### Design decision (R-2 shape)
Chose the **minimal** option: keep `isinstance(provider, ContextProvider)` for compile-time routing (acceptable against a concrete sibling provider) and only promote the value-probe to public — one new method, not a ClassVar+method decouple. R-4/R-5/R-6 deferred (marginal; the compile vs. validate predicates genuinely diverge, so R-5 can't be cleanly unified). Recorded in the bundle.

## Test Plan
- [x] Behavior-preserving — no new tests; existing suite exercises all `display_name` branches and the renamed method
- [x] 208 passed, 100% coverage (`just test-ci`)
- [x] `just lint-ci` clean (the SLF001 noqa is gone; ty clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)