### PR TITLE
refactor: extract WiringPlan from Factory

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -53,7 +53,7 @@ The four registries split into two categories:
 |---|---|---|
 | `ProvidersRegistry` | Yes — all containers share one instance | Maps `type → AbstractProvider`; populated once at root construction time from `groups`. |
 | `OverridesRegistry` | Yes — all containers share one instance | Maps `provider_id → override object`; used by tests to substitute real instances. |
-| `CacheRegistry` | No — each container has its own | Maps `provider_id → CacheItem`; stores resolved singleton instances and compiled kwargs for this scope level. |
+| `CacheRegistry` | No — each container has its own | Maps `provider_id → CacheItem`; stores resolved singleton instances and the memoized `WiringPlan` for this scope level. |
 | `ContextRegistry` | No — each container has its own | Maps `type → runtime object`; populated via `context=` at construction or `container.set_context()` after the fact. |
 
 Because `ProvidersRegistry` and `OverridesRegistry` are shared, registering a group or setting an

--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -59,10 +59,10 @@ via `kwargs={...}`, give the parameter a default, or set `skip_creator_parsing=T
 
 ### Recursive resolution
 
-When a `Factory` is resolved, `_compile_kwargs` iterates the parsed parameter map. For each parameter it looks up
-a matching provider by type in the registry and recurses into `container.resolve_provider(dep_provider)`.
-Resolution errors are annotated with a breadcrumb describing the current factory, so the full chain appears in the
-exception.
+When a `Factory` is resolved, `WiringPlan.build` (in `modern_di/wiring.py`) iterates the parsed parameter map and
+partitions it into the plan; `Factory` then recurses into `container.resolve_provider(dep_provider)` for each matched
+provider. The plan is built once and memoized on the `CacheItem`. Resolution errors are annotated with a breadcrumb
+describing the current factory, so the full chain appears in the exception.
 
 ### Static kwargs
 
@@ -114,9 +114,9 @@ providers.ContextProvider(scope=Scope.REQUEST, context_type=HttpRequest)
 ```
 
 At resolution time it looks the value up in the container's `context_registry` for the matching scope. If no
-value was supplied (the key is absent), `resolve` returns `None`. `Factory._compile_kwargs` handles the
-absent-context case explicitly: if the dependent parameter has a default or is nullable it is silently satisfied;
-otherwise an `ArgumentResolutionError` is raised.
+value was supplied (the key is absent), `resolve` returns `None`. `Factory._resolve_context_value` handles the
+absent-context case live via the shared `absent_disposition` helper: if the dependent parameter has a default or is
+nullable it is silently satisfied; otherwise an `ArgumentResolutionError` is raised.
 
 `ContextProvider` also accepts an optional `bound_type` that overrides the inferred bound type.
 

--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -56,50 +56,59 @@ if self.cache_settings and cache_item.cache is not types.UNSET:
 If `cache_settings` is configured **and** the cache slot already holds a value, the cached instance is returned
 immediately. (A `Factory` with no `cache_settings` always re-runs the creator.)
 
-## Step 4 — kwargs compilation
+## Step 4 — Wiring plan
 
-If no cached instance is returned, `Factory` compiles the keyword arguments needed to call the creator. This is done
-once per container per provider via `_ensure_kwargs_cached`, which stores the split result on `CacheItem` so subsequent
-calls (within the same container lifetime) skip recompilation.
+If no cached instance is returned, `Factory` builds the **wiring plan**: the partition of the creator's parameters by
+how each is satisfied. This is done once per container per provider via `_ensure_plan`, which stores a single
+`WiringPlan` on the `CacheItem` so subsequent calls (within the same container lifetime) reuse it.
 
-Compilation is **type matching only** — it decides *which* provider (if any) backs each parameter, not what value that
-provider currently holds. It therefore never goes stale and is never invalidated. `_compile_kwargs` iterates over
-`_parsed_kwargs` — the `SignatureItem` map produced at provider-declaration time by `types_parser.parse_creator` — and
-sorts each parameter into one of three buckets stored on the `CacheItem`:
+`WiringPlan.build` (in `modern_di/wiring.py`) is a **pure function** of `(parsed_kwargs, kwargs, providers_registry,
+owner)` — it reads no cache, scope, or live context, so it runs outside the container lock and never goes stale (the
+providers registry is fixed after construction). It is **type matching only**: it decides *which* provider (if any)
+backs each parameter, not what value that provider currently holds. It iterates `_parsed_kwargs` — the `SignatureItem`
+map produced at provider-declaration time by `types_parser.parse_creator` — and sorts each parameter:
 
 1. **Static kwarg shadows** — if the parameter was supplied via the provider's declaration-time `kwargs`, it is taken
-   from there. Provider-valued static kwargs go to `provider_kwargs`; plain values go to `static_kwargs`. These bypass
-   type-based wiring.
+   from there. Provider-valued static kwargs go to the plan's `provider_kwargs`; plain values go to `static_kwargs`.
+   These bypass type-based wiring and are *not* recorded in the plan's `dependencies` view, so `validate()` does not
+   traverse them.
 
-2. **Provider lookup** — otherwise `_find_dep_provider` searches `providers_registry` for a provider matching the
+2. **Provider lookup** — otherwise `find_dep_provider` searches `providers_registry` for a provider matching the
    parameter's resolved type (`arg_type`) or, for union types, any of the union members (`args`); self-references are
    excluded. A matching `ContextProvider` goes to `context_kwargs` (resolved live, see Step 5); any other provider goes
-   to `provider_kwargs`.
+   to `provider_kwargs`. Type-matched providers are also recorded in the plan's `dependencies` view, which `validate()`
+   reads.
 
    > **Union vs. single parameterized generics.** A bare parameterized generic (e.g. `list[str]`) is *rejected at
    > declaration* — it cannot be resolved by type. Inside a union, however, each member degrades to its origin for
    > matching, so `int | list[str]` matches a provider registered for plain `list`. The element type is not enforced
    > (Python ignores it at runtime); this asymmetry is intentional, not a wiring guarantee.
 
-3. **No provider found** — this is a static graph fact, decided once here:
+3. **No provider found** — a static graph fact, decided once via the shared `absent_disposition(item)` helper (the
+   single home of the absent-value table):
    - If the parameter has a default, it is omitted (the creator's own default applies).
-   - If `SignatureItem.is_nullable` is `True` (the annotation included `None`, e.g. `X | None` or `Optional[X]`), it is
-     set to `None` in `static_kwargs`.
-   - Otherwise, `ArgumentResolutionError` is raised.
+   - Else if `SignatureItem.is_nullable` is `True` (the annotation included `None`, e.g. `X | None` or `Optional[X]`),
+     `None` is placed in `static_kwargs`.
+   - Otherwise the parameter is recorded in the plan's `unwireable` list as a `(name, SignatureItem)` record — **not** a
+     pre-built exception (see Step 5).
 
-The three buckets — `provider_kwargs` (regular providers, resolved recursively), `static_kwargs` (plain values), and
-`context_kwargs` (`ContextProvider` + its `SignatureItem`, resolved live) — are memoized so subsequent resolves within
-the same container lifetime skip recompilation.
+The plan's buckets — `provider_kwargs` (regular providers, resolved recursively), `static_kwargs` (plain values), and
+`context_kwargs` (`ContextProvider` + its `SignatureItem`, resolved live) — plus the `dependencies` view and the
+`unwireable` records are memoized on the `CacheItem`. The same `WiringPlan.build` backs `validate()`: `get_dependencies`
+reads `dependencies`, `iter_validation_issues` builds a fresh error per `unwireable` record.
 
 ## Step 5 — Recursive resolution
 
-With compiled kwargs in hand:
+With the wiring plan in hand, `Factory` first surfaces any unwireable parameter: if `plan.unwireable` is non-empty it
+raises a **freshly built** `ArgumentResolutionError` from the first record before calling the creator. The error is
+built fresh on every raise (never memoized) because `ResolutionError.prepend_step` *mutates* the exception as it
+propagates up the chain — a stored instance would accumulate and leak breadcrumbs across repeated or nested resolves.
 
 ```python
-resolved_kwargs = dict(static_kwargs)
-for k, v in provider_kwargs.items():
+resolved_kwargs = dict(plan.static_kwargs)
+for k, v in plan.provider_kwargs.items():
     resolved_kwargs[k] = container.resolve_provider(v)
-for k, (context_provider, item) in context_kwargs.items():
+for k, (context_provider, item) in plan.context_kwargs.items():
     value = self._resolve_context_value(container, k, context_provider, item)
     if value is not types.UNSET:
         resolved_kwargs[k] = value
@@ -110,8 +119,8 @@ sequence from Step 1 — override check, then `provider.resolve(container)`.
 
 Context-backed parameters are resolved **live on every resolve**, so a `set_context` after a factory has already
 resolved is always picked up (across scopes, for non-cached factories). `_resolve_context_value` mirrors
-`resolve_provider`'s override check, then reads the live context value; when the value is absent it applies the same
-fallback as Step 4's no-provider case — omit (default applies), `None` (nullable), or raise `ArgumentResolutionError`.
+`resolve_provider`'s override check, then reads the live context value; when the value is absent it applies the shared
+`absent_disposition` helper — omit (default applies), `None` (nullable), or raise `ArgumentResolutionError`.
 
 The recursion bottoms out at providers with
 no dependencies or at already-cached instances.
@@ -130,9 +139,10 @@ the instance is stored and returned.
 
 `types_parser.SignatureItem` carries an `is_nullable: bool` field. It is set to `True` when the parameter annotation
 is a union that includes `NoneType` — that is, `X | None`, `Optional[X]`, or any union spelled with `typing.Union`
-that contains `None`. When `_compile_kwargs` cannot find a provider for the parameter (or finds a `ContextProvider`
-with no value set) and the parameter has no default, `is_nullable=True` causes `None` to be injected rather than
-raising an error.
+that contains `None`. When no provider is found for the parameter (or a `ContextProvider` has no value set) and the
+parameter has no default, the shared `absent_disposition` helper returns `None` for `is_nullable=True` — at plan-build
+time (`WiringPlan.build`) for a missing provider, or live at resolve time (`_resolve_context_value`) for an unset
+context value — rather than raising an error.
 
 ## Thread safety
 

--- a/benchmarks/test_bench_kwargs_split.py
+++ b/benchmarks/test_bench_kwargs_split.py
@@ -53,9 +53,13 @@ class BenchGroup(Group):
 
 def _baseline_resolve_inner(cache_item: CacheItem, container: Container) -> dict[str, typing.Any]:
     """Simulate the old resolved_kwargs dict-comp that ran on every resolve()."""
+    plan = cache_item.wiring_plan
+    if plan is None:
+        return {}
+    unified = {**plan.provider_kwargs, **plan.static_kwargs}
     return {
-        k: container.resolve_provider(v) if isinstance(v, AbstractProvider) else v
-        for k, v in {**cache_item.provider_kwargs, **cache_item.static_kwargs}.items()
+        k: container.resolve_provider(v) if isinstance(v, AbstractProvider) else v  # type: ignore[arg-type]
+        for k, v in unified.items()
     }
 
 

--- a/benchmarks/test_bench_kwargs_split.py
+++ b/benchmarks/test_bench_kwargs_split.py
@@ -58,7 +58,7 @@ def _baseline_resolve_inner(cache_item: CacheItem, container: Container) -> dict
         return {}
     unified = {**plan.provider_kwargs, **plan.static_kwargs}
     return {
-        k: container.resolve_provider(v) if isinstance(v, AbstractProvider) else v  # type: ignore[arg-type]
+        k: container.resolve_provider(v) if isinstance(v, AbstractProvider) else v
         for k, v in unified.items()
     }
 

--- a/benchmarks/test_bench_kwargs_split.py
+++ b/benchmarks/test_bench_kwargs_split.py
@@ -57,10 +57,7 @@ def _baseline_resolve_inner(cache_item: CacheItem, container: Container) -> dict
     if plan is None:
         return {}
     unified = {**plan.provider_kwargs, **plan.static_kwargs}
-    return {
-        k: container.resolve_provider(v) if isinstance(v, AbstractProvider) else v
-        for k, v in unified.items()
-    }
+    return {k: container.resolve_provider(v) if isinstance(v, AbstractProvider) else v for k, v in unified.items()}
 
 
 # ---------------------------------------------------------------------------

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -16,6 +16,7 @@ from modern_di.wiring import WiringPlan, _Absent, absent_disposition
 if typing.TYPE_CHECKING:
     from modern_di import Container
     from modern_di.registries.cache_registry import CacheItem
+    from modern_di.registries.providers_registry import ProvidersRegistry
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -115,8 +116,14 @@ class Factory(AbstractProvider[types.T_co]):
         return exceptions.ResolutionStep(scope=self.scope, name=self.display_name)
 
     def _argument_resolution_error(
-        self, arg_name: str, item: SignatureItem, suggestions: list[str]
+        self, *, arg_name: str, item: SignatureItem, registry: "ProvidersRegistry | None" = None
     ) -> exceptions.ArgumentResolutionError:
+        # The single error-construction site: build the message and (when a registry is given and the
+        # argument has a resolvable type) the closest-match suggestions. The context path passes no
+        # registry, so absent-context errors carry no suggestions — as before.
+        suggestions = (
+            registry.build_suggestions(item.arg_type) if registry is not None and item.arg_type is not None else []
+        )
         return exceptions.ArgumentResolutionError(
             arg_name=arg_name,
             arg_type=item.arg_type,
@@ -160,7 +167,7 @@ class Factory(AbstractProvider[types.T_co]):
             return types.UNSET  # omit kwarg; creator default applies
         if disposition is _Absent.NULL:
             return None
-        raise self._argument_resolution_error(arg_name, item, [])
+        raise self._argument_resolution_error(arg_name=arg_name, item=item)
 
     def get_dependencies(self, container: "Container") -> dict[str, "AbstractProvider[typing.Any]"]:
         """Return parameter-name → dependency-provider mapping using only the providers registry.
@@ -184,10 +191,7 @@ class Factory(AbstractProvider[types.T_co]):
             owner=self,
         )
         for name, item in plan.unwireable:
-            suggestions = (
-                container.providers_registry.build_suggestions(item.arg_type) if item.arg_type is not None else []
-            )
-            yield self._argument_resolution_error(name, item, suggestions)
+            yield self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
 
     def _call_creator(self, resolved_kwargs: dict[str, typing.Any]) -> types.T_co:
         try:
@@ -207,10 +211,7 @@ class Factory(AbstractProvider[types.T_co]):
         plan = self._ensure_plan(container, cache_item)
         if plan.unwireable:
             name, item = plan.unwireable[0]
-            suggestions = (
-                container.providers_registry.build_suggestions(item.arg_type) if item.arg_type is not None else []
-            )
-            raise self._argument_resolution_error(name, item, suggestions)
+            raise self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
         resolved_kwargs = dict(plan.static_kwargs)
         for k, v in plan.provider_kwargs.items():
             resolved_kwargs[k] = container.resolve_provider(v)

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -177,12 +177,17 @@ class Factory(AbstractProvider[types.T_co]):
 
     def iter_validation_issues(self, container: "Container") -> typing.Iterable[Exception]:
         """Yield ArgumentResolutionError for parameters with no provider, no default, no static kwarg."""
-        return WiringPlan.build(
+        plan = WiringPlan.build(
             parsed_kwargs=self._parsed_kwargs,
             kwargs=self._kwargs,
             registry=container.providers_registry,
             owner=self,
-        ).issues
+        )
+        for name, item in plan.unwireable:
+            suggestions = (
+                container.providers_registry.build_suggestions(item.arg_type) if item.arg_type is not None else []
+            )
+            yield self._argument_resolution_error(name, item, suggestions)
 
     def _call_creator(self, resolved_kwargs: dict[str, typing.Any]) -> types.T_co:
         try:
@@ -200,8 +205,12 @@ class Factory(AbstractProvider[types.T_co]):
 
     def _resolve_kwargs(self, container: "Container", cache_item: "CacheItem") -> dict[str, typing.Any]:
         plan = self._ensure_plan(container, cache_item)
-        if plan.issues:
-            raise plan.issues[0]
+        if plan.unwireable:
+            name, item = plan.unwireable[0]
+            suggestions = (
+                container.providers_registry.build_suggestions(item.arg_type) if item.arg_type is not None else []
+            )
+            raise self._argument_resolution_error(name, item, suggestions)
         resolved_kwargs = dict(plan.static_kwargs)
         for k, v in plan.provider_kwargs.items():
             resolved_kwargs[k] = container.resolve_provider(v)

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -10,6 +10,7 @@ from modern_di.providers import ContextProvider
 from modern_di.providers.abstract import AbstractProvider
 from modern_di.scope import Scope
 from modern_di.types_parser import SignatureItem, parse_creator
+from modern_di.wiring import WiringPlan, _Absent, absent_disposition
 
 
 if typing.TYPE_CHECKING:
@@ -113,18 +114,6 @@ class Factory(AbstractProvider[types.T_co]):
     def _resolution_step(self) -> exceptions.ResolutionStep:
         return exceptions.ResolutionStep(scope=self.scope, name=self.display_name)
 
-    def _find_dep_provider(self, container: "Container", v: SignatureItem) -> "AbstractProvider[typing.Any] | None":
-        if v.arg_type:
-            provider = container.providers_registry.find_provider(v.arg_type)
-            if provider is self:
-                return None
-            return provider
-        for x in v.args:
-            provider = container.providers_registry.find_provider(x)
-            if provider is not None and provider is not self:
-                return provider
-        return None
-
     def _argument_resolution_error(
         self, arg_name: str, item: SignatureItem, suggestions: list[str]
     ) -> exceptions.ArgumentResolutionError:
@@ -136,60 +125,19 @@ class Factory(AbstractProvider[types.T_co]):
             member_types=item.args,
         )
 
-    def _compile_kwargs(
-        self, container: "Container"
-    ) -> tuple[dict[str, "AbstractProvider[typing.Any]"], dict[str, typing.Any], dict[str, typing.Any]]:
-        """Partition parameters into live providers, static values, and live context lookups.
-
-        ``context_kwargs`` holds parameters backed by a ``ContextProvider``; their value is
-        looked up on every resolve (so a late ``set_context`` is always picked up) and the
-        value-absent decision (default / None / raise) is deferred to resolve time. A
-        parameter with no registered provider is a static graph fact, decided once here.
-        """
-        provider_kwargs: dict[str, AbstractProvider[typing.Any]] = {}
-        static_kwargs: dict[str, typing.Any] = {}
-        context_kwargs: dict[str, typing.Any] = {}
-        for k, v in self._parsed_kwargs.items():
-            if self._kwargs and k in self._kwargs:
-                continue  # supplied as a static kwarg below
-            provider = self._find_dep_provider(container, v)
-            if provider is not None:
-                if isinstance(provider, ContextProvider):
-                    context_kwargs[k] = (provider, v)
-                else:
-                    provider_kwargs[k] = provider
-                continue
-
-            if v.default is not types.UNSET:
-                continue
-            if v.is_nullable:
-                static_kwargs[k] = None
-                continue
-            suggestions = container.providers_registry.build_suggestions(v.arg_type) if v.arg_type is not None else []
-            raise self._argument_resolution_error(k, v, suggestions)
-
-        if self._kwargs:
-            for k, static_value in self._kwargs.items():
-                if isinstance(static_value, AbstractProvider):
-                    provider_kwargs[k] = static_value
-                else:
-                    static_kwargs[k] = static_value
-        return provider_kwargs, static_kwargs, context_kwargs
-
-    def _ensure_kwargs_cached(
-        self, container: "Container", cache_item: "CacheItem"
-    ) -> tuple[dict[str, "AbstractProvider[typing.Any]"], dict[str, typing.Any], dict[str, typing.Any]]:
-        # Compilation runs outside the container lock (the lock guards only singleton creation).
-        # Under the GIL this is safe: the buckets are a deterministic function of the fixed providers
-        # registry, so concurrent compiles produce identical results and at worst recompute once.
+    def _ensure_plan(self, container: "Container", cache_item: "CacheItem") -> WiringPlan:
+        # Plan runs outside the container lock (the lock guards only singleton creation).
+        # Under the GIL this is safe: the plan is a deterministic function of the fixed providers
+        # registry, so concurrent builds produce identical results and at worst recompute once.
         # (Free-threaded/nogil caveat tracked in planning/deferred.md.)
-        if not cache_item.kwargs_compiled:
-            provider_kwargs, static_kwargs, context_kwargs = self._compile_kwargs(container)
-            cache_item.provider_kwargs = provider_kwargs
-            cache_item.static_kwargs = static_kwargs
-            cache_item.context_kwargs = context_kwargs
-            cache_item.kwargs_compiled = True
-        return cache_item.provider_kwargs, cache_item.static_kwargs, cache_item.context_kwargs
+        if cache_item.wiring_plan is None:
+            cache_item.wiring_plan = WiringPlan.build(
+                parsed_kwargs=self._parsed_kwargs,
+                kwargs=self._kwargs,
+                registry=container.providers_registry,
+                owner=self,
+            )
+        return cache_item.wiring_plan
 
     def _resolve_context_value(
         self, container: "Container", arg_name: str, provider: ContextProvider[typing.Any], item: SignatureItem
@@ -207,9 +155,10 @@ class Factory(AbstractProvider[types.T_co]):
         value = provider.fetch_context_value(container)
         if value is not types.UNSET:
             return value
-        if item.default is not types.UNSET:
-            return types.UNSET
-        if item.is_nullable:
+        disposition = absent_disposition(item)
+        if disposition is _Absent.OMIT:
+            return types.UNSET  # omit kwarg; creator default applies
+        if disposition is _Absent.NULL:
             return None
         raise self._argument_resolution_error(arg_name, item, [])
 
@@ -219,35 +168,21 @@ class Factory(AbstractProvider[types.T_co]):
         Pure lookup: no scope check, no cache touch, no context-value lookup. Used by
         Container.validate() to traverse the static graph.
         """
-        result: dict[str, AbstractProvider[typing.Any]] = {}
-        for k, v in self._parsed_kwargs.items():
-            if self._kwargs and k in self._kwargs:
-                continue
-            provider = self._find_dep_provider(container, v)
-            if provider is not None:
-                result[k] = provider
-        return result
+        return WiringPlan.build(
+            parsed_kwargs=self._parsed_kwargs,
+            kwargs=self._kwargs,
+            registry=container.providers_registry,
+            owner=self,
+        ).dependencies
 
     def iter_validation_issues(self, container: "Container") -> typing.Iterable[Exception]:
         """Yield ArgumentResolutionError for parameters with no provider, no default, no static kwarg."""
-        for k, v in self._parsed_kwargs.items():
-            is_kwarg_not_found = not self._kwargs or k not in self._kwargs
-            if not is_kwarg_not_found:
-                continue
-            if self._find_dep_provider(container, v) is not None:
-                continue
-            if v.default is not types.UNSET:
-                continue
-            if v.is_nullable:
-                continue
-            suggestions = container.providers_registry.build_suggestions(v.arg_type) if v.arg_type is not None else []
-            yield exceptions.ArgumentResolutionError(
-                arg_name=k,
-                arg_type=v.arg_type,
-                bound_type=self.bound_type or self._creator,
-                suggestions=suggestions,
-                member_types=v.args,
-            )
+        return WiringPlan.build(
+            parsed_kwargs=self._parsed_kwargs,
+            kwargs=self._kwargs,
+            registry=container.providers_registry,
+            owner=self,
+        ).issues
 
     def _call_creator(self, resolved_kwargs: dict[str, typing.Any]) -> types.T_co:
         try:
@@ -264,11 +199,13 @@ class Factory(AbstractProvider[types.T_co]):
             raise error from exc
 
     def _resolve_kwargs(self, container: "Container", cache_item: "CacheItem") -> dict[str, typing.Any]:
-        provider_kwargs, static_kwargs, context_kwargs = self._ensure_kwargs_cached(container, cache_item)
-        resolved_kwargs = dict(static_kwargs)
-        for k, v in provider_kwargs.items():
+        plan = self._ensure_plan(container, cache_item)
+        if plan.issues:
+            raise plan.issues[0]
+        resolved_kwargs = dict(plan.static_kwargs)
+        for k, v in plan.provider_kwargs.items():
             resolved_kwargs[k] = container.resolve_provider(v)
-        for k, (context_provider, item) in context_kwargs.items():
+        for k, (context_provider, item) in plan.context_kwargs.items():
             value = self._resolve_context_value(container, k, context_provider, item)
             if value is not types.UNSET:
                 resolved_kwargs[k] = value

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -6,15 +6,16 @@ from modern_di import exceptions, types
 from modern_di.providers import CacheSettings, Factory
 
 
+if typing.TYPE_CHECKING:
+    from modern_di.wiring import WiringPlan
+
+
 @dataclasses.dataclass(kw_only=True, slots=True)
 class CacheItem:
     settings: CacheSettings[typing.Any] | None
     cache: typing.Any = types.UNSET
-    kwargs_compiled: bool = False
     finalized: bool = False
-    provider_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
-    static_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
-    context_kwargs: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
+    wiring_plan: "WiringPlan | None" = None
 
     def _clear(self) -> None:
         if self.settings and self.settings.clear_cache:

--- a/modern_di/wiring.py
+++ b/modern_di/wiring.py
@@ -1,0 +1,153 @@
+"""Kwarg-wiring decision for Factory providers.
+
+``WiringPlan`` is the single authoritative place where a creator's parsed
+parameters are partitioned into provider lookups, static values, and context
+lookups.  It is a pure function of its inputs — no cache, no scope, no live
+context — so it is exercisable without a Container.
+
+``absent_disposition`` is the single copy of the absent-value table:
+    default is not UNSET  → OMIT (creator default applies)
+    is_nullable           → NULL (inject None)
+    else                  → UNWIRABLE (required, no provider)
+"""
+
+import dataclasses
+import enum
+import typing
+
+from modern_di import exceptions
+from modern_di.providers import ContextProvider
+from modern_di.providers.abstract import AbstractProvider
+from modern_di.types import UNSET
+from modern_di.types_parser import SignatureItem
+
+
+if typing.TYPE_CHECKING:
+    from modern_di.providers.factory import Factory
+    from modern_di.registries.providers_registry import ProvidersRegistry
+
+
+class _Absent(enum.Enum):
+    OMIT = enum.auto()       # parameter omitted; creator default applies
+    NULL = enum.auto()       # inject None (annotation was nullable)
+    UNWIRABLE = enum.auto()  # required, no provider, no default → error
+
+
+def absent_disposition(item: SignatureItem) -> _Absent:
+    """Single copy of the absent-value table.
+
+    Precedence: default before nullable before unwirable — matches today's
+    ``_compile_kwargs`` order exactly.
+    """
+    if item.default is not UNSET:
+        return _Absent.OMIT
+    if item.is_nullable:
+        return _Absent.NULL
+    return _Absent.UNWIRABLE
+
+
+def find_dep_provider(
+    registry: "ProvidersRegistry",
+    owner: "Factory[typing.Any]",
+    item: SignatureItem,
+) -> "AbstractProvider[typing.Any] | None":
+    """Look up a dependency provider for *item* in *registry*, excluding *owner* itself.
+
+    Mirrors ``Factory._find_dep_provider`` exactly: prefers ``arg_type``,
+    falls back to the first matching type in ``args`` (union members).
+    """
+    if item.arg_type:
+        provider = registry.find_provider(item.arg_type)
+        if provider is owner:
+            return None
+        return provider
+    for x in item.args:
+        provider = registry.find_provider(x)
+        if provider is not None and provider is not owner:
+            return provider
+    return None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class WiringPlan:
+    """Immutable result of partitioning a creator's parameters.
+
+    Attributes:
+        provider_kwargs:  name → provider resolved live each resolve call.
+        static_kwargs:    name → literal value (including nullable-None).
+        context_kwargs:   name → (ContextProvider, SignatureItem) looked up live.
+        dependencies:     type-matched providers only (regular + context),
+                          excluding providers supplied via ``kwargs={...}``.
+                          Used by ``validate()``'s graph traversal.
+        issues:           UNWIRABLE parameters as ``ArgumentResolutionError``
+                          instances; ``build`` never raises.
+
+    """
+
+    provider_kwargs: dict[str, "AbstractProvider[typing.Any]"]
+    static_kwargs: dict[str, typing.Any]
+    context_kwargs: dict[str, "tuple[ContextProvider[typing.Any], SignatureItem]"]
+    dependencies: dict[str, "AbstractProvider[typing.Any]"]
+    issues: "list[exceptions.ArgumentResolutionError]"
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        parsed_kwargs: dict[str, SignatureItem],
+        kwargs: dict[str, typing.Any] | None,
+        registry: "ProvidersRegistry",
+        owner: "Factory[typing.Any]",
+    ) -> "WiringPlan":
+        """Partition *parsed_kwargs* into wiring buckets.
+
+        Pure function of its arguments — no cache, no scope, no live context —
+        runnable outside the container lock (GIL-determinism argument preserved
+        from ``_compile_kwargs``; free-threaded/nogil caveat tracked in
+        planning/deferred.md).
+
+        The plan never raises; unwireable parameters are recorded in ``issues``.
+        """
+        provider_kwargs: dict[str, AbstractProvider[typing.Any]] = {}
+        static_kwargs: dict[str, typing.Any] = {}
+        context_kwargs: dict[str, tuple[ContextProvider[typing.Any], SignatureItem]] = {}
+        dependencies: dict[str, AbstractProvider[typing.Any]] = {}
+        issues: list[exceptions.ArgumentResolutionError] = []
+
+        for name, item in parsed_kwargs.items():
+            if kwargs and name in kwargs:
+                continue  # supplied as a static kwarg below
+
+            provider = find_dep_provider(registry, owner, item)
+            if provider is not None:
+                dependencies[name] = provider  # validate-visible (type-matched only)
+                if isinstance(provider, ContextProvider):
+                    context_kwargs[name] = (provider, item)
+                else:
+                    provider_kwargs[name] = provider
+                continue
+
+            disposition = absent_disposition(item)
+            if disposition is _Absent.OMIT:
+                continue
+            if disposition is _Absent.NULL:
+                static_kwargs[name] = None
+                continue
+            # UNWIRABLE: record the error but do not raise
+            suggestions = registry.build_suggestions(item.arg_type) if item.arg_type else []
+            issues.append(owner._argument_resolution_error(name, item, suggestions))  # noqa: SLF001
+
+        if kwargs:  # static overlay — NOT added to `dependencies`
+            for name, value in kwargs.items():
+                if isinstance(value, AbstractProvider):
+                    provider_kwargs[name] = value
+                else:
+                    static_kwargs[name] = value
+
+        return cls(
+            provider_kwargs=provider_kwargs,
+            static_kwargs=static_kwargs,
+            context_kwargs=context_kwargs,
+            dependencies=dependencies,
+            issues=issues,
+        )

--- a/modern_di/wiring.py
+++ b/modern_di/wiring.py
@@ -15,7 +15,6 @@ import dataclasses
 import enum
 import typing
 
-from modern_di import exceptions
 from modern_di.providers import ContextProvider
 from modern_di.providers.abstract import AbstractProvider
 from modern_di.types import UNSET
@@ -28,8 +27,8 @@ if typing.TYPE_CHECKING:
 
 
 class _Absent(enum.Enum):
-    OMIT = enum.auto()       # parameter omitted; creator default applies
-    NULL = enum.auto()       # inject None (annotation was nullable)
+    OMIT = enum.auto()  # parameter omitted; creator default applies
+    NULL = enum.auto()  # inject None (annotation was nullable)
     UNWIRABLE = enum.auto()  # required, no provider, no default → error
 
 
@@ -56,7 +55,7 @@ def find_dep_provider(
     Mirrors ``Factory._find_dep_provider`` exactly: prefers ``arg_type``,
     falls back to the first matching type in ``args`` (union members).
     """
-    if item.arg_type:
+    if item.arg_type is not None:
         provider = registry.find_provider(item.arg_type)
         if provider is owner:
             return None
@@ -79,8 +78,12 @@ class WiringPlan:
         dependencies:     type-matched providers only (regular + context),
                           excluding providers supplied via ``kwargs={...}``.
                           Used by ``validate()``'s graph traversal.
-        issues:           UNWIRABLE parameters as ``ArgumentResolutionError``
-                          instances; ``build`` never raises.
+        unwireable:       UNWIRABLE parameters as (param-name, SignatureItem)
+                          records; ``build`` never raises. Consumers construct
+                          fresh ``ArgumentResolutionError`` instances at
+                          raise/yield time so that ``prepend_step`` mutations
+                          do not compound across repeated resolves of the same
+                          memoized plan.
 
     """
 
@@ -88,7 +91,7 @@ class WiringPlan:
     static_kwargs: dict[str, typing.Any]
     context_kwargs: dict[str, "tuple[ContextProvider[typing.Any], SignatureItem]"]
     dependencies: dict[str, "AbstractProvider[typing.Any]"]
-    issues: "list[exceptions.ArgumentResolutionError]"
+    unwireable: "list[tuple[str, SignatureItem]]"
 
     @classmethod
     def build(
@@ -106,13 +109,17 @@ class WiringPlan:
         from ``_compile_kwargs``; free-threaded/nogil caveat tracked in
         planning/deferred.md).
 
-        The plan never raises; unwireable parameters are recorded in ``issues``.
+        The plan never raises; unwireable parameters are recorded in
+        ``unwireable`` as raw (name, SignatureItem) records — NOT pre-built
+        exceptions — so that consumers can construct a fresh
+        ``ArgumentResolutionError`` at each raise/yield site without risk of
+        ``prepend_step`` mutations compounding across repeated resolves.
         """
         provider_kwargs: dict[str, AbstractProvider[typing.Any]] = {}
         static_kwargs: dict[str, typing.Any] = {}
         context_kwargs: dict[str, tuple[ContextProvider[typing.Any], SignatureItem]] = {}
         dependencies: dict[str, AbstractProvider[typing.Any]] = {}
-        issues: list[exceptions.ArgumentResolutionError] = []
+        unwireable: list[tuple[str, SignatureItem]] = []
 
         for name, item in parsed_kwargs.items():
             if kwargs and name in kwargs:
@@ -133,9 +140,8 @@ class WiringPlan:
             if disposition is _Absent.NULL:
                 static_kwargs[name] = None
                 continue
-            # UNWIRABLE: record the error but do not raise
-            suggestions = registry.build_suggestions(item.arg_type) if item.arg_type else []
-            issues.append(owner._argument_resolution_error(name, item, suggestions))  # noqa: SLF001
+            # UNWIRABLE: record the (name, item) pair but do not raise
+            unwireable.append((name, item))
 
         if kwargs:  # static overlay — NOT added to `dependencies`
             for name, value in kwargs.items():
@@ -149,5 +155,5 @@ class WiringPlan:
             static_kwargs=static_kwargs,
             context_kwargs=context_kwargs,
             dependencies=dependencies,
-            issues=issues,
+            unwireable=unwireable,
         )

--- a/planning/changes/2026-06-23.01-wiring-plan-extraction/design.md
+++ b/planning/changes/2026-06-23.01-wiring-plan-extraction/design.md
@@ -1,0 +1,339 @@
+---
+status: draft
+date: 2026-06-23
+slug: wiring-plan-extraction
+summary: Extract a WiringPlan deep module from Factory so the kwarg-binding decision lives in one place, testable without a Container.
+supersedes: null
+superseded_by: null
+pr: null
+outcome: null
+---
+
+# Design: Extract the kwarg-wiring decision out of `Factory` into a `WiringPlan`
+
+## Summary
+
+The static decision "how do this creator's parameters bind to providers,
+static values, and context — and which can't be wired at all" is implemented
+**four times** inside `Factory`, with the absent-value table (default → omit,
+nullable → `None`, else → raise) **hand-copied at three sites** that must stay
+in sync. This change concentrates that decision in one deep module,
+`WiringPlan`, built once per `CacheItem` exactly as today's compiled kwargs are.
+`Factory.resolve` and `Container.validate()` both read the plan; the only thing
+that stays split is the *consumer* discipline — resolve raises the first
+unwireable parameter, validate collects them all. Behavior and per-resolve cost
+are identical; the win is locality (one decision, one absent-value table, one
+error-construction site) and testability (`WiringPlan.build(...)` is a pure
+function of its inputs — exercisable with no `Container`, `Group`, or scope
+chain).
+
+## Motivation
+
+From the 2026-06-23 architecture review (top recommendation). Inside
+`modern_di/providers/factory.py`, the "parsed signature → providers, given the
+registry" decision is spread across four traversals of `self._parsed_kwargs`:
+
+- `_compile_kwargs` (`factory.py:139-177`) — partitions parameters into
+  `provider_kwargs` / `static_kwargs` / `context_kwargs` for resolution; **raises
+  eagerly** on the first unwireable required parameter.
+- `_resolve_context_value` (`factory.py:194-214`) — applies the same absent-value
+  table **live** for context-backed parameters; raises on required-absent.
+- `get_dependencies` (`factory.py:216-229`) — re-matches each parameter to a
+  provider for `validate()`'s graph traversal; no fallback, never raises.
+- `iter_validation_issues` (`factory.py:231-250`) — **yields** an
+  `ArgumentResolutionError` for every unwireable required parameter, for
+  `validate()`'s collect-all.
+
+The matching half is already shared (`_find_dep_provider`, `factory.py:116-126`,
+called from three of the four). The **absent-value table is not**: the
+`default → omit / is_nullable → None / else → raise` precedence is written out at
+`factory.py:163-169`, `factory.py:210-214`, and `factory.py:241-244`. Three
+copies of one decision is exactly the locality defect the review flagged; a
+change to the rule (or a new disposition) must be made in three places or it
+drifts.
+
+Testability is the second cost. To check "does this creator wire correctly
+against these providers?" today you must build a `Container` + `Group` (+ child
+container for scoped cases), call `resolve`, and catch — the suite does this at
+98 construction sites. The wiring decision is *already* a pure function of
+`(_parsed_kwargs, _kwargs, providers_registry)` (it never reads cache, scope, or
+live context — see the `_ensure_kwargs_cached` comment at `factory.py:182-185`),
+but it has no seam, so it is reachable only through full resolution.
+
+## Non-goals
+
+- **Changing the caching lifetime.** The plan is built once and stored on the
+  `CacheItem`, on first resolve, under the existing one-time guard — same
+  lifetime, same scope, same per-container memo as today. Hoisting the plan to a
+  per-registry cache (compile once per container *tree*) is a separate, later
+  change; it touches the shared registry's locking and is not needed for the
+  locality/testability win.
+- **Fixing the static-kwarg-provider validation gap.** Today a provider passed
+  via `kwargs={"x": SomeProvider}` *is* resolved at resolve time
+  (`_compile_kwargs` routes it into `provider_kwargs`, `factory.py:171-176`) but
+  is **not** traversed by `validate()` (`get_dependencies` and
+  `iter_validation_issues` skip every `self._kwargs` key). This change preserves
+  that asymmetry exactly (see Design §4); closing the gap is a deliberate,
+  separate behavior change.
+- **Touching the polymorphic provider interface.** `AbstractProvider.
+  get_dependencies` / `iter_validation_issues` stay as they are; `Alias` and the
+  others are untouched. Only `Factory`'s two implementations are rewritten as
+  thin plan-readers.
+- **Free-threaded / nogil.** The existing GIL-determinism argument
+  (`factory.py:182-185`) is preserved verbatim; the no-GIL caveat already tracked
+  in `planning/deferred.md` is unchanged.
+
+## Design
+
+### 1. New module `modern_di/wiring.py`
+
+A top-level support module alongside `types_parser.py` and `scope.py`, holding:
+
+- **`WiringPlan`** — a frozen value object (the buckets + issues + a validate
+  view), built by a pure classmethod.
+- **`absent_disposition(item)`** — the single copy of the absent-value table.
+- **`find_dep_provider(registry, owner, item)`** — the matcher moved out of
+  `Factory` (today's `_find_dep_provider`), self-reference exclusion preserved.
+
+`wiring.py` imports `SignatureItem` from `types_parser`, `AbstractProvider` and
+`ContextProvider` from `modern_di.providers`, and `exceptions`. It imports
+`ContextProvider` exactly as `factory.py` does today (`from modern_di.providers
+import ContextProvider`); this is cycle-safe because `providers/__init__.py`
+binds `ContextProvider` (line 4) before `factory` (line 5), and `wiring` is
+imported *by* `factory`. `Factory` is referenced for typing only (under
+`TYPE_CHECKING`).
+
+```python
+class _Absent(enum.Enum):
+    OMIT = enum.auto()   # parameter omitted; creator default applies
+    NULL = enum.auto()   # inject None (annotation was nullable)
+    UNWIRABLE = enum.auto()  # required, no provider, no default → error
+
+
+def absent_disposition(item: SignatureItem) -> _Absent:
+    # precedence matches today: default before nullable before raise
+    if item.default is not UNSET:
+        return _Absent.OMIT
+    if item.is_nullable:
+        return _Absent.NULL
+    return _Absent.UNWIRABLE
+```
+
+`absent_disposition` is pure on the `SignatureItem` (no registry, no container).
+It is the *only* place the table lives after this change.
+
+### 2. `WiringPlan` — representation (buckets + issues + dependencies view)
+
+The representation is deliberately the three buckets `Factory` already resolves
+from, plus an `issues` list and a `dependencies` view; the resolve hot loop does
+not move.
+
+```python
+@dataclasses.dataclass(frozen=True, slots=True)
+class WiringPlan:
+    provider_kwargs: dict[str, AbstractProvider]   # resolved live each resolve
+    static_kwargs: dict[str, typing.Any]           # literals + nullable-None
+    context_kwargs: dict[str, tuple[ContextProvider, SignatureItem]]
+    dependencies: dict[str, AbstractProvider]      # type-matched only → validate
+    issues: list[ArgumentResolutionError]          # UNWIRABLE params
+
+    @classmethod
+    def build(cls, *, parsed_kwargs, kwargs, registry, owner) -> "WiringPlan":
+        ...
+```
+
+`build` is a pure function of `(parsed_kwargs, kwargs, registry, owner)` — no
+cache, no scope, no live context — so it stays runnable **outside** the container
+lock, exactly as `_compile_kwargs` runs today (preserving the determinism
+argument at `factory.py:182-185`). The algorithm is today's `_compile_kwargs`
+with the raise replaced by an append, and a parallel `dependencies` map recorded
+for validate:
+
+```python
+for name, item in parsed_kwargs.items():
+    if kwargs and name in kwargs:
+        continue                      # supplied as a static kwarg below
+    provider = find_dep_provider(registry, owner, item)
+    if provider is not None:
+        dependencies[name] = provider                 # validate-visible
+        if isinstance(provider, ContextProvider):
+            context_kwargs[name] = (provider, item)
+        else:
+            provider_kwargs[name] = provider
+        continue
+    disposition = absent_disposition(item)
+    if disposition is _Absent.OMIT:
+        continue
+    if disposition is _Absent.NULL:
+        static_kwargs[name] = None
+        continue
+    suggestions = registry.build_suggestions(item.arg_type) if item.arg_type else []
+    issues.append(owner._argument_resolution_error(name, item, suggestions))
+
+if kwargs:                            # static overlay — NOT in `dependencies`
+    for name, value in kwargs.items():
+        if isinstance(value, AbstractProvider):
+            provider_kwargs[name] = value
+        else:
+            static_kwargs[name] = value
+```
+
+The plan **never raises**; it records `issues`. Two consumers, two disciplines
+(Design §3, §4). Error construction stays single-source: `build` calls the
+owner's existing `_argument_resolution_error` (cross-module private access, with
+`# noqa: SLF001` consistent with `alias.py:63`), so the message/suggestion shape
+is defined in exactly one place and shared by the resolve and validate paths.
+
+Note on suggestion cost: today resolve builds suggestions only for the one
+parameter it raises on; `build` constructs the error (with suggestions) for every
+`issue`. This is off the hot path — `issues` is non-empty only when the graph is
+already broken, in which case resolve is about to raise and validate already does
+this work per issue. The happy path does zero suggestion work.
+
+### 3. `Factory.resolve` reads the plan, raises the first issue
+
+`_ensure_kwargs_cached` becomes `_ensure_plan`, returning (and memoizing) a
+single `WiringPlan` on the `CacheItem`:
+
+```python
+def _ensure_plan(self, container, cache_item) -> WiringPlan:
+    if cache_item.wiring_plan is None:
+        cache_item.wiring_plan = WiringPlan.build(
+            parsed_kwargs=self._parsed_kwargs,
+            kwargs=self._kwargs,
+            registry=container.providers_registry,
+            owner=self,
+        )
+    return cache_item.wiring_plan
+```
+
+`_resolve_kwargs` reads `plan.provider_kwargs` / `static_kwargs` /
+`context_kwargs` with its current loop unchanged, except it first surfaces any
+recorded issue so behavior matches today's eager raise:
+
+```python
+plan = self._ensure_plan(container, cache_item)
+if plan.issues:
+    raise plan.issues[0]
+```
+
+Because `build` iterates `_parsed_kwargs` in order and `resolve` raises
+`issues[0]`, the *same* `ArgumentResolutionError` is raised as today's
+first-encountered eager raise. The only difference is that `build` finishes
+partitioning before the raise surfaces — extra work on the error path only.
+
+Context-backed parameters keep their **live** loop in `Factory`
+(`_resolve_context_value` stays a `Factory` method — it needs the live
+container, override registry, and scope), but its absent branch now calls the
+shared helper instead of re-spelling the table:
+
+```python
+value = provider.fetch_context_value(container)
+if value is not UNSET:
+    return value
+disposition = absent_disposition(item)          # shared with build
+if disposition is _Absent.OMIT:
+    return UNSET                                  # omit kwarg
+if disposition is _Absent.NULL:
+    return None
+raise self._argument_resolution_error(arg_name, item, [])
+```
+
+### 4. `Factory.get_dependencies` / `iter_validation_issues` become plan-readers
+
+Both delegate to a freshly built plan (no `CacheItem` exists at validate time —
+validate runs across the registry at construction):
+
+```python
+def get_dependencies(self, container):
+    return WiringPlan.build(..., registry=container.providers_registry, owner=self).dependencies
+
+def iter_validation_issues(self, container):
+    return WiringPlan.build(..., owner=self).issues
+```
+
+`plan.dependencies` is the **type-matched** providers only (regular + context),
+excluding providers supplied via `self._kwargs` — exactly what today's
+`get_dependencies` returns, so `validate()`'s graph traversal and scope-ordering
+checks are unchanged (see Non-goals on the static-kwarg gap). `plan.issues`
+equals today's `iter_validation_issues` output. Validate builds the plan twice
+per `Factory` (once per method); validate is a one-shot construction-time check,
+so the double build is negligible and the polymorphic interface stays exactly as
+wide as it is.
+
+### 5. `CacheItem` stores one plan instead of three buckets + a flag
+
+`CacheItem` (`cache_registry.py:9-17`) drops `kwargs_compiled`,
+`provider_kwargs`, `static_kwargs`, and `context_kwargs`, and gains a single
+`wiring_plan: "WiringPlan | None" = None` field (type imported under
+`TYPE_CHECKING` from `modern_di.wiring`). "Compiled" ⇔ `wiring_plan is not
+None`. This is the same per-`CacheItem` memo lifetime as today — only the stored
+shape changes (4 fields → 1) — and it is the locality win extended to the cache
+item.
+
+## Operations
+
+None — library-internal refactor + docs.
+
+## Out of scope
+
+See Non-goals: per-registry plan hoisting, the static-kwarg-provider validation
+gap, and any provider-interface widening are all explicitly excluded and can be
+filed as follow-ups.
+
+## Testing
+
+The headline payoff is a new **`tests/test_wiring.py`** that exercises
+`WiringPlan.build` and `absent_disposition` directly — no `Container`:
+
+1. **Partitioning:** a creator with one type-matched provider param, one static
+   `kwargs` literal, one `ContextProvider` param, one defaulted-absent param, one
+   nullable-absent param → assert each lands in the right bucket / is omitted /
+   is `None`.
+2. **Issues, no raise:** a creator with a required, unwireable param → `build`
+   returns `plan.issues == [ArgumentResolutionError(...)]` and does **not** raise;
+   assert the error carries the same `arg_name` / `arg_type` / suggestions as
+   today.
+3. **`dependencies` excludes static-supplied providers:** `kwargs={"x":
+   SomeProvider}` → `x` in `plan.provider_kwargs` but **not** in
+   `plan.dependencies` (locks in the preserved validate asymmetry).
+4. **`absent_disposition` precedence:** default-before-nullable-before-unwirable,
+   as a small parametrized table test.
+
+Behavior-preservation is proven by the **existing suite staying green,
+unchanged**: every current resolve / validate / context / override / suggestion
+test must pass as-is (any test that needs editing signals a behavior change and
+is a red flag). Specifically confirm:
+
+- the eager-raise tests in `test_factory.py` still raise the same
+  `ArgumentResolutionError` (now via `plan.issues[0]`);
+- the `validate()` cycle / scope-ordering / collect-all tests in
+  `test_container.py` are untouched;
+- the cross-scope live-`set_context` regression from the
+  `set-context-cross-scope-staleness` bundle still passes (context stays live).
+
+`just test` green, **100% coverage maintained**, `just lint-ci` clean (watch for
+`SLF001` on the cross-module `_argument_resolution_error` call — annotate as
+`alias.py` does). On ship, promote into `architecture/resolution.md` (the wiring
+decision now lives in `WiringPlan`; the absent-value table is single-source) and
+`architecture/providers.md` (Factory delegates partitioning to `WiringPlan`).
+
+## Risk
+
+- **Behavior drift in the resolve/validate output** — *low likelihood / high
+  impact.* The whole change is a relocation; the algorithm is line-for-line
+  today's `_compile_kwargs` / `iter_validation_issues` with raise↔append swapped.
+  Mitigation: the unchanged existing suite at 100% coverage is the guard; the
+  preserved static-kwarg asymmetry (§4) is explicitly tested.
+- **Import cycle from `wiring.py`** — *low.* It mirrors `factory.py`'s existing,
+  working `from modern_di.providers import ContextProvider`, and `__init__`
+  binds `ContextProvider` before `factory`. Mitigation: keep `Factory` /
+  `ProvidersRegistry` as `TYPE_CHECKING`-only imports in `wiring`; smoke-import
+  `modern_di` at the top of the task.
+- **Thread-safety regression** — *low.* `WiringPlan.build` stays pure and runs
+  outside the lock, identical to `_compile_kwargs` today; the lock still guards
+  only singleton creation. Mitigation: preserve the determinism comment verbatim
+  on `_ensure_plan`.
+- **Suggestion work moved earlier** — *negligible.* Only on the error path
+  (`issues` non-empty), where resolve is about to raise and validate already does
+  per-issue suggestion work today.

--- a/planning/changes/2026-06-23.01-wiring-plan-extraction/design.md
+++ b/planning/changes/2026-06-23.01-wiring-plan-extraction/design.md
@@ -122,11 +122,11 @@ def absent_disposition(item: SignatureItem) -> _Absent:
 `absent_disposition` is pure on the `SignatureItem` (no registry, no container).
 It is the *only* place the table lives after this change.
 
-### 2. `WiringPlan` — representation (buckets + issues + dependencies view)
+### 2. `WiringPlan` — representation (buckets + unwireable records + dependencies view)
 
 The representation is deliberately the three buckets `Factory` already resolves
-from, plus an `issues` list and a `dependencies` view; the resolve hot loop does
-not move.
+from, plus an `unwireable` list and a `dependencies` view; the resolve hot loop
+does not move.
 
 ```python
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -135,7 +135,7 @@ class WiringPlan:
     static_kwargs: dict[str, typing.Any]           # literals + nullable-None
     context_kwargs: dict[str, tuple[ContextProvider, SignatureItem]]
     dependencies: dict[str, AbstractProvider]      # type-matched only → validate
-    issues: list[ArgumentResolutionError]          # UNWIRABLE params
+    unwireable: list[tuple[str, SignatureItem]]    # UNWIRABLE params (name, item)
 
     @classmethod
     def build(cls, *, parsed_kwargs, kwargs, registry, owner) -> "WiringPlan":
@@ -167,8 +167,8 @@ for name, item in parsed_kwargs.items():
     if disposition is _Absent.NULL:
         static_kwargs[name] = None
         continue
-    suggestions = registry.build_suggestions(item.arg_type) if item.arg_type else []
-    issues.append(owner._argument_resolution_error(name, item, suggestions))
+    # UNWIRABLE: record the raw (name, item) pair — NOT a pre-built exception
+    unwireable.append((name, item))
 
 if kwargs:                            # static overlay — NOT in `dependencies`
     for name, value in kwargs.items():
@@ -178,17 +178,15 @@ if kwargs:                            # static overlay — NOT in `dependencies`
             static_kwargs[name] = value
 ```
 
-The plan **never raises**; it records `issues`. Two consumers, two disciplines
-(Design §3, §4). Error construction stays single-source: `build` calls the
-owner's existing `_argument_resolution_error` (cross-module private access, with
-`# noqa: SLF001` consistent with `alias.py:63`), so the message/suggestion shape
-is defined in exactly one place and shared by the resolve and validate paths.
-
-Note on suggestion cost: today resolve builds suggestions only for the one
-parameter it raises on; `build` constructs the error (with suggestions) for every
-`issue`. This is off the hot path — `issues` is non-empty only when the graph is
-already broken, in which case resolve is about to raise and validate already does
-this work per issue. The happy path does zero suggestion work.
+The plan **never raises**; it records `unwireable` as raw `(name, SignatureItem)`
+records rather than pre-built `ArgumentResolutionError` instances. This is
+critical: `ResolutionError.prepend_step` mutates the exception in place
+(`self.dependency_path.insert(0, step); self.args = (str(self),)`), so storing a
+pre-built exception in a memoized plan means the breadcrumb grows on every
+repeated resolve. Two consumers, two disciplines (Design §3, §4). Each consumer
+constructs a fresh error at raise/yield time, calling the owner's existing
+`_argument_resolution_error`, so the message/suggestion shape is defined in one
+place and shared by the resolve and validate paths.
 
 ### 3. `Factory.resolve` reads the plan, raises the first issue
 
@@ -209,17 +207,21 @@ def _ensure_plan(self, container, cache_item) -> WiringPlan:
 
 `_resolve_kwargs` reads `plan.provider_kwargs` / `static_kwargs` /
 `context_kwargs` with its current loop unchanged, except it first surfaces any
-recorded issue so behavior matches today's eager raise:
+recorded unwireable param so behavior matches today's eager raise:
 
 ```python
 plan = self._ensure_plan(container, cache_item)
-if plan.issues:
-    raise plan.issues[0]
+if plan.unwireable:
+    name, item = plan.unwireable[0]
+    suggestions = container.providers_registry.build_suggestions(item.arg_type) if item.arg_type is not None else []
+    raise self._argument_resolution_error(name, item, suggestions)
 ```
 
-Because `build` iterates `_parsed_kwargs` in order and `resolve` raises
-`issues[0]`, the *same* `ArgumentResolutionError` is raised as today's
-first-encountered eager raise. The only difference is that `build` finishes
+Because `build` iterates `_parsed_kwargs` in order and `resolve` raises on
+`unwireable[0]`, the same error shape is raised as today's first-encountered
+eager raise. A fresh `ArgumentResolutionError` is constructed each time so that
+`resolve()`'s subsequent `prepend_step` mutation does not compound across repeated
+calls. The only difference vs. the pre-fix code is that `build` finishes
 partitioning before the raise surfaces — extra work on the error path only.
 
 Context-backed parameters keep their **live** loop in `Factory`
@@ -249,17 +251,21 @@ def get_dependencies(self, container):
     return WiringPlan.build(..., registry=container.providers_registry, owner=self).dependencies
 
 def iter_validation_issues(self, container):
-    return WiringPlan.build(..., owner=self).issues
+    plan = WiringPlan.build(..., owner=self)
+    for name, item in plan.unwireable:
+        suggestions = registry.build_suggestions(item.arg_type) if item.arg_type is not None else []
+        yield self._argument_resolution_error(name, item, suggestions)
 ```
 
 `plan.dependencies` is the **type-matched** providers only (regular + context),
 excluding providers supplied via `self._kwargs` — exactly what today's
 `get_dependencies` returns, so `validate()`'s graph traversal and scope-ordering
-checks are unchanged (see Non-goals on the static-kwarg gap). `plan.issues`
-equals today's `iter_validation_issues` output. Validate builds the plan twice
-per `Factory` (once per method); validate is a one-shot construction-time check,
-so the double build is negligible and the polymorphic interface stays exactly as
-wide as it is.
+checks are unchanged (see Non-goals on the static-kwarg gap). Validate builds the
+plan twice per `Factory` (once per method); validate is a one-shot
+construction-time check, so the double build is negligible and the polymorphic
+interface stays exactly as wide as it is. Yielding a fresh error per unwireable
+param (rather than returning `plan.issues`) keeps `iter_validation_issues`
+consistent with the fresh-per-raise discipline.
 
 ### 5. `CacheItem` stores one plan instead of three buckets + a flag
 
@@ -334,6 +340,13 @@ decision now lives in `WiringPlan`; the absent-value table is single-source) and
   outside the lock, identical to `_compile_kwargs` today; the lock still guards
   only singleton creation. Mitigation: preserve the determinism comment verbatim
   on `_ensure_plan`.
-- **Suggestion work moved earlier** — *negligible.* Only on the error path
-  (`issues` non-empty), where resolve is about to raise and validate already does
-  per-issue suggestion work today.
+- **Memoized-exception mutation hazard** — *medium likelihood if storing
+  pre-built exceptions in the plan / high impact.* `ResolutionError.prepend_step`
+  mutates the exception in place; storing an `ArgumentResolutionError` on the
+  memoized `WiringPlan` would cause the breadcrumb to grow on every repeated
+  failing resolve (and to leak parent steps into sibling direct resolves).
+  Mitigation: `unwireable` stores raw `(name, SignatureItem)` records; each
+  consumer constructs a fresh exception at raise/yield time.
+- **Suggestion work per raise** — *negligible.* Each failing resolve now calls
+  `build_suggestions` at raise time rather than once at plan-build time. On the
+  error path (where resolution is already failing), this cost is immaterial.

--- a/planning/changes/2026-06-23.01-wiring-plan-extraction/design.md
+++ b/planning/changes/2026-06-23.01-wiring-plan-extraction/design.md
@@ -1,12 +1,22 @@
 ---
-status: draft
+status: shipped
 date: 2026-06-23
 slug: wiring-plan-extraction
 summary: Extract a WiringPlan deep module from Factory so the kwarg-binding decision lives in one place, testable without a Container.
 supersedes: null
 superseded_by: null
-pr: null
-outcome: null
+pr: 226
+outcome: |
+  Shipped. Factory's kwarg-wiring decision moved to a pure WiringPlan module
+  (modern_di/wiring.py): one matcher, one absent-value table (absent_disposition),
+  one error-construction site, testable with no Container. _compile_kwargs and
+  _find_dep_provider deleted; CacheItem holds one wiring_plan field. Behavior
+  preserved; the static-kwarg-provider validate() asymmetry kept intentionally.
+  The whole-branch review caught a CRITICAL regression — the plan memoized a
+  pre-built ArgumentResolutionError that resolve()'s prepend_step mutated, so
+  breadcrumbs compounded/leaked across repeated and nested failing resolves; fixed
+  by storing unwireable (name, SignatureItem) records and building the error fresh
+  per raise (regression tests added). 225 tests, 100% coverage.
 ---
 
 # Design: Extract the kwarg-wiring decision out of `Factory` into a `WiringPlan`

--- a/planning/changes/2026-06-23.01-wiring-plan-extraction/plan.md
+++ b/planning/changes/2026-06-23.01-wiring-plan-extraction/plan.md
@@ -1,0 +1,215 @@
+---
+status: draft
+date: 2026-06-23
+slug: wiring-plan-extraction
+spec: wiring-plan-extraction
+pr: null
+---
+
+# wiring-plan-extraction — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the kwarg-wiring decision out of `Factory` into a pure
+`WiringPlan` module so the partition, the absent-value table, and the
+error-construction site each exist once — with no change to behavior, coverage,
+or per-resolve cost.
+
+**Spec:** [`design.md`](./design.md)
+
+**Branch:** `refactor/wiring-plan-extraction`
+
+**Commit strategy:** Per-task commits; the suite must be green at task 3 onward.
+
+---
+
+### Task 1: Create the `wiring` module
+
+**Files:**
+- Create: `modern_di/wiring.py`
+
+Introduce `_Absent`, `absent_disposition`, `find_dep_provider`, and
+`WiringPlan.build` as a pure unit — nothing imports it yet.
+
+- [ ] **Step 1: Write `modern_di/wiring.py`**
+
+  Per design §1–§2: `_Absent` enum (`OMIT`/`NULL`/`UNWIRABLE`);
+  `absent_disposition(item)` (default → OMIT, nullable → NULL, else UNWIRABLE);
+  `find_dep_provider(registry, owner, item)` (moved verbatim from
+  `Factory._find_dep_provider`, self-exclusion via `provider is owner`);
+  `WiringPlan` frozen dataclass with `provider_kwargs` / `static_kwargs` /
+  `context_kwargs` / `dependencies` / `issues` and the `build` classmethod.
+  Import `ContextProvider` as `factory.py` does; keep `Factory` and
+  `ProvidersRegistry` under `TYPE_CHECKING`. `build` calls
+  `owner._argument_resolution_error(...)` with `# noqa: SLF001`.
+
+- [ ] **Step 2: Smoke-import to catch cycles**
+
+  ```bash
+  uv run python -c "import modern_di, modern_di.wiring; print('ok')"
+  ```
+  Expect `ok`. If it raises an ImportError cycle, move `Factory`/registry imports
+  under `TYPE_CHECKING` (per design risk note).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add modern_di/wiring.py
+  git commit -m "refactor: add WiringPlan module (unused)
+
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 2: Store one plan on `CacheItem`
+
+**Files:**
+- Modify: `modern_di/registries/cache_registry.py`
+
+Replace the four compiled-kwargs fields with a single `wiring_plan` slot.
+
+- [ ] **Step 1: Edit `CacheItem`**
+
+  Drop `kwargs_compiled`, `provider_kwargs`, `static_kwargs`, `context_kwargs`
+  (`cache_registry.py:13-17`); add `wiring_plan: "WiringPlan | None" = None` with
+  a `TYPE_CHECKING` import of `WiringPlan` from `modern_di.wiring`. Leave
+  `cache`, `finalized`, `settings`, and the `_clear`/`close_*` methods untouched.
+
+- [ ] **Step 2: Confirm it imports**
+
+  ```bash
+  uv run python -c "from modern_di.registries.cache_registry import CacheItem; print('ok')"
+  ```
+  Expect `ok`. (Suite is red until Task 3 — that is expected.)
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add modern_di/registries/cache_registry.py
+  git commit -m "refactor: store a single WiringPlan on CacheItem
+
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 3: Rewire `Factory` onto the plan
+
+**Files:**
+- Modify: `modern_di/providers/factory.py`
+
+`Factory` reads the plan for resolve and validate; the duplicated traversals and
+the moved matcher are deleted.
+
+- [ ] **Step 1: Add `_ensure_plan`, delete `_ensure_kwargs_cached`**
+
+  Build + memoize `cache_item.wiring_plan` via `WiringPlan.build` (design §3).
+
+- [ ] **Step 2: Point `resolve` / `_resolve_kwargs` at the plan**
+
+  Read `plan.provider_kwargs` / `static_kwargs` / `context_kwargs` (loop
+  unchanged); raise `plan.issues[0]` if any before building kwargs, matching the
+  current eager raise.
+
+- [ ] **Step 3: Share the absent table in the context path**
+
+  `_resolve_context_value` keeps its live container/override/scope logic but its
+  absent branch calls `absent_disposition(item)` (design §3) instead of
+  re-spelling default/`None`/raise.
+
+- [ ] **Step 4: Make `get_dependencies` / `iter_validation_issues` plan-readers**
+
+  Both build a transient plan and return `.dependencies` / `.issues`
+  respectively (design §4).
+
+- [ ] **Step 5: Delete the now-dead code**
+
+  Remove `_compile_kwargs`, `_find_dep_provider` (moved to `wiring`), and any
+  helper left unused. Keep `_argument_resolution_error` (now called from
+  `wiring.build` and the context path).
+
+- [ ] **Step 6: Green suite, unchanged**
+
+  ```bash
+  just test
+  ```
+  All existing tests pass **without edits**. If any test needs changing, stop —
+  it signals a behavior change; reconcile against design §3/§4 before proceeding.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add modern_di/providers/factory.py
+  git commit -m "refactor: resolve and validate Factory via WiringPlan
+
+  Collapses _compile_kwargs, get_dependencies, iter_validation_issues, and
+  the context absent-value table into one plan + one shared helper.
+
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 4: Direct tests for the plan
+
+**Files:**
+- Create: `tests/test_wiring.py`
+
+Exercise `WiringPlan.build` and `absent_disposition` with no `Container` (design
+§Testing 1–4).
+
+- [ ] **Step 1: Write the tests**
+
+  Partitioning into the four buckets; `issues` populated without raising;
+  `dependencies` excludes static-supplied providers; `absent_disposition`
+  precedence table. Annotate all test args (per repo convention).
+
+- [ ] **Step 2: Run them**
+
+  ```bash
+  just test tests/test_wiring.py
+  ```
+  All pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add tests/test_wiring.py
+  git commit -m "test: cover WiringPlan.build and absent_disposition directly
+
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 5: Verify coverage, lint, and the full graph
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full suite + 100% coverage**
+
+  ```bash
+  just test
+  ```
+  Green; coverage gate (100% line) holds. If `wiring.py` shows an uncovered
+  branch, add the missing direct test in `test_wiring.py`.
+
+- [ ] **Step 2: Lint clean**
+
+  ```bash
+  just lint-ci
+  ```
+  No `SLF001` escapes beyond the annotated `_argument_resolution_error` call; `ty`
+  clean.
+
+- [ ] **Step 3: Open the PR**
+
+  Branch off `origin/main` is current; push and open a PR titled
+  `refactor: extract WiringPlan from Factory`, linking this bundle. On ship,
+  hand-edit `architecture/resolution.md` + `architecture/providers.md` and set
+  `status: shipped` + `pr:` + `outcome:` in the design front-matter, then run
+  `just index`.

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -608,15 +608,6 @@ def test_repeated_failing_resolve_breadcrumb_does_not_compound() -> None:
     assert first == second == third, f"breadcrumb compounded: {first!r} != {second!r}"
 
 
-class _UnregisteredLeaf:
-    pass
-
-
-class _ParentNeedsLeaf:
-    def __init__(self, leaf: _UnregisteredLeaf) -> None:
-        self.leaf = leaf  # pragma: no cover
-
-
 def test_nested_then_direct_resolve_does_not_leak_parent_breadcrumb() -> None:
     """After a parent's failing resolve, a direct resolve of the leaf must not include the parent's step.
 
@@ -624,17 +615,7 @@ def test_nested_then_direct_resolve_does_not_leak_parent_breadcrumb() -> None:
     ``prepend_step``, so subsequent direct resolves of the leaf incorrectly showed the
     parent in the chain.
     """
-    leaf_factory: providers.Factory[_UnregisteredLeaf] = providers.Factory(creator=_UnregisteredLeaf, scope=Scope.APP)
-    parent_factory: providers.Factory[_ParentNeedsLeaf] = providers.Factory(creator=_ParentNeedsLeaf, scope=Scope.APP)
-    container = Container(scope=Scope.APP)
-    container.providers_registry.register(_UnregisteredLeaf, leaf_factory)
-    container.providers_registry.register(_ParentNeedsLeaf, parent_factory)
 
-    # First resolve the parent — it fails because Leaf has no registered dep; the
-    # parent's step is prepended to the error as it propagates.
-    # (Note: Leaf itself IS registered; it just needs _UnregisteredDep which is not.)
-    # For this test we need a provider that depends on something TRULY unwired.
-    # Let's use a separate container where the leaf's dep is missing.
     class _MissingDep:
         pass
 

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -1,3 +1,4 @@
+import contextlib
 import dataclasses
 import re
 import unittest.mock
@@ -569,3 +570,97 @@ def test_internal_typeerror_from_creator_body_is_not_wrapped() -> None:
         container.resolve(_InternalTypeErrorService)
     assert not isinstance(exc_info.value, exceptions.CreatorCallError)
     assert "len()" in str(exc_info.value)
+
+
+# Regression: memoized plan must not compound breadcrumbs across repeated resolves
+
+
+class _UnregisteredDep:
+    pass
+
+
+class _NeedsUnregistered:
+    def __init__(self, dep: _UnregisteredDep) -> None:
+        self.dep = dep  # pragma: no cover
+
+
+def test_repeated_failing_resolve_breadcrumb_does_not_compound() -> None:
+    """Resolving an unwireable provider twice must produce identical error strings.
+
+    Before the fix, ``prepend_step`` mutated the memoized exception in place so the
+    dependency path grew on every call (e.g. "NeedsUnregistered → NeedsUnregistered →
+    …" on the third resolve).
+    """
+    factory: providers.Factory[_NeedsUnregistered] = providers.Factory(creator=_NeedsUnregistered, scope=Scope.APP)
+    container = Container(scope=Scope.APP)
+    container.providers_registry.register(_NeedsUnregistered, factory)
+
+    def _grab() -> str:
+        try:
+            container.resolve(_NeedsUnregistered)
+        except exceptions.ResolutionError as exc:
+            return str(exc)
+        return ""  # pragma: no cover
+
+    first = _grab()
+    second = _grab()
+    third = _grab()
+    assert first == second == third, f"breadcrumb compounded: {first!r} != {second!r}"
+
+
+class _UnregisteredLeaf:
+    pass
+
+
+class _ParentNeedsLeaf:
+    def __init__(self, leaf: _UnregisteredLeaf) -> None:
+        self.leaf = leaf  # pragma: no cover
+
+
+def test_nested_then_direct_resolve_does_not_leak_parent_breadcrumb() -> None:
+    """After a parent's failing resolve, a direct resolve of the leaf must not include the parent's step.
+
+    Before the fix, the leaf's memoized exception was mutated by the parent's
+    ``prepend_step``, so subsequent direct resolves of the leaf incorrectly showed the
+    parent in the chain.
+    """
+    leaf_factory: providers.Factory[_UnregisteredLeaf] = providers.Factory(creator=_UnregisteredLeaf, scope=Scope.APP)
+    parent_factory: providers.Factory[_ParentNeedsLeaf] = providers.Factory(creator=_ParentNeedsLeaf, scope=Scope.APP)
+    container = Container(scope=Scope.APP)
+    container.providers_registry.register(_UnregisteredLeaf, leaf_factory)
+    container.providers_registry.register(_ParentNeedsLeaf, parent_factory)
+
+    # First resolve the parent — it fails because Leaf has no registered dep; the
+    # parent's step is prepended to the error as it propagates.
+    # (Note: Leaf itself IS registered; it just needs _UnregisteredDep which is not.)
+    # For this test we need a provider that depends on something TRULY unwired.
+    # Let's use a separate container where the leaf's dep is missing.
+    class _MissingDep:
+        pass
+
+    class _Leaf2:
+        def __init__(self, dep: _MissingDep) -> None:
+            self.dep = dep  # pragma: no cover
+
+    class _Parent2:
+        def __init__(self, leaf: _Leaf2) -> None:
+            self.leaf = leaf  # pragma: no cover
+
+    leaf2: providers.Factory[_Leaf2] = providers.Factory(creator=_Leaf2, scope=Scope.APP)
+    parent2: providers.Factory[_Parent2] = providers.Factory(creator=_Parent2, scope=Scope.APP)
+    c2 = Container(scope=Scope.APP)
+    c2.providers_registry.register(_Leaf2, leaf2)
+    c2.providers_registry.register(_Parent2, parent2)
+
+    # Resolve parent — propagates through leaf → parent step prepended
+    with contextlib.suppress(exceptions.ResolutionError):
+        c2.resolve(_Parent2)
+
+    # Now resolve leaf directly — its error must NOT contain Parent2's breadcrumb
+    try:
+        c2.resolve(_Leaf2)
+    except exceptions.ResolutionError as exc:
+        leaf_err = str(exc)
+        assert "Parent2" not in leaf_err, f"Parent2 leaked into leaf error: {leaf_err!r}"
+    else:
+        pytest.fail("Expected ResolutionError when resolving _Leaf2 directly")  # pragma: no cover

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -5,6 +5,7 @@ import warnings
 
 import pytest
 
+import modern_di.wiring as wiring_mod
 from modern_di import Container, Group, Scope, exceptions, providers
 from modern_di.exceptions import ArgumentResolutionError, ScopeNotInitializedError, UnknownFactoryKwargError
 
@@ -431,15 +432,13 @@ def test_compile_kwargs_is_memoized_across_resolves() -> None:
         svc = providers.Factory(scope=Scope.APP, creator=DependentCreator)
 
     container = Container(groups=[_MemoGroup])
-    real_compile = providers.Factory._compile_kwargs  # noqa: SLF001 — spying on the memoization internal
-    with unittest.mock.patch.object(
-        providers.Factory, "_compile_kwargs", autospec=True, side_effect=real_compile
-    ) as compile_spy:
+    real_build = wiring_mod.WiringPlan.build
+    with unittest.mock.patch.object(wiring_mod.WiringPlan, "build", autospec=True, side_effect=real_build) as build_spy:
         container.resolve(DependentCreator)
         container.resolve(DependentCreator)
-    # svc + leaf each compile once on the first resolve; the second reuses the memo (else this is 4).
-    expected_compile_calls = 2
-    assert compile_spy.call_count == expected_compile_calls
+    # svc + leaf each build their plan once on the first resolve; the second reuses the memo (else this is 4).
+    expected_build_calls = 2
+    assert build_spy.call_count == expected_build_calls
 
 
 # Q-1 / G-3 — optional (X | None) params inject None when no provider is registered

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -2,13 +2,13 @@
 
 import pytest
 
-from modern_di import exceptions, providers
+from modern_di import providers
 from modern_di.providers import ContextProvider
 from modern_di.registries.providers_registry import ProvidersRegistry
 from modern_di.scope import Scope
 from modern_di.types import UNSET
 from modern_di.types_parser import SignatureItem
-from modern_di.wiring import WiringPlan, _Absent, absent_disposition
+from modern_di.wiring import WiringPlan, _Absent, absent_disposition, find_dep_provider
 
 
 # ---------------------------------------------------------------------------
@@ -99,8 +99,8 @@ def test_wiring_plan_partitioning() -> None:
     assert "with_default" not in plan.static_kwargs
     assert "with_default" not in plan.context_kwargs
 
-    # no issues on a correctly wired plan
-    assert plan.issues == []
+    # no unwireable params on a correctly wired plan
+    assert plan.unwireable == []
 
 
 def test_wiring_plan_nullable_no_default_goes_to_static_kwargs() -> None:
@@ -117,7 +117,7 @@ def test_wiring_plan_nullable_no_default_goes_to_static_kwargs() -> None:
 
     assert "nullable" in plan.static_kwargs
     assert plan.static_kwargs["nullable"] is None
-    assert plan.issues == []
+    assert plan.unwireable == []
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +130,7 @@ class _UnwirableCreator:
         pass  # pragma: no cover
 
 
-def test_wiring_plan_issues_no_raise() -> None:
+def test_wiring_plan_unwireable_no_raise() -> None:
     # Empty registry — _ServiceA has no provider
     registry = ProvidersRegistry()
     owner = providers.Factory(scope=Scope.APP, creator=_UnwirableCreator)
@@ -143,11 +143,10 @@ def test_wiring_plan_issues_no_raise() -> None:
     )
 
     # build returns normally (no raise)
-    assert len(plan.issues) == 1
-    issue = plan.issues[0]
-    assert isinstance(issue, exceptions.ArgumentResolutionError)
-    assert issue.arg_name == "required_dep"
-    assert issue.arg_type is _ServiceA
+    assert len(plan.unwireable) == 1
+    unwired_name, unwired_item = plan.unwireable[0]
+    assert unwired_name == "required_dep"
+    assert unwired_item.arg_type is _ServiceA
 
     # nothing wired when the only param is unwirable
     assert plan.provider_kwargs == {}
@@ -194,7 +193,7 @@ def test_wiring_plan_dependencies_excludes_static_supplied_providers() -> None:
     assert "y" in plan.dependencies
     assert plan.dependencies["y"] is factory_b
 
-    assert plan.issues == []
+    assert plan.unwireable == []
 
 
 # ---------------------------------------------------------------------------
@@ -229,3 +228,49 @@ def test_absent_disposition_default_wins_over_nullable() -> None:
     # default is not UNSET (it is None), so OMIT regardless of is_nullable
     assert item.default is not UNSET
     assert absent_disposition(item) is _Absent.OMIT
+
+
+# ---------------------------------------------------------------------------
+# Test: find_dep_provider — union-args branch (arg_type is None)
+# ---------------------------------------------------------------------------
+
+
+class _UnionTypeA:
+    pass
+
+
+class _UnionTypeB:
+    pass
+
+
+def test_find_dep_provider_union_args_matches_first_registered() -> None:
+    """When arg_type is None (union member), find_dep_provider falls through to args list.
+
+    A SignatureItem with args=[_UnionTypeA, _UnionTypeB] and no arg_type (the
+    union-member branch) should resolve to the provider registered for the first
+    matching member — and appear in provider_kwargs/dependencies accordingly.
+    """
+    factory_a = providers.Factory(scope=Scope.APP, creator=_UnionTypeA)
+    registry = ProvidersRegistry()
+    registry.add_providers(factory_a)
+
+    owner = providers.Factory(scope=Scope.APP, creator=_UnionTypeA)
+
+    # Manually craft a SignatureItem with args but no arg_type (union member scenario)
+    item = SignatureItem(arg_type=None, args=[_UnionTypeA, _UnionTypeB])
+
+    result = find_dep_provider(registry, owner, item)
+    # factory_a is registered for _UnionTypeA; it is not `owner`, so it must be returned
+    assert result is factory_a
+
+
+def test_find_dep_provider_union_args_skips_owner() -> None:
+    """When the only union member matching a registered provider IS the owner, returns None."""
+    factory_a = providers.Factory(scope=Scope.APP, creator=_UnionTypeA)
+    registry = ProvidersRegistry()
+    registry.add_providers(factory_a)
+
+    # owner IS factory_a — should be skipped
+    item = SignatureItem(arg_type=None, args=[_UnionTypeA])
+    result = find_dep_provider(registry, factory_a, item)
+    assert result is None

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -1,0 +1,231 @@
+"""Direct tests for WiringPlan.build and absent_disposition — no Container required."""
+
+import pytest
+
+from modern_di import exceptions, providers
+from modern_di.providers import ContextProvider
+from modern_di.registries.providers_registry import ProvidersRegistry
+from modern_di.scope import Scope
+from modern_di.types import UNSET
+from modern_di.types_parser import SignatureItem
+from modern_di.wiring import WiringPlan, _Absent, absent_disposition
+
+
+# ---------------------------------------------------------------------------
+# Simple domain types used across tests
+# ---------------------------------------------------------------------------
+
+
+class _ServiceA:
+    pass
+
+
+class _ServiceB:
+    pass
+
+
+class _Request:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Partitioning — five bucket kinds across two creators
+# ---------------------------------------------------------------------------
+
+
+class _MultiKindCreator:
+    """Creator exercising four wiring buckets.
+
+    a) type-matched provider param  → provider_kwargs
+    b) static kwarg literal         → static_kwargs
+    c) ContextProvider param        → context_kwargs
+    d) defaulted param (absent)     → omitted from all buckets
+    """
+
+    def __init__(
+        self,
+        svc_a: _ServiceA,
+        svc_b: _ServiceB,
+        req: _Request,
+        with_default: int = 42,
+    ) -> None:
+        pass  # pragma: no cover
+
+
+class _NullableNoDefaultCreator:
+    """Creator with a nullable param and no default.
+
+    Maps to static_kwargs[k] = None (the NULL disposition).
+    """
+
+    def __init__(self, nullable: str | None) -> None:
+        pass  # pragma: no cover
+
+
+def test_wiring_plan_partitioning() -> None:
+    factory_a = providers.Factory(scope=Scope.APP, creator=_ServiceA)
+    factory_b = providers.Factory(scope=Scope.APP, creator=_ServiceB)
+    ctx_req = ContextProvider(scope=Scope.APP, context_type=_Request)
+
+    registry = ProvidersRegistry()
+    registry.add_providers(factory_a, factory_b, ctx_req)
+
+    owner = providers.Factory(
+        scope=Scope.APP,
+        creator=_MultiKindCreator,
+        kwargs={"svc_b": "static-literal"},  # supply svc_b as a static value
+    )
+
+    plan = WiringPlan.build(
+        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
+        kwargs=owner._kwargs,  # noqa: SLF001
+        registry=registry,
+        owner=owner,
+    )
+
+    # a) type-matched provider → provider_kwargs
+    assert "svc_a" in plan.provider_kwargs
+    assert plan.provider_kwargs["svc_a"] is factory_a
+
+    # b) static kwarg literal → static_kwargs
+    assert plan.static_kwargs.get("svc_b") == "static-literal"
+
+    # c) ContextProvider param → context_kwargs
+    assert "req" in plan.context_kwargs
+    assert plan.context_kwargs["req"][0] is ctx_req
+
+    # d) defaulted param → omitted from all three buckets
+    assert "with_default" not in plan.provider_kwargs
+    assert "with_default" not in plan.static_kwargs
+    assert "with_default" not in plan.context_kwargs
+
+    # no issues on a correctly wired plan
+    assert plan.issues == []
+
+
+def test_wiring_plan_nullable_no_default_goes_to_static_kwargs() -> None:
+    # e) nullable param, no default, no registered provider → static_kwargs[k] is None
+    registry = ProvidersRegistry()
+    owner = providers.Factory(scope=Scope.APP, creator=_NullableNoDefaultCreator)
+
+    plan = WiringPlan.build(
+        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
+        kwargs=None,
+        registry=registry,
+        owner=owner,
+    )
+
+    assert "nullable" in plan.static_kwargs
+    assert plan.static_kwargs["nullable"] is None
+    assert plan.issues == []
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Issues populated without raising
+# ---------------------------------------------------------------------------
+
+
+class _UnwirableCreator:
+    def __init__(self, required_dep: _ServiceA) -> None:
+        pass  # pragma: no cover
+
+
+def test_wiring_plan_issues_no_raise() -> None:
+    # Empty registry — _ServiceA has no provider
+    registry = ProvidersRegistry()
+    owner = providers.Factory(scope=Scope.APP, creator=_UnwirableCreator)
+
+    plan = WiringPlan.build(
+        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
+        kwargs=None,
+        registry=registry,
+        owner=owner,
+    )
+
+    # build returns normally (no raise)
+    assert len(plan.issues) == 1
+    issue = plan.issues[0]
+    assert isinstance(issue, exceptions.ArgumentResolutionError)
+    assert issue.arg_name == "required_dep"
+    assert issue.arg_type is _ServiceA
+
+    # nothing wired when the only param is unwirable
+    assert plan.provider_kwargs == {}
+    assert plan.static_kwargs == {}
+    assert plan.context_kwargs == {}
+
+
+# ---------------------------------------------------------------------------
+# Test 3: dependencies excludes static-supplied providers
+# ---------------------------------------------------------------------------
+
+
+class _MixedOwner:
+    def __init__(self, x: _ServiceA, y: _ServiceB) -> None:
+        pass  # pragma: no cover
+
+
+def test_wiring_plan_dependencies_excludes_static_supplied_providers() -> None:
+    factory_a = providers.Factory(scope=Scope.APP, creator=_ServiceA)
+    factory_b = providers.Factory(scope=Scope.APP, creator=_ServiceB)
+
+    registry = ProvidersRegistry()
+    registry.add_providers(factory_a, factory_b)
+
+    # Supply `x` via kwargs as a provider reference (static overlay, not type-matched)
+    owner = providers.Factory(
+        scope=Scope.APP,
+        creator=_MixedOwner,
+        kwargs={"x": factory_a},
+    )
+
+    plan = WiringPlan.build(
+        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
+        kwargs=owner._kwargs,  # noqa: SLF001
+        registry=registry,
+        owner=owner,
+    )
+
+    # `x` is in provider_kwargs (resolved live), but NOT in dependencies
+    assert "x" in plan.provider_kwargs
+    assert "x" not in plan.dependencies
+
+    # `y` is type-matched → IS in dependencies
+    assert "y" in plan.dependencies
+    assert plan.dependencies["y"] is factory_b
+
+    assert plan.issues == []
+
+
+# ---------------------------------------------------------------------------
+# Test 4: absent_disposition precedence — parametrized table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("item", "expected"),
+    [
+        # default present (even if also nullable) → OMIT (default wins)
+        (SignatureItem(default=0, is_nullable=True), _Absent.OMIT),
+        (SignatureItem(default="x"), _Absent.OMIT),
+        # no default, nullable → NULL
+        (SignatureItem(is_nullable=True), _Absent.NULL),
+        # no default, not nullable → UNWIRABLE
+        (SignatureItem(arg_type=int), _Absent.UNWIRABLE),
+        (SignatureItem(), _Absent.UNWIRABLE),
+    ],
+)
+def test_absent_disposition_precedence(item: SignatureItem, expected: _Absent) -> None:
+    assert absent_disposition(item) is expected
+
+
+# ---------------------------------------------------------------------------
+# Test: default-present overrides nullable (extra precision for the OMIT branch)
+# ---------------------------------------------------------------------------
+
+
+def test_absent_disposition_default_wins_over_nullable() -> None:
+    item = SignatureItem(default=None, is_nullable=True)
+    # default is not UNSET (it is None), so OMIT regardless of is_nullable
+    assert item.default is not UNSET
+    assert absent_disposition(item) is _Absent.OMIT


### PR DESCRIPTION
## Summary

Pure refactor extracting `Factory`'s kwarg-wiring decision into a new `WiringPlan` deep module. The "how do this creator's parameters bind to providers / static values / context — and which can't be wired" decision was implemented **four times** inside `Factory`, with the absent-value table (default → omit, nullable → `None`, else → raise) **hand-copied at three sites**. It now lives in one pure module, testable with no `Container`.

Design + plan: [`planning/changes/2026-06-23.01-wiring-plan-extraction/`](../tree/refactor/wiring-plan-extraction/planning/changes/2026-06-23.01-wiring-plan-extraction).

## What changed

- **New `modern_di/wiring.py`** — `WiringPlan.build(*, parsed_kwargs, kwargs, registry, owner)` (pure, runs outside the container lock), `absent_disposition(item)` (the single copy of the absent-value table), `find_dep_provider(...)`.
- **`CacheItem`** stores one `wiring_plan` field instead of four (`kwargs_compiled` + three kwarg dicts).
- **`Factory`** delegates: `_ensure_plan` memoizes the plan on the `CacheItem`; `resolve`, `get_dependencies`, and `iter_validation_issues` are thin plan-readers; `_resolve_context_value` keeps its live path but calls the shared `absent_disposition`. `_compile_kwargs`/`_find_dep_provider` deleted (`factory.py` nets ~60 fewer lines).

Behavior is identical; the static-kwarg-provider `validate()` asymmetry is deliberately preserved (`plan.dependencies` excludes `kwargs`-supplied providers).

## Testability payoff

New `tests/test_wiring.py` exercises the wiring decision directly — partitioning, issues-without-raise, the `dependencies`-exclusion guarantee, and the `absent_disposition` precedence table — with no `Container`, `Group`, or scope chain.

## Review note — a regression was caught and fixed

The whole-branch review found a **CRITICAL** bug in an intermediate commit: the plan memoized a pre-built `ArgumentResolutionError`, and `resolve()`'s `prepend_step` **mutates** it in place — so on a misconfigured provider, error breadcrumbs *compounded* across repeated resolves and *leaked* across nested ones (reproduced: 3 repeated resolves → `[Need]`, `[Need, Need]`, `[Need, Need, Need]`; base → `[Need]` each time). Fixed by storing unwireable params as records and constructing the exception fresh at each raise, restoring pre-refactor behavior. Two regression tests added (verified to fail pre-fix, pass after).

## Verification

- `just test-ci` — **225 passed, 100% line coverage** (the project gate).
- `just lint-ci` — `ruff format`, `ruff check`, `ty` clean on `modern_di/`, `tests/`, `benchmarks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
