### PR TITLE
refactor: extract the suggester fuzzy-match module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ class MyGroup(Group):
 - `modern_di/providers/context_provider.py` — ContextProvider for runtime-injected values
 - `modern_di/providers/container_provider.py` — auto-registered provider that resolves to the Container itself
 - `modern_di/types_parser.py` — Signature introspection engine (parses type hints for DI wiring)
+- `modern_di/suggester.py` — `close_matches`, the shared difflib fuzzy-match used by registry type suggestions and factory kwarg "did you mean"
 - `modern_di/scope.py` — Scope enum
 - `modern_di/group.py` — Group base class for provider namespaces
 - `modern_di/exceptions.py` — exception class hierarchy (`ModernDIError` → `ContainerError`/`ResolutionError`/`RegistrationError` subclasses); each error message is an inline f-string in the class that raises it

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -1,11 +1,10 @@
 import dataclasses
-import difflib
 import enum
 import inspect
 import typing
 import warnings
 
-from modern_di import exceptions, types
+from modern_di import exceptions, suggester, types
 from modern_di.providers import ContextProvider
 from modern_di.providers.abstract import AbstractProvider
 from modern_di.scope import Scope
@@ -93,7 +92,7 @@ class Factory(AbstractProvider[types.T_co]):
             return
         suggestions: dict[str, str] = {}
         for bad in unknown:
-            matches = difflib.get_close_matches(bad, known, n=1)
+            matches = suggester.close_matches(bad, known, n=1)
             if matches:
                 suggestions[bad] = matches[0]
         raise exceptions.UnknownFactoryKwargError(

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -1,14 +1,12 @@
-import difflib
 import inspect
 import threading
 import typing
 
-from modern_di import exceptions, types
+from modern_di import exceptions, suggester, types
 from modern_di.providers.abstract import AbstractProvider
 
 
 _MAX_SUGGESTIONS = 3
-_SIMILARITY_CUTOFF = 0.6
 
 
 def _hierarchy_hint(requested_type: type, provider: AbstractProvider[typing.Any]) -> str | None:
@@ -88,8 +86,6 @@ class ProvidersRegistry:
         remaining = _MAX_SUGGESTIONS - len(hierarchy_hints)
         typo_hints = [
             f"  - {name} (similar name, scope={name_to_provider[name].scope.name})"
-            for name in difflib.get_close_matches(
-                requested_name, name_to_provider.keys(), n=remaining, cutoff=_SIMILARITY_CUTOFF
-            )
+            for name in suggester.close_matches(requested_name, name_to_provider.keys(), n=remaining)
         ]
         return hierarchy_hints + typo_hints

--- a/modern_di/suggester.py
+++ b/modern_di/suggester.py
@@ -1,0 +1,12 @@
+import difflib
+import typing
+
+
+def close_matches(target: str, candidates: typing.Iterable[str], *, n: int, cutoff: float = 0.6) -> list[str]:
+    """Fuzzy-match ``target`` against ``candidates``; best ``n`` at/above ``cutoff``.
+
+    Thin wrapper over ``difflib.get_close_matches`` so the similarity cutoff and
+    its tuning live in one place, and the matching is unit-testable without
+    raising an error.
+    """
+    return difflib.get_close_matches(target, list(candidates), n=n, cutoff=cutoff)

--- a/planning/changes/2026-06-23.03-suggester/design.md
+++ b/planning/changes/2026-06-23.03-suggester/design.md
@@ -1,12 +1,19 @@
 ---
-status: draft
+status: shipped
 date: 2026-06-23
 slug: suggester
 summary: Extract the shared difflib fuzzy-match primitive into a directly-testable suggester module.
 supersedes: null
 superseded_by: null
-pr: null
-outcome: null
+pr: 228
+outcome: |
+  Shipped. The two difflib.get_close_matches sites (registry type suggestions,
+  factory kwarg "did you mean") now delegate to modern_di/suggester.close_matches;
+  the 0.6 cutoff lives once as its default; difflib is confined to suggester.py.
+  Adds tests/test_suggester.py (7 direct tests) — the fuzzy match is now unit-
+  testable without raising an error. Behavior identical (both sites already used
+  0.6); review confirmed the list(candidates) materialization is behavior-neutral
+  (difflib's equal-ratio tie-break is deterministic). 232 tests, 100% coverage.
 ---
 
 # Design: A `suggester` module for the shared "did you mean" fuzzy match

--- a/planning/changes/2026-06-23.03-suggester/design.md
+++ b/planning/changes/2026-06-23.03-suggester/design.md
@@ -1,0 +1,122 @@
+---
+status: draft
+date: 2026-06-23
+slug: suggester
+summary: Extract the shared difflib fuzzy-match primitive into a directly-testable suggester module.
+supersedes: null
+superseded_by: null
+pr: null
+outcome: null
+---
+
+# Design: A `suggester` module for the shared "did you mean" fuzzy match
+
+## Summary
+
+`difflib.get_close_matches` is called in two places — `ProvidersRegistry.
+build_suggestions` (fuzzy type-name suggestions) and `Factory._validate_kwargs_
+against_signature` (unknown-kwarg "did you mean"). Both are reachable only by
+triggering an error, so neither is unit-tested directly, and the `0.6` cutoff is
+aligned across them only by coincidence. This change extracts the one shared
+primitive into a new top-level `modern_di/suggester.py` —
+`close_matches(target, candidates, *, n, cutoff=0.6)` — that both sites delegate
+to. Pure refactor: behavior is identical (both already used cutoff `0.6`); the
+win is a directly-testable seam and a single home for the cutoff policy.
+
+## Motivation
+
+From the 2026-06-23 architecture review (candidate 3). The fuzzy-match logic is
+duplicated at `registries/providers_registry.py:91` (`n=remaining,
+cutoff=_SIMILARITY_CUTOFF` where `_SIMILARITY_CUTOFF = 0.6`) and
+`providers/factory.py:96` (`n=1`, no cutoff → `difflib`'s default, which is also
+`0.6`). The two thresholds are equal today by accident, not design: changing
+`_SIMILARITY_CUTOFF` would not move factory's. And the matching is exercised only
+through raised `ProviderNotRegisteredError` / `ArgumentResolutionError` /
+`UnknownFactoryKwargError` messages — there is no way to unit-test "does this
+target fuzzy-match these candidates?" in isolation.
+
+The **deletion test**: a `suggester` concentrates the one genuinely-shared thing
+(the `difflib` wrapper + the cutoff policy). The divergent halves — `providers_
+registry`'s scope-annotated formatting and hierarchy hints, factory's
+`{bad: match}` map — stay at their sites, where candidate 2 just put them. Two
+real callers justify the seam.
+
+## Non-goals
+
+- **Moving formatting or `_hierarchy_hint`.** The two sites format differently,
+  and `_hierarchy_hint` needs `bound_type`/subclass knowledge — both stay put.
+- **Changing `_MAX_SUGGESTIONS`** (the total-suggestions cap in `build_
+  suggestions`) — it is suggestion-assembly policy, not fuzzy matching; it stays.
+- **Touching the suggestion *vocabulary*** (`SUGGESTION_HEADER` in `exceptions.py`,
+  the line-formats in `providers_registry.py`). Candidate 2 deliberately left
+  that split; unifying message text is out of scope here.
+
+## Design
+
+### 1. New `modern_di/suggester.py`
+
+```python
+import difflib
+import typing
+
+
+def close_matches(
+    target: str, candidates: typing.Iterable[str], *, n: int, cutoff: float = 0.6
+) -> list[str]:
+    """Fuzzy-match ``target`` against ``candidates``; best ``n`` at/above ``cutoff``.
+
+    Thin wrapper over ``difflib.get_close_matches`` so the similarity cutoff and
+    its tuning live in one place, and the matching is unit-testable without
+    raising an error.
+    """
+    return difflib.get_close_matches(target, list(candidates), n=n, cutoff=cutoff)
+```
+
+`0.6` lives here, once, as the default. (`difflib.get_close_matches` already
+returns matches sorted best-first and capped at `n`; the wrapper preserves that
+contract exactly. `candidates` is materialized to a `list` so any iterable —
+`dict_keys`, `set` — works, matching today's call sites.)
+
+### 2. `providers_registry.build_suggestions` delegates
+
+Replace the inline `difflib.get_close_matches(requested_name,
+name_to_provider.keys(), n=remaining, cutoff=_SIMILARITY_CUTOFF)` with
+`suggester.close_matches(requested_name, name_to_provider.keys(), n=remaining)`.
+Drop `import difflib` and the `_SIMILARITY_CUTOFF` constant (the `0.6` now lives
+in the suggester default). `_MAX_SUGGESTIONS` and `_hierarchy_hint` are unchanged.
+
+### 3. `factory._validate_kwargs_against_signature` delegates
+
+Replace `difflib.get_close_matches(bad, known, n=1)` with
+`suggester.close_matches(bad, known, n=1)`. Drop `import difflib` from
+`factory.py` (its only use). The unknown-key detection and the
+`UnknownFactoryKwargError` construction are unchanged.
+
+## Testing
+
+The payoff is a new **`tests/test_suggester.py`** exercising `close_matches`
+directly (no `Container`, no raised error):
+
+- exact match returned;
+- a fuzzy hit at/above the cutoff returned; a near-miss below it excluded;
+- the `n` cap honoured; results ordered best-first;
+- empty `candidates` → `[]`;
+- the default cutoff is `0.6` (a borderline candidate that passes at `0.6` and a
+  lower-similarity one that fails, to pin the default).
+
+Existing tests pass **unchanged**: `tests/test_suggestions.py` (the
+type-suggestion message assertions), `tests/registries/test_providers_registry.py`,
+and the factory unknown-kwarg tests all still exercise the same behavior, since
+both sites already used cutoff `0.6`. `just test-ci` green at 100% coverage,
+`just lint-ci` clean.
+
+No `architecture/` capability prose changes (suggestion *behavior* is unchanged);
+add `modern_di/suggester.py` to the `CLAUDE.md` "Key files" list on ship.
+
+## Risk
+
+- **Behavior drift in suggestions** — *low / fully guarded.* Both sites already
+  resolved to cutoff `0.6` and the same `n`; the wrapper preserves `difflib`'s
+  contract. `test_suggestions.py` + the registry/factory tests are the guard.
+- **`list(candidates)` materialization** — *none.* The sites already pass finite
+  collections (`dict_keys`, `set`); `difflib` materializes internally anyway.

--- a/planning/changes/2026-06-23.03-suggester/plan.md
+++ b/planning/changes/2026-06-23.03-suggester/plan.md
@@ -1,0 +1,144 @@
+---
+status: draft
+date: 2026-06-23
+slug: suggester
+spec: suggester
+pr: null
+---
+
+# suggester — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the shared `difflib` fuzzy-match into a directly-testable
+`modern_di/suggester.py`, delegate both call sites to it, and home the `0.6`
+cutoff once — with suggestion behavior unchanged.
+
+**Spec:** [`design.md`](./design.md)
+
+**Branch:** `refactor/suggester`
+
+**Commit strategy:** Per-task commits; suite green after each task.
+
+---
+
+### Task 1: Create `suggester.py` with direct tests (TDD)
+
+**Files:**
+- Create: `modern_di/suggester.py`
+- Create: `tests/test_suggester.py`
+
+Per design §1 and §Testing. The module is pure — write its tests first.
+
+- [ ] **Step 1: Write `tests/test_suggester.py` (RED)**
+
+  Cover: exact match; fuzzy hit ≥ cutoff returned; near-miss < cutoff excluded;
+  `n` cap; best-first ordering; empty candidates → `[]`; default cutoff `0.6`
+  boundary. Annotate all test args + returns. Run → fails (module absent).
+
+- [ ] **Step 2: Write `modern_di/suggester.py` (GREEN)**
+
+  `close_matches(target, candidates, *, n, cutoff=0.6)` per design §1.
+
+- [ ] **Step 3: Verify**
+
+  `just test tests/test_suggester.py` green; `uv run ruff check modern_di/suggester.py tests/test_suggester.py && uv run ty check modern_di` clean (run `ruff format` and keep its result).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add modern_di/suggester.py tests/test_suggester.py
+  git commit -m "feat: add suggester.close_matches with direct tests
+
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 2: Delegate `providers_registry` to the suggester
+
+**Files:**
+- Modify: `modern_di/registries/providers_registry.py`
+
+Per design §2.
+
+- [ ] **Step 1: Delegate + drop the local cutoff**
+
+  Replace the inline `difflib.get_close_matches(...)` in `build_suggestions` with
+  `suggester.close_matches(requested_name, name_to_provider.keys(), n=remaining)`.
+  Remove `import difflib` and the `_SIMILARITY_CUTOFF` constant. Add `from
+  modern_di import suggester` (or `from modern_di.suggester import close_matches`
+  — match neighbouring import style). Keep `_MAX_SUGGESTIONS` and `_hierarchy_hint`.
+
+- [ ] **Step 2: Verify**
+
+  `grep -n "difflib\|_SIMILARITY_CUTOFF" modern_di/registries/providers_registry.py` → empty.
+  `just test tests/test_suggestions.py tests/registries/test_providers_registry.py` green; ruff + ty clean.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add modern_di/registries/providers_registry.py
+  git commit -m "refactor: route registry suggestions through the suggester
+
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 3: Delegate `factory` to the suggester
+
+**Files:**
+- Modify: `modern_di/providers/factory.py`
+
+Per design §3.
+
+- [ ] **Step 1: Delegate + drop the import**
+
+  Replace `difflib.get_close_matches(bad, known, n=1)` in
+  `_validate_kwargs_against_signature` with `suggester.close_matches(bad, known,
+  n=1)`. Remove `import difflib` (its only use). Add the suggester import.
+
+- [ ] **Step 2: Verify**
+
+  `grep -n "difflib" modern_di/providers/factory.py` → empty.
+  `just test tests/providers/test_factory.py` green; ruff + ty clean.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add modern_di/providers/factory.py
+  git commit -m "refactor: route factory kwarg suggestions through the suggester
+
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 4: Full verification + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (add `modern_di/suggester.py` to Key files)
+
+- [ ] **Step 1: No stray difflib**
+
+  `grep -rn "difflib" modern_di` → only `modern_di/suggester.py`.
+
+- [ ] **Step 2: Full gates**
+
+  `just test-ci` — full suite green at **100% coverage**. `just lint-ci` clean
+  (`eof-fixer`, `ruff format --check`, `ruff check --no-fix`, `ty check` — run the
+  whole-tree commands CI runs, not just scoped, to catch any drift).
+
+- [ ] **Step 3: Docs**
+
+  Add `modern_di/suggester.py` to the `CLAUDE.md` "Key files" list. Commit.
+
+- [ ] **Step 4: Open the PR**
+
+  Sync off `origin/main`, push, open a PR titled `refactor: extract the suggester
+  fuzzy-match module`, linking this bundle. On ship set `status: shipped` + `pr:`
+  + `outcome:` in the design front-matter and run `just index`.

--- a/tests/test_suggester.py
+++ b/tests/test_suggester.py
@@ -1,0 +1,44 @@
+from modern_di.suggester import close_matches
+
+
+def test_exact_match_returned() -> None:
+    result = close_matches("hello", ["hello", "world"], n=5)
+    assert result == ["hello"]
+
+
+def test_fuzzy_hit_at_or_above_cutoff_returned() -> None:
+    # 'helo' vs 'hello': ratio=0.8889, well above 0.6
+    result = close_matches("hello", ["helo", "world"], n=5)
+    assert "helo" in result
+
+
+def test_near_miss_below_cutoff_excluded() -> None:
+    # 'world' vs 'hello': ratio=0.2000, well below 0.6
+    result = close_matches("hello", ["world"], n=5)
+    assert result == []
+
+
+def test_n_cap_honoured() -> None:
+    # Three candidates all >= 0.6; n=2 must return at most 2
+    n = 2
+    result = close_matches("hello", ["helo", "jello", "yello"], n=n)
+    assert len(result) == n
+
+
+def test_results_ordered_best_first() -> None:
+    # 'helo' (0.8889) should precede 'jello' (0.8000)
+    result = close_matches("hello", ["jello", "helo"], n=5)
+    assert result == ["helo", "jello"]
+
+
+def test_empty_candidates_returns_empty_list() -> None:
+    result = close_matches("hello", [], n=5)
+    assert result == []
+
+
+def test_default_cutoff_is_0_6() -> None:
+    # 'scope' vs 'rope': ratio=0.6667 (>= 0.6) -> included by default
+    # 'scope' vs 'abc': ratio=0.0 (< 0.6) -> excluded by default
+    result = close_matches("scope", ["rope", "abc"], n=5)
+    assert "rope" in result
+    assert "abc" not in result


### PR DESCRIPTION
## Summary

Extract the shared `difflib` fuzzy-match into a new `modern_di/suggester.py` — `close_matches(target, candidates, *, n, cutoff=0.6)` — and delegate the two call sites to it. Pure refactor: suggestion behavior is unchanged. Candidate #3 from the 2026-06-23 architecture review.

Design + plan: [`planning/changes/2026-06-23.03-suggester/`](../tree/refactor/suggester/planning/changes/2026-06-23.03-suggester).

## Why

`difflib.get_close_matches` was called in two places — `ProvidersRegistry.build_suggestions` (type-name suggestions) and `Factory._validate_kwargs_against_signature` (unknown-kwarg "did you mean"). Both were reachable only by triggering an error, so the matching was **never unit-tested directly**, and the `0.6` cutoff was aligned across them only by coincidence (one explicit constant, one relying on difflib's default).

## What changed

- **New `modern_di/suggester.py`** — a 12-line thin wrapper; the `0.6` cutoff now lives here once, as the default.
- `registries/providers_registry.py` — delegates; drops `import difflib` and `_SIMILARITY_CUTOFF`. `_hierarchy_hint` / `_MAX_SUGGESTIONS` / formatting untouched.
- `providers/factory.py` — delegates; drops `import difflib` (now confined to the suggester).
- **New `tests/test_suggester.py`** — the payoff: 7 direct tests (exact/fuzzy/miss/`n`-cap/ordering/empty/default-cutoff boundary).

## Out of scope (Non-goals)

The hierarchy-hint logic, the `_MAX_SUGGESTIONS` cap, and the suggestion message vocabulary (candidate #2 left it split) all stay where they are. The suggester is the thin matching primitive only.

## Verification

- `just test-ci` — **232 passed** (225 prior + 7 new), 100% coverage.
- `just lint-ci` — whole-tree `ruff format`/`ruff check` + `ty` + `eof` clean; `difflib` now appears only in `suggester.py`.
- Behavior identical (both sites already used cutoff 0.6); the review confirmed difflib's equal-ratio tie-break is deterministic, so the wrapper's `list(candidates)` is behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
