### PR TITLE
ci: deploy docs via GitHub Actions Pages (drop gh-pages branch)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,20 +9,32 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-concurrency:
-  group: docs-deploy
-  cancel-in-progress: true
-
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - uses: extractions/setup-just@v4
       - uses: astral-sh/setup-uv@v8.2.0
-      - run: just docs-deploy
+      - run: just docs-build
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/Justfile
+++ b/Justfile
@@ -37,8 +37,3 @@ publish:
 # Build the docs site, failing on broken links / nav warnings; CI runs this on every PR.
 docs-build:
     uvx --with-requirements docs/requirements.txt mkdocs build --strict
-
-# Force-pushes built site to gh-pages; CI runs this on push to main.
-# Manual invocation from a stale checkout will roll the live site back.
-docs-deploy:
-    uvx --with-requirements docs/requirements.txt mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary

- Migrates docs deploy to GitHub-managed Pages flow (build artifact + `actions/deploy-pages`)
- Removes the obsolete `docs-deploy` Justfile recipe (was `mkdocs gh-deploy --force`)
- Pages source flip to GitHub Actions + gh-pages branch deletion happen as a post-merge cutover

## Test plan

- [ ] Confirm `just docs-build` passes locally (exit 0, no --strict failures)
- [ ] Merge, then flip Pages source to "GitHub Actions" in repo Settings → Pages
- [ ] Verify deploy workflow triggers on next push to `main` touching docs

Part of a 6-repo rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)