### PR TITLE
Fix 2.20.0 notes gap + make curated notes obligatory for stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,25 @@ jobs:
       - uses: extractions/setup-just@v4
       - uses: astral-sh/setup-uv@v7
 
+      # Curated release notes are MANDATORY for a stable tag. This runs BEFORE
+      # `just publish` (which is irreversible) so a missing notes file aborts
+      # the release before anything reaches PyPI — rather than silently shipping
+      # with GitHub's auto-generated notes. Pre-release tags (a letter in the
+      # name, e.g. 2.0.0rc1) are exempt and keep the auto-generated fallback.
+      - name: Require curated release notes (stable tags)
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF_NAME" =~ [a-z] ]]; then
+            echo "Pre-release ${GITHUB_REF_NAME}: curated notes not required."
+            exit 0
+          fi
+          notes="planning/releases/${GITHUB_REF_NAME}.md"
+          if [ ! -f "$notes" ]; then
+            echo "::error::Stable tag ${GITHUB_REF_NAME} has no curated release notes at ${notes}. Write the notes, commit to main, and re-tag." >&2
+            exit 1
+          fi
+          echo "Found curated release notes: ${notes}"
+
       # PyPI is irreversible, so it runs FIRST: if it fails the job stops and no
       # GitHub Release is created advertising a version that never reached PyPI.
       # `just publish` derives the version from $GITHUB_REF_NAME (the tag name).
@@ -31,9 +50,10 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       # Description source: planning/releases/<tag>.md if present (verbatim, no
-      # auto-changelog appended); otherwise GitHub's generated notes. A tag with
-      # a letter (2.0.0rc1) is a pre-release -> flagged so GitHub won't mark it
-      # "Latest".
+      # auto-changelog appended); otherwise GitHub's generated notes. The guard
+      # above makes the file mandatory for stable tags, so the generated-notes
+      # fallback only ever fires for pre-releases. A tag with a letter (2.0.0rc1)
+      # is a pre-release -> flagged so GitHub won't mark it "Latest".
       - name: Resolve release metadata
         id: meta
         run: |

--- a/planning/releases/2.20.0.md
+++ b/planning/releases/2.20.0.md
@@ -1,0 +1,27 @@
+# modern-di 2.20.0 — `Group.get_named_providers()`
+
+Purely additive. One new public method; the contract of existing code is unchanged.
+
+## Feature
+
+- **`Group.get_named_providers() -> dict[str, AbstractProvider]`** — an MRO-walking accessor that maps each declared attribute name to its provider. `Group.get_providers()` is now `list(cls.get_named_providers().values())`, so the traversal and dedup/masking logic lives in one place.
+
+The new method preserves the exact semantics of the old `get_providers()` traversal:
+
+- MRO order (most-derived first)
+- first-seen name wins (diamond inheritance returns each provider once)
+- a non-provider override masks the parent provider of the same name
+
+`get_providers()`'s contract (return type, order, dedup, masking) is unchanged.
+
+## Why
+
+`get_providers()` discarded the attribute name each provider was declared under. Downstream integrations that need names (notably `modern-di-litestar`'s autowiring) reconstructed them with a fragile `id()`-keyed reverse lookup over `group.__dict__`. That lookup only sees the subclass `__dict__` while `get_providers()` walks the full MRO, so autowiring a `Group` that **inherits** a provider raised `KeyError`. Exposing names at the source — where `Group` owns provider declaration and traversal — fixes the bug for every consumer.
+
+## Downstream
+
+Unblocks the `modern-di-litestar` autowiring fix, which consumes `get_named_providers()` and bumps its floor to `modern-di>=2.20.0`. The FastAPI, FastStream, Typer, and `modern-di-pytest` integrations do **not** need to bump.
+
+## Internals
+
+- 100% line coverage maintained across Python 3.10–3.14; `ruff` and `ty` clean.


### PR DESCRIPTION
## What
Two commits closing the same gap and preventing recurrence:

1. **`docs(release): add 2.20.0 notes`** — adds the missing `planning/releases/2.20.0.md`. Covers the one feature in 2.20.0, `Group.get_named_providers()` (#242); the rest of the tag range is planning/CLAUDE.md/CI chores with no API change.
2. **`ci(release): require curated notes for stable tags`** — adds a guard step in `release.yml` **before** `just publish` that fails the release if a stable tag has no `planning/releases/<tag>.md`.

## Why
The `2.20.0` tag was cut without a curated notes file, so `release.yml` hit its fallback (`generate_release_notes: true`) and published the GitHub Release with GitHub's auto-generated PR list — the only release since 2.15.0 missing curated notes.

Because PyPI publish is irreversible and runs first, the guard runs **before** it: a missing notes file now aborts the release before anything ships, instead of silently degrading to auto-generated notes. Pre-release tags (e.g. `2.0.0rc1`) stay exempt and keep the fallback.

## Follow-up (manual, outward-facing)
The live 2.20.0 GitHub Release body still shows the auto-generated notes. After merge, restore it from the curated file:
```
gh release edit 2.20.0 --notes-file planning/releases/2.20.0.md
```
Nothing to do on PyPI — that publish is irreversible and already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)