### PR TITLE
docs: reference the aiohttp integration across the docs set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`modern-di` is a **zero-dependency** Python dependency injection framework that wires up object graphs from type annotations, manages lifetimes via hierarchical scopes, and supports both sync and async finalizers. Framework integrations (FastAPI, FastStream, LiteStar, Typer) and the pytest integration (`modern-di-pytest`) live in **separate repositories** and are published as separate PyPI packages.
+`modern-di` is a **zero-dependency** Python dependency injection framework that wires up object graphs from type annotations, manages lifetimes via hierarchical scopes, and supports both sync and async finalizers. Framework integrations (aiohttp, FastAPI, FastStream, LiteStar, Starlette, Typer) and the pytest integration (`modern-di-pytest`) live in **separate repositories** and are published as separate PyPI packages.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - Scopes and context management
 - Python 3.10+ support
 - Fully typed and tested
-- Integrations with `FastAPI`, `FastStream`, `LiteStar`, `Starlette` and `Typer`
+- Integrations with `aiohttp`, `FastAPI`, `FastStream`, `LiteStar`, `Starlette` and `Typer`
 - Pytest integration (`modern-di-pytest`) — turns any DI dependency into a pytest fixture
 
 ## Install

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Welcome to the `modern-di` documentation!
 - Scopes and context management
 - Python 3.10+ support
 - Fully typed and tested
-- Integrations with `FastAPI`, `FastStream`, `LiteStar`, `Starlette`, `Typer`, and `pytest`
+- Integrations with `aiohttp`, `FastAPI`, `FastStream`, `LiteStar`, `Starlette`, `Typer`, and `pytest`
 
 Reference templates:
 
@@ -42,7 +42,7 @@ For end-to-end patterns drawn from real services, see the [Recipes](recipes/sqla
     poetry add modern-di
     ```
 
-If you want a framework integration, install the matching adapter — e.g. `modern-di-fastapi`, `modern-di-litestar`, `modern-di-faststream`, `modern-di-starlette`, `modern-di-typer`. For pytest support, install `modern-di-pytest`.
+If you want a framework integration, install the matching adapter — e.g. `modern-di-aiohttp`, `modern-di-fastapi`, `modern-di-litestar`, `modern-di-faststream`, `modern-di-starlette`, `modern-di-typer`. For pytest support, install `modern-di-pytest`.
 
 ## 2. Describe your dependencies
 
@@ -94,6 +94,7 @@ Pick **one** of the two mutually-exclusive options below.
 
 Pick the integration you need:
 
+- [aiohttp](integrations/aiohttp.md)
 - [FastAPI](integrations/fastapi.md)
 - [FastStream](integrations/faststream.md)
 - [LiteStar](integrations/litestar.md)

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -201,6 +201,17 @@ builds and closes the per-connection child, the decorator only reads it back fro
 the ASGI scope and resolves. See [Frameworks without native
 DI](#frameworks-without-native-di-the-decorator-path).
 
+The **aiohttp** integration ([`modern-di-aiohttp`](aiohttp.md)) is another
+middleware + decorator hybrid, for a non-ASGI server where the only connection
+object at middleware entry is `web.Request` — a WebSocket is an upgraded HTTP
+request, not a distinct type. It detects a WebSocket via
+`web.WebSocketResponse().can_prepare(request).ok`, opens a `Scope.REQUEST`
+child for an HTTP request or a `Scope.SESSION` child for a WebSocket, and —
+because both connection providers bind `web.Request` — registers
+`aiohttp_request_provider` by type while keeping `aiohttp_websocket_provider`
+reference-only (`bound_type=None`). Its root lifecycle rides aiohttp's
+`on_startup`/`on_cleanup` signals rather than a composed lifespan.
+
 The **pytest** integration
 ([`modern-di-pytest`](pytest.md)) is a different shape: it has no app to wire, so
 instead of `setup_di`/`FromDI` it exposes `modern_di_fixture` (turn one

--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -24,7 +24,7 @@ Reach for a container when one of these is true:
   the HTTP layer.
 
 modern-di's core promise is exactly that: **one typed wiring shared across
-FastAPI, Litestar, FastStream, Starlette, and Typer.**
+aiohttp, FastAPI, Litestar, FastStream, Starlette, and Typer.**
 
 ## The landscape
 
@@ -34,7 +34,7 @@ FastAPI, Litestar, FastStream, Starlette, and Typer.**
 | Scopes | APP→…→STEP (fixed chain) | RUNTIME→…→STEP (+ custom) | lifetimes (Singleton/Factory/Resource) | Singleton / Thread / None | request only |
 | Resolution | sync (by design) | sync + async | sync + async | sync | async |
 | First-party pytest plugin | ✅ | ✘ | ✘ | ✘ | n/a |
-| Official integrations | 6 (FastAPI, Litestar, FastStream, Starlette, Typer, pytest) | ~20+ | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
+| Official integrations | 7 (aiohttp, FastAPI, Litestar, FastStream, Starlette, Typer, pytest) | ~20+ | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
 | Typed resolution | ✅ | ✅ | partial | ✅ | callable-keyed |
 | License | MIT | Apache-2.0 | BSD-3 | BSD | — |
 | Adoption | newest, very active | established, large community | most popular, mature | mature | built into FastAPI |


### PR DESCRIPTION
Adds modern-di-aiohttp (https://github.com/modern-python/modern-di-aiohttp, released 2.0.0) to the integration cross-references it was missing: README + docs/index features lists and the 'pick an integration' list, the comparison page's integration sentence and count (6 -> 7), CLAUDE.md overview (also fixes a stale Starlette omission there), and a middleware+decorator-hybrid callout in the writing-an-integration guide. Docs-only.