### PR TITLE
docs: mention planning/decisions/ in the CLAUDE.md workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,11 @@ Planning follows a portable two-axis convention (shared with
 - **`planning/changes/<YYYY-MM-DD.NN-slug>/`** are change
   bundles: `design.md` + `plan.md` (full lane), or `change.md` (lightweight).
   Tiny changes (typo, dep bump, CI tweak) skip bundles entirely.
+- **`planning/decisions/<YYYY-MM-DD>-<slug>.md`** — when something is decided
+  *not* to be done (a rejected option with a load-bearing reason), record it
+  here, one file each with a revisit trigger, so it isn't re-litigated; listed
+  by `just index`. (`deferred.md` is the flat backlog of real-but-unscheduled
+  work.)
 - Templates live in [`planning/_templates/`](planning/_templates/).
 - **Shipping a change** hand-edits the affected
   `architecture/<capability>.md` and sets `status: shipped` + `pr:` +


### PR DESCRIPTION
One-line workflow addition: point CLAUDE.md at `planning/decisions/`.

The decisions lane (added in #229) only prevents re-litigation if an agent knows to record a rejected decision in the first place — and CLAUDE.md is the always-loaded instruction file, where `planning/README.md` is not. So a one-line, actionable mention ("when something is decided *not* to be done, record it here") earns its place; `deferred.md` is noted in passing for context.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)