### PR TITLE
ci: publish to PyPI via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,15 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'               # stable:      2.7.2
       - '[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+'   # pre-release: 2.0.0rc1, 4.0.0a2
 
-# Needed for softprops/action-gh-release to create the GitHub Release.
+# contents: write -> create the GitHub Release; id-token: write -> OIDC for PyPI Trusted Publishing.
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi  # scopes the PyPI Trusted Publisher; hook for approval rules
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v4
@@ -45,9 +47,9 @@ jobs:
       # PyPI is irreversible, so it runs FIRST: if it fails the job stops and no
       # GitHub Release is created advertising a version that never reached PyPI.
       # `just publish` derives the version from $GITHUB_REF_NAME (the tag name).
+      # Auth via PyPI Trusted Publishing (OIDC); no PYPI_TOKEN. Needs a Trusted
+      # Publisher on the modern-di PyPI project (env: pypi, workflow: release.yml).
       - run: just publish
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       # Description source: planning/releases/<tag>.md if present (verbatim, no
       # auto-changelog appended); otherwise GitHub's generated notes. The guard

--- a/Justfile
+++ b/Justfile
@@ -37,11 +37,12 @@ bench:
     uv run --no-sync pytest benchmarks/ --benchmark-only
 
 # Build + publish to PyPI. Version comes from the git tag ($GITHUB_REF_NAME); no pyproject bump.
+# Auth via PyPI Trusted Publishing (OIDC); uv publish auto-detects the CI id-token.
 publish:
     rm -rf dist
     uv version $GITHUB_REF_NAME
     uv build
-    uv publish --token $PYPI_TOKEN
+    uv publish
 
 # Build the docs site, failing on broken links / nav warnings; CI runs this on every PR.
 docs-build:


### PR DESCRIPTION
## What

Replace the long-lived `PYPI_TOKEN` secret with PyPI **Trusted Publishing** (OIDC).

## Changes

- `release.yml`: add `id-token: write`, run the job under a `pypi` environment, drop the `PYPI_TOKEN` env from the publish step.
- `Justfile`: `uv publish --token $PYPI_TOKEN` -> `uv publish` (uv auto-detects the CI id-token).

## Why

No credential to leak or rotate; OIDC tokens are short-lived and scoped to this repo + workflow. This is PyPI's recommended path.

## Required before merge / next tag (maintainer, PyPI-side)

Code alone can't enable this:

1. PyPI -> `modern-di` project -> **Publishing** -> add a Trusted Publisher: owner `modern-python`, repo `modern-di`, workflow `release.yml`, environment `pypi`.
2. Create the `pypi` environment under repo **Settings -> Environments** (add approval/wait-timer rules if wanted).
3. After the first OIDC release succeeds, delete the `PYPI_TOKEN` repo secret.

If 1-2 aren't in place when a tag is pushed, that publish fails; nothing auto-releases in between, and reverting this diff restores the token path.