### PR TITLE
feat: expose ContextProvider.context_type as a public attribute

### DIFF
--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -20,7 +20,7 @@ class ContextProvider(AbstractProvider[types.T_co]):
     ``ArgumentResolutionError``.
     """
 
-    __slots__ = ("_context_type",)
+    __slots__ = ("context_type",)
 
     def __init__(
         self,
@@ -32,10 +32,12 @@ class ContextProvider(AbstractProvider[types.T_co]):
         super().__init__(
             scope=scope, bound_type=context_type if isinstance(bound_type, types.UnsetType) else bound_type
         )
-        self._context_type = context_type
+        # Public, like its sibling ``bound_type`` — the type this provider supplies and
+        # the key its value is set under in ``context``.
+        self.context_type = context_type
 
     def __repr__(self) -> str:
-        return f"ContextProvider(context_type={self._context_type!r}, scope={self.scope!r})"
+        return f"ContextProvider(context_type={self.context_type!r}, scope={self.scope!r})"
 
     def resolve(self, container: "Container") -> types.T_co | None:
         value = self.fetch_context_value(container)
@@ -47,4 +49,4 @@ class ContextProvider(AbstractProvider[types.T_co]):
         container = container.find_container(self.scope)
         if container.closed:
             raise exceptions.ContainerClosedError(container_scope=container.scope)
-        return container.context_registry.find_context(self._context_type)
+        return container.context_registry.find_context(self.context_type)

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -66,6 +66,11 @@ def test_context_provider_repr() -> None:
     assert repr(provider) == "ContextProvider(context_type=<class 'str'>, scope=<Scope.REQUEST: 3>)"
 
 
+def test_context_provider_exposes_context_type() -> None:
+    provider = providers.ContextProvider(context_type=datetime.datetime, scope=Scope.REQUEST)
+    assert provider.context_type is datetime.datetime
+
+
 @pytest.mark.parametrize("value", [0, False, "", [], {}, 0.0])
 def test_context_provider_returns_falsy_values(value: object) -> None:
     context_type = type(value)


### PR DESCRIPTION
## What

`ContextProvider` stored its context type privately (`_context_type`) with no accessor. Expose it as a **public plain attribute** `context_type`.

```python
provider = ContextProvider(scope=Scope.REQUEST, context_type=fastapi.Request)
provider.context_type  # -> fastapi.Request
```

## Why

Integrations (modern-di-fastapi, and the same pattern in -litestar / -faststream / -typer) build a connection→scope→context-key mapping. Without a public `context_type` they re-state, in an `isinstance` ladder, the very type they passed into the provider — the knowledge is split across two places. Exposing `context_type` lets an integration drive that dispatch off the provider objects themselves, single-sourcing the mapping.

## Design choice — attribute, not property

- `context_type` is the sibling of `bound_type` (both come from the same constructor arg; `bound_type` *defaults* to `context_type`). `bound_type` and `scope` are **public plain slots** on the base provider — so `context_type` matches its peers.
- Every `@property` in the providers wraps a **derived** value (`display_name`). `context_type` is stored config, so a plain attribute fits the local idiom; a property would be the first one exposing stored state.

## Tests

- New `test_context_provider_exposes_context_type` (TDD: added red, then implemented).
- Full suite green at **100%** coverage; ruff / format / ty clean.

Minor, additive, backward-compatible — suggest a minor release (e.g. 2.20.0) so consumers can rely on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)