### PR TITLE
ci: align release.yml with the canonical template (setup-uv @v7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,15 @@
 name: Release
 
 # Tag-driven: pushing a semver tag publishes to PyPI and creates the matching
-# GitHub Release. The old `on: release: published` trigger is gone on purpose —
-# this workflow creates a published Release itself, which would re-fire that
-# trigger and double-publish. The tag is the sole entry point. By convention a
-# tag is only ever cut off a green main, so there is no in-workflow CI gate.
+# GitHub Release. Replaces the old `on: release: published` publish.yml — that
+# trigger is removed so the published Release this workflow creates can't re-fire
+# it (double-publish). The tag is the sole entry point; by convention a tag is
+# only cut off a green main, so there is no in-workflow CI gate.
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'               # stable:      2.19.2
-      - '[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+'   # pre-release: 2.0.0a5, 2.0.0b1, 2.0.0rc2
+      - '[0-9]+.[0-9]+.[0-9]+'               # stable:      2.7.2
+      - '[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+'   # pre-release: 2.0.0rc1, 4.0.0a2
 
 # Needed for softprops/action-gh-release to create the GitHub Release.
 permissions:
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v4
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@v7
 
       # PyPI is irreversible, so it runs FIRST: if it fails the job stops and no
       # GitHub Release is created advertising a version that never reached PyPI.
@@ -30,10 +30,10 @@ jobs:
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
-      # Description source: planning/releases/<tag>.md if present (used verbatim,
-      # no auto-changelog appended); otherwise fall back to GitHub's generated
-      # notes. A tag containing a letter (2.0.0rc1) is a PEP 440 pre-release, so
-      # it's flagged and GitHub won't mark it "Latest".
+      # Description source: planning/releases/<tag>.md if present (verbatim, no
+      # auto-changelog appended); otherwise GitHub's generated notes. A tag with
+      # a letter (2.0.0rc1) is a pre-release -> flagged so GitHub won't mark it
+      # "Latest".
       - name: Resolve release metadata
         id: meta
         run: |


### PR DESCRIPTION
Aligns modern-di's `release.yml` with the org-wide canonical template now rolled out to the sibling repos, so all repos share a byte-identical release workflow.

Only behavioural change: `astral-sh/setup-uv@v8.2.0` → `@v7` (highest floating major; no inputs passed, so behaviour is identical). The remainder is comment/example-text alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)