### PR TITLE
chore: sync index.py, clear done deferred item, fix ty 0.0.54 drift

### DIFF
--- a/benchmarks/test_bench_override_fastpath.py
+++ b/benchmarks/test_bench_override_fastpath.py
@@ -62,7 +62,7 @@ def test_no_overrides_optimized(benchmark):
 
 def test_no_overrides_baseline(benchmark):
     original = Container.resolve_provider
-    Container.resolve_provider = _baseline_resolve_provider  # ty: ignore[invalid-assignment]
+    Container.resolve_provider = _baseline_resolve_provider
     try:
         container = Container(scope=Scope.APP, groups=[BenchGroup])
         benchmark(container.resolve_provider, BenchGroup.svc)
@@ -83,7 +83,7 @@ def test_override_other_optimized(benchmark):
 
 def test_override_other_baseline(benchmark):
     original = Container.resolve_provider
-    Container.resolve_provider = _baseline_resolve_provider  # ty: ignore[invalid-assignment]
+    Container.resolve_provider = _baseline_resolve_provider
     try:
         container = Container(scope=Scope.APP, groups=[BenchGroup])
         container.override(BenchGroup.dep, Dep())
@@ -105,7 +105,7 @@ def test_override_self_optimized(benchmark):
 
 def test_override_self_baseline(benchmark):
     original = Container.resolve_provider
-    Container.resolve_provider = _baseline_resolve_provider  # ty: ignore[invalid-assignment]
+    Container.resolve_provider = _baseline_resolve_provider
     try:
         container = Container(scope=Scope.APP, groups=[BenchGroup])
         container.override(BenchGroup.svc, Service(dep=Dep()))

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -19,16 +19,3 @@ replaced the old set-`kwargs_compiled`-after-the-bucket-fields sequence — but 
 options: build and publish `wiring_plan` under the existing container lock, or publish the reference
 behind an explicit barrier/atomic. Until then, document modern-di as GIL-assuming for plan compilation.
 See [2026-06-14 audit A-1](audits/2026-06-14-deep-audit-report.md).
-
-## Roll the planning convention into sibling repos — from 2026-06-25
-
-The convention now lives in the canonical repo
-[`lesnik512/planning-convention`](https://github.com/lesnik512/planning-convention)
-(v1.0.0); `modern-di` is consumer #1 (`planning/.convention-version`). Sibling
-repos (`faststream-outbox`, the modern-di integrations) still carry an older,
-hand-copied form.
-
-**Revisit trigger:** next time a sibling repo's planning convention is touched,
-or in a dedicated sync pass — from each sibling, run the canonical repo's
-`APPLY.md` flow (fresh adopt: it has no `.convention-version` yet), verify with
-`just check-planning`, and open a PR.

--- a/planning/index.py
+++ b/planning/index.py
@@ -58,6 +58,8 @@ def _named(fields: dict[str, str], name: str, pattern: re.Pattern[str]) -> dict[
 def load_bundles() -> list[dict[str, str]]:
     """Read each bundle's summary; derive date/slug from the directory name."""
     bundles: list[dict[str, str]] = []
+    if not CHANGES_DIR.is_dir():
+        return bundles
     for bundle in sorted(CHANGES_DIR.iterdir()):
         if not bundle.is_dir():
             continue
@@ -160,9 +162,10 @@ def _check_decision(path: pathlib.Path, violations: list[str]) -> None:
 def check() -> list[str]:
     """Validate every bundle and decision; return the list of violation strings."""
     violations: list[str] = []
-    for bundle in sorted(CHANGES_DIR.iterdir()):
-        if bundle.is_dir():
-            _check_bundle(bundle, violations)
+    if CHANGES_DIR.is_dir():
+        for bundle in sorted(CHANGES_DIR.iterdir()):
+            if bundle.is_dir():
+                _check_bundle(bundle, violations)
     if DECISIONS_DIR.is_dir():
         for path in sorted(DECISIONS_DIR.glob("*.md")):
             if path.name == "README.md" or path.name.startswith("_"):


### PR DESCRIPTION
Cleanups after the org-wide convention rollout, plus an unrelated CI-unblock:

- **Sync `planning/index.py` to canonical.** modern-di was merged before the canonical `index.py` gained its fresh-adopt guard (tolerate a missing `changes/` dir). Re-vendor so it's byte-identical to `lesnik512/planning-convention`. No behavior change (modern-di has `changes/`).
- **Clear the resolved `deferred.md` entry** — the 'roll the convention into sibling repos' work shipped 2026-06-25.
- **Drop 3 unused `# ty: ignore[invalid-assignment]` directives** in `benchmarks/test_bench_override_fastpath.py`. **ty 0.0.54** (released today) no longer needs them; since `uv.lock` floats, CI's fresh ty install made `main` go red on its own. This unblocks lint.

`just lint-ci` green locally under ty 0.0.54.