### PR TITLE
docs(release): add 2.21.1 notes (Trusted Publishing pipeline)

### DIFF
--- a/planning/releases/2.21.1.md
+++ b/planning/releases/2.21.1.md
@@ -1,0 +1,11 @@
+# modern-di 2.21.1 — release pipeline on PyPI Trusted Publishing
+
+No library changes. The package is identical to 2.21.0; this release exercises the new publish path end-to-end.
+
+## CI
+
+- Releases now authenticate to PyPI via **Trusted Publishing (OIDC)** instead of a long-lived `PYPI_TOKEN` secret. `uv publish` auto-detects the GitHub Actions id-token; the release job runs under a `pypi` environment that scopes the trusted publisher (#251).
+
+## Downstream
+
+No action required. Nothing about the installed package changes.


### PR DESCRIPTION
Curated release notes for **2.21.1** (mandatory for a stable tag). No library changes; this release validates the new PyPI Trusted Publishing pipeline from #251 end-to-end.

Merge, then tag `2.21.1` off green `main` to publish.