### PR TITLE
Audit batches 4+5: test hardening (P-6/R-3/X-2) + DX docs (X-3/X-4/X-5)

### DIFF
--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -72,7 +72,9 @@ Catch `ContainerError` for any container/scope failure.
 
 Catch `ResolutionError` for any resolution failure. These carry a `dependency_path` that is
 accumulated as the error propagates, so the message shows the full chain from the requested type
-down to the failing dependency.
+down to the failing dependency. `dependency_path` is a `list[ResolutionStep]`, where each
+`ResolutionStep` (importable from `modern_di.exceptions`) has a `.scope` and a `.name` — inspect it
+to render the chain programmatically.
 
 - **`ProviderNotRegisteredError`** — raised by `resolve(SomeType)` when no provider is registered for
   the type. The message includes "did you mean…" suggestions when a close match exists. See

--- a/modern_di/__init__.py
+++ b/modern_di/__init__.py
@@ -1,3 +1,4 @@
+from modern_di import exceptions
 from modern_di.container import Container
 from modern_di.group import Group
 from modern_di.scope import Scope
@@ -7,5 +8,6 @@ __all__ = [
     "Container",
     "Group",
     "Scope",
+    "exceptions",
     "providers",
 ]

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -11,6 +11,14 @@ if typing.TYPE_CHECKING:
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class ResolutionStep:
+    """One entry in a :class:`ResolutionError`'s ``dependency_path``.
+
+    Attributes:
+        scope: the scope of the provider at this step of the resolution chain.
+        name: the provider's display name (bound type or creator name).
+
+    """
+
     scope: enum.IntEnum
     name: str
 
@@ -28,6 +36,8 @@ class ContainerError(ModernDIError):
 
 
 class InvalidChildScopeError(ContainerError):
+    """Child scope is not deeper than the parent. Inspect ``.parent_scope``, ``.child_scope``, ``.allowed_scopes``."""
+
     __slots__ = ("allowed_scopes", "child_scope", "parent_scope")
 
     def __init__(self, *, parent_scope: enum.IntEnum, child_scope: enum.IntEnum, allowed_scopes: list[str]) -> None:
@@ -44,6 +54,8 @@ class InvalidChildScopeError(ContainerError):
 
 
 class MaxScopeReachedError(ContainerError):
+    """No scope deeper than ``.parent_scope`` exists, so no child scope can be auto-derived."""
+
     __slots__ = ("parent_scope",)
 
     def __init__(self, *, parent_scope: enum.IntEnum) -> None:
@@ -52,6 +64,8 @@ class MaxScopeReachedError(ContainerError):
 
 
 class ScopeNotInitializedError(ContainerError):
+    """Provider's scope is deeper than any active container. Inspect ``.provider_scope``, ``.container_scope``."""
+
     __slots__ = ("container_scope", "provider_scope")
 
     def __init__(self, *, provider_scope: enum.IntEnum, container_scope: enum.IntEnum) -> None:
@@ -66,6 +80,8 @@ class ScopeNotInitializedError(ContainerError):
 
 
 class ScopeSkippedError(ContainerError):
+    """Provider's scope was skipped in the container chain. Attrs: ``provider_scope``, ``container_scope``."""
+
     __slots__ = ("container_scope", "provider_scope")
 
     def __init__(self, *, provider_scope: enum.IntEnum, container_scope: enum.IntEnum) -> None:
@@ -80,6 +96,8 @@ class ScopeSkippedError(ContainerError):
 
 
 class InvalidScopeTypeError(ContainerError):
+    """A non-``IntEnum`` value was passed as a scope. Inspect ``.scope_value``."""
+
     __slots__ = ("scope_value",)
 
     def __init__(self, *, scope_value: typing.Any) -> None:  # noqa: ANN401
@@ -93,6 +111,8 @@ class InvalidScopeTypeError(ContainerError):
 
 
 class ContainerClosedError(ContainerError):
+    """Operation attempted on a closed container. Attr: ``container_scope``; re-enter the ``with`` block to reopen."""
+
     __slots__ = ("container_scope",)
 
     def __init__(self, *, container_scope: enum.IntEnum) -> None:
@@ -133,6 +153,8 @@ class ResolutionError(ModernDIError):
 
 
 class ProviderNotRegisteredError(ResolutionError):
+    """No provider registered for the requested type. Inspect ``.provider_type`` and ``.suggestions``."""
+
     __slots__ = ("provider_type", "suggestions")
 
     def __init__(
@@ -150,6 +172,8 @@ class ProviderNotRegisteredError(ResolutionError):
 
 
 class AliasSourceNotRegisteredError(ResolutionError):
+    """An ``Alias`` points at a ``.source_type`` that has no registered provider."""
+
     __slots__ = ("source_type",)
 
     def __init__(self, *, source_type: type) -> None:
@@ -158,6 +182,8 @@ class AliasSourceNotRegisteredError(ResolutionError):
 
 
 class ArgumentResolutionError(ResolutionError):
+    """Creator parameter could not be wired. Attrs: ``arg_name``, ``arg_type``, ``bound_type``, ``suggestions``."""
+
     __slots__ = ("arg_name", "arg_type", "bound_type", "suggestions")
 
     def __init__(
@@ -190,6 +216,8 @@ class ArgumentResolutionError(ResolutionError):
 
 
 class CreatorCallError(ResolutionError):
+    """A creator's dependencies resolved but the creator itself raised. Inspect ``.creator`` and ``.original_error``."""
+
     __slots__ = ("creator", "original_error")
 
     def __init__(self, *, creator: typing.Any, original_error: Exception) -> None:  # noqa: ANN401
@@ -200,6 +228,8 @@ class CreatorCallError(ResolutionError):
 
 
 class CircularDependencyError(ResolutionError):
+    """A dependency cycle was detected by ``validate()``. Inspect ``.cycle_path`` (the loop as type names)."""
+
     __slots__ = ("cycle_path",)
 
     def __init__(self, *, cycle_path: list[str]) -> None:
@@ -214,6 +244,8 @@ class RegistrationError(ModernDIError):
 
 
 class DuplicateProviderTypeError(RegistrationError):
+    """Two providers were registered for the same ``.provider_type``."""
+
     __slots__ = ("provider_type",)
 
     def __init__(self, *, provider_type: type) -> None:
@@ -222,6 +254,8 @@ class DuplicateProviderTypeError(RegistrationError):
 
 
 class UnknownFactoryKwargError(RegistrationError):
+    """Factory kwargs had unknown keys. Attrs: ``creator``, ``unknown_keys``, ``known_keys``, ``suggestions``."""
+
     __slots__ = ("creator", "known_keys", "suggestions", "unknown_keys")
 
     def __init__(
@@ -250,6 +284,8 @@ class UnknownFactoryKwargError(RegistrationError):
 
 
 class UnsupportedCreatorParameterError(RegistrationError):
+    """A creator parameter cannot be wired by type. Inspect ``.creator``, ``.parameter_name``, ``.reason``."""
+
     __slots__ = ("creator", "parameter_name", "reason")
 
     def __init__(self, *, creator: typing.Any, parameter_name: str, reason: str) -> None:  # noqa: ANN401
@@ -265,6 +301,8 @@ class UnsupportedCreatorParameterError(RegistrationError):
 
 
 class InvalidScopeDependencyError(RegistrationError):
+    """A provider depends on a deeper-scoped one. Inspect ``.provider``, ``.parameter_name``, ``.dep_provider``."""
+
     __slots__ = ("dep_provider", "parameter_name", "provider")
 
     def __init__(
@@ -292,6 +330,8 @@ class InvalidScopeDependencyError(RegistrationError):
 
 
 class ValidationFailedError(ContainerError):
+    """``validate()`` found one or more issues. Inspect ``.errors`` (the list of underlying exceptions)."""
+
     __slots__ = ("errors",)
 
     def __init__(self, *, errors: list[Exception]) -> None:
@@ -307,6 +347,8 @@ class ValidationFailedError(ContainerError):
 
 
 class FinalizerError(ModernDIError):
+    """One or more finalizers raised during close. Inspect ``.finalizer_errors`` and ``.is_async``."""
+
     __slots__ = ("finalizer_errors", "is_async")
 
     def __init__(self, *, finalizer_errors: list[BaseException], is_async: bool) -> None:
@@ -328,6 +370,8 @@ class AsyncFinalizerInSyncCloseError(ModernDIError):
 
 
 class GroupInstantiationError(ModernDIError):
+    """A ``Group`` subclass was instantiated. Inspect ``.group_name``; groups are namespaces, never objects."""
+
     __slots__ = ("group_name",)
 
     def __init__(self, *, group_name: str) -> None:

--- a/planning/changes/active/2026-06-14.06-audit-fixes-batch4-5/plan.md
+++ b/planning/changes/active/2026-06-14.06-audit-fixes-batch4-5/plan.md
@@ -1,0 +1,69 @@
+---
+status: draft
+date: 2026-06-14
+slug: audit-fixes-batch4-5
+spec: ../../../audits/2026-06-14-deep-audit-report.md
+pr: null
+---
+
+# audit-fixes-batch4-5 — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Clear the remaining actionable low-severity findings from the 2026-06-14 deep
+audit — test hardening (**P-6, R-3, X-2**) and DX/docs (**X-3, X-4, X-5**).
+
+**Spec:** [2026-06-14 deep audit report](../../../audits/2026-06-14-deep-audit-report.md)
+
+**Branch:** `fix/audit-fixes-batch4-5`
+
+**Commit strategy:** Two commits — (1) test hardening, (2) DX/docs.
+
+**Scope notes:** X-2 and R-3 are deliberately **surgical** — the verifier defended exact-match
+asserts as a useful DX-regression guard for this library, so only the genuinely brittle cases are
+changed (the `<locals>`-coupled typo message and the exact-indentation dependency tree for X-2;
+the one white-box assert with a clear behavioral surface for R-3). The remaining exact-match and
+white-box asserts are left as intentional guards.
+
+---
+
+### Task 1 (commit 1): Test hardening — P-6, R-3, X-2
+
+**Files:**
+- Modify: `tests/providers/test_factory.py` (P-6)
+- Modify: `tests/providers/test_singleton.py` (R-3)
+- Modify: `tests/test_suggestions.py`, `tests/test_dependency_path.py` (X-2)
+
+- [x] **P-6:** add `test_compile_kwargs_is_memoized_across_resolves` — spies on
+  `Factory._compile_kwargs`, asserts it runs once per provider across two resolves (pins the
+  compile-once invariant).
+- [x] **R-3:** rewrite the `test_app_singleton` `cache_item.cache is not UNSET` check into a
+  behavioral reopen assertion (`clear_cache=False` instance survives close and is returned again
+  after reopen). Other white-box asserts (async-finalizer-in-sync-close; failed-creation
+  `cached_count`) are intentional and already commented.
+- [x] **X-2:** `test_typo_suggestion` asserts `exc.suggestions` + message substrings instead of the
+  full rendered string (drops the brittle `<locals>.Repostory` repr); `test_chain_appears_…`
+  keeps the structured `dependency_path` assert and checks the rendered tree via substrings.
+
+### Task 2 (commit 2): DX/docs — X-3, X-4, X-5
+
+**Files:**
+- Modify: `modern_di/exceptions.py` (X-3 + X-5 docstrings)
+- Modify: `modern_di/__init__.py` (X-4)
+- Modify: `docs/providers/errors-and-exceptions.md` (X-5)
+
+- [x] **X-3:** add concise class docstrings to every concrete exception, naming its public
+  inspection attributes (IDE hover).
+- [x] **X-4:** explicitly `from modern_di import exceptions` and add `"exceptions"` to `__all__`.
+- [x] **X-5:** docstring on `ResolutionStep` (its `scope`/`name` fields) + a doc note that
+  `dependency_path` is a `list[ResolutionStep]`.
+
+### Task 3: Verify and ship
+
+- [x] `just test-ci` — 209 passed, 100% coverage.
+- [x] `just lint-ci` — clean. `uv run mkdocs build --strict` — OK.
+- [ ] Commit (×2), push, open PR. On merge: archive bundle (`status: shipped` + `pr:`), move
+  Index line, mark P-6/R-3/X-2/X-3/X-4/X-5 resolved in the audit report Status line. This closes
+  every actionable finding; only R-4/R-5/R-6 (won't-fix) and the A-1 nogil follow-up remain.

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -422,6 +422,26 @@ def test_provider_instances_have_no_dict() -> None:
         factory.some_unexpected_attr = 1
 
 
+def test_compile_kwargs_is_memoized_across_resolves() -> None:
+    # Pins the compile-once invariant: kwargs compilation (type lookups + partitioning) runs
+    # exactly once per provider per container, not on every resolve. A regression that moved it
+    # back onto the per-resolve path would leave correctness tests green but silently slow.
+    class _MemoGroup(Group):
+        leaf = providers.Factory(scope=Scope.APP, creator=SimpleCreator, kwargs={"dep1": "x"})
+        svc = providers.Factory(scope=Scope.APP, creator=DependentCreator)
+
+    container = Container(groups=[_MemoGroup])
+    real_compile = providers.Factory._compile_kwargs  # noqa: SLF001 — spying on the memoization internal
+    with unittest.mock.patch.object(
+        providers.Factory, "_compile_kwargs", autospec=True, side_effect=real_compile
+    ) as compile_spy:
+        container.resolve(DependentCreator)
+        container.resolve(DependentCreator)
+    # svc + leaf each compile once on the first resolve; the second reuses the memo (else this is 4).
+    expected_compile_calls = 2
+    assert compile_spy.call_count == expected_compile_calls
+
+
 # Q-1 / G-3 — optional (X | None) params inject None when no provider is registered
 
 

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -51,12 +51,15 @@ async def test_app_singleton() -> None:
     assert singleton1 is singleton2
 
     app_container.close_sync()
-    cache_item = app_container.cache_registry.fetch_cache_item(LocalGroup.singleton)
-    assert cache_item.cache is not UNSET
-    assert sync_calls == [singleton1]
+    assert sync_calls == [singleton1]  # finalizer ran once on close
 
     with pytest.raises(ContainerClosedError):
         app_container.resolve_provider(LocalGroup.singleton)
+
+    # clear_cache=False: the instance survives the close and is returned again after reopen,
+    # without re-running the creator or finalizer (behavioral check, not cache_registry inspection).
+    with app_container:
+        assert app_container.resolve_provider(LocalGroup.singleton) is singleton1
 
     await app_container.close_async()
     assert sync_calls == [singleton1]

--- a/tests/test_dependency_path.py
+++ b/tests/test_dependency_path.py
@@ -32,17 +32,17 @@ def test_chain_appears_when_arg_unresolvable() -> None:
         container.resolve(MyService)
 
     exc = exc_info.value
+    # The structured path is the stable contract; the rendered string is checked via substrings
+    # rather than exact whitespace so cosmetic formatting can evolve without churning this test.
     assert exc.dependency_path == [
         ResolutionStep(scope=Scope.APP, name="MyService"),
         ResolutionStep(scope=Scope.APP, name="Repository"),
     ]
-    assert str(exc) == (
-        "Cannot resolve dependency chain:\n"
-        "  APP  MyService\n"
-        "  APP  └─> Repository\n"
-        "  caused by: Argument db of type <class 'tests.test_dependency_path.Database'> "
-        "cannot be resolved. Trying to build dependency <class 'tests.test_dependency_path.Repository'>."
-    )
+    rendered = str(exc)
+    assert rendered.startswith("Cannot resolve dependency chain:")
+    assert "MyService" in rendered
+    assert "└─> Repository" in rendered
+    assert "caused by: Argument db" in rendered
 
 
 def test_no_chain_when_top_level_provider_missing() -> None:

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -64,13 +64,14 @@ def test_typo_suggestion() -> None:
     with pytest.raises(ProviderNotRegisteredError) as exc_info:
         container.resolve(Repostory)
 
-    assert str(exc_info.value) == (
-        "Provider of type "
-        "<class 'tests.test_suggestions.test_typo_suggestion.<locals>.Repostory'> "
-        "is not registered in providers registry.\n"
-        "Did you mean:\n"
-        "  - Repository (similar name, scope=APP)"
-    )
+    # Assert the structured suggestion + message essence rather than the full rendered string,
+    # which would otherwise embed the brittle `<locals>.Repostory` repr (couples to this test's name).
+    exc = exc_info.value
+    assert exc.provider_type is Repostory
+    assert exc.suggestions == ["  - Repository (similar name, scope=APP)"]
+    rendered = str(exc)
+    assert "is not registered in providers registry" in rendered
+    assert "Did you mean:" in rendered
 
 
 def test_suggestion_includes_provider_scope() -> None:


### PR DESCRIPTION
## Summary

Batches 4 + 5 of the [2026-06-14 deep audit](planning/audits/2026-06-14-deep-audit-report.md) — the remaining actionable low-severity findings, in two commits.

**Test hardening (commit 1):**
- **P-6** — `test_compile_kwargs_is_memoized_across_resolves` pins the compile-once invariant (spies on `Factory._compile_kwargs`; asserts one compile per provider across two resolves).
- **R-3** — rewrite a singleton `cache_item.cache is not UNSET` white-box assert into a behavioral reopen check (`clear_cache=False` instance survives close and returns again after reopen).
- **X-2** — `test_typo_suggestion` and the dependency-path test assert structured fields (`exc.suggestions`, `exc.dependency_path`) + message substrings instead of brittle full-string matches (drops the `<locals>.Repostory` repr and exact-indentation coupling).

**DX / docs (commit 2):**
- **X-3** — concise class docstrings on every concrete exception, naming its public inspection attributes (IDE hover).
- **X-4** — explicitly export `exceptions` from `modern_di` and add it to `__all__`.
- **X-5** — docstring on `ResolutionStep`; note `dependency_path` is a `list[ResolutionStep]` in the errors doc.

### Scope note
X-2/R-3 are deliberately **surgical** — the audit verifier defended exact-match asserts as a useful DX-regression guard for this library, so only the genuinely brittle cases were changed; the rest are kept as intentional guards. R-4/R-5/R-6 remain **won't-fix** (marginal internal tidiness); the A-1 nogil item stays in `deferred.md`. **This PR closes every actionable audit finding.**

## Test Plan
- [x] 209 passed, 100% coverage (`just test-ci`)
- [x] `just lint-ci` clean (ruff + ty); `mkdocs build --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)