### PR TITLE
feat: ergonomic Factory(cache=...) toggle, deprecate cache_settings=

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -151,5 +151,5 @@ resolved **live** on every resolve (see [resolution](resolution.md)), so a value
 picked up by subsequent resolves of **non-cached** providers — including factories in deeper-scoped
 child containers that read this container's context — with no cache invalidation needed.
 
-A **cached** provider (`Factory(cache_settings=...)`) is built once and its instance is *not*
+A **cached** provider (`Factory(cache=...)`) is built once and its instance is *not*
 rebuilt by a later `set_context`; set the context before its first resolve.

--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -39,7 +39,8 @@ Factory(
     creator: Callable[..., T],
     bound_type: type | None = UNSET,
     kwargs: dict[str, Any] | None = None,
-    cache_settings: CacheSettings[T] | None = None,
+    cache: bool | CacheSettings[T] | None = None,
+    cache_settings: CacheSettings[T] | None = UNSET,  # deprecated alias of `cache`
     skip_creator_parsing: bool = False,
 )
 ```
@@ -83,12 +84,18 @@ because the provider cannot be resolved by type.
 
 ## `CacheSettings` — singleton behavior
 
-There is **no separate `Singleton` class**. Singleton behavior is opted into by passing a `CacheSettings` instance
-to `Factory(cache_settings=...)`:
+There is **no separate `Singleton` class**. Singleton behavior is opted into via the `cache` argument:
+`cache=True` enables caching with default settings, `cache=CacheSettings(...)` enables caching and tunes it
+(finalizer, `clear_cache`), and an absent, `None`, or `False` value means a fresh instance is created on every
+resolution.
 
 ```python
-providers.Factory(scope=Scope.APP, creator=Database, cache_settings=providers.CacheSettings())
+providers.Factory(scope=Scope.APP, creator=Database, cache=True)
+providers.Factory(scope=Scope.APP, creator=Database, cache=providers.CacheSettings(finalizer=close))
 ```
+
+`cache_settings=` is a deprecated alias of `cache` (it emits a `DeprecationWarning` and will be removed in a
+future release); passing both `cache` and `cache_settings` raises `TypeError`.
 
 `CacheSettings` is a `dataclass` with the following fields:
 
@@ -101,7 +108,7 @@ providers.Factory(scope=Scope.APP, creator=Database, cache_settings=providers.Ca
 `is_async_finalizer` is not an init parameter — it is derived by `inspect.iscoroutinefunction(finalizer)` in
 `__post_init__`. The container uses it to decide whether to `await` the finalizer.
 
-Without `cache_settings`, `Factory.resolve` calls the creator on every resolution and returns a fresh instance
+Without `cache`, `Factory.resolve` calls the creator on every resolution and returns a fresh instance
 each time.
 
 ---

--- a/architecture/scopes.md
+++ b/architecture/scopes.md
@@ -68,7 +68,7 @@ from modern_di import providers
 # DatabasePool and UserFromRequest are your own classes.
 class AppGroup(Group):
     # Resolved once and cached for the lifetime of the app container.
-    db_pool = providers.Factory(scope=Scope.APP, creator=DatabasePool, cache_settings=providers.CacheSettings())
+    db_pool = providers.Factory(scope=Scope.APP, creator=DatabasePool, cache=True)
 
     # Resolved once per request container.
     current_user = providers.Factory(scope=Scope.REQUEST, creator=UserFromRequest)

--- a/benchmarks/test_bench_kwargs_split.py
+++ b/benchmarks/test_bench_kwargs_split.py
@@ -98,11 +98,9 @@ def test_singleton_optimized(benchmark):
     """Cached provider: current code resolves deps via split dicts."""
 
     class SGroup(Group):
-        leaf = providers.Factory(scope=Scope.APP, creator=Leaf, cache_settings=providers.CacheSettings())
-        dep = providers.Factory(scope=Scope.APP, creator=Dep, cache_settings=providers.CacheSettings())
-        svc = providers.Factory(
-            scope=Scope.APP, creator=Service, kwargs={"tag": "bench"}, cache_settings=providers.CacheSettings()
-        )
+        leaf = providers.Factory(scope=Scope.APP, creator=Leaf, cache=True)
+        dep = providers.Factory(scope=Scope.APP, creator=Dep, cache=True)
+        svc = providers.Factory(scope=Scope.APP, creator=Service, kwargs={"tag": "bench"}, cache=True)
 
     container = Container(scope=Scope.APP, groups=[SGroup])
     container.resolve_provider(SGroup.svc)  # warm cache
@@ -113,11 +111,9 @@ def test_singleton_baseline(benchmark):
     """Cached provider: baseline unified dict-comp with isinstance."""
 
     class SGroup(Group):
-        leaf = providers.Factory(scope=Scope.APP, creator=Leaf, cache_settings=providers.CacheSettings())
-        dep = providers.Factory(scope=Scope.APP, creator=Dep, cache_settings=providers.CacheSettings())
-        svc = providers.Factory(
-            scope=Scope.APP, creator=Service, kwargs={"tag": "bench"}, cache_settings=providers.CacheSettings()
-        )
+        leaf = providers.Factory(scope=Scope.APP, creator=Leaf, cache=True)
+        dep = providers.Factory(scope=Scope.APP, creator=Dep, cache=True)
+        svc = providers.Factory(scope=Scope.APP, creator=Service, kwargs={"tag": "bench"}, cache=True)
 
     container = Container(scope=Scope.APP, groups=[SGroup])
     container.resolve_provider(SGroup.svc)  # warm cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ class Dependencies(Group):
     settings = providers.Factory(
         scope=Scope.APP,                          # APP is the default
         creator=Settings,
-        cache_settings=providers.CacheSettings(),  # one Settings for the whole app
+        cache=True,  # cache the singleton for the whole app
     )
 
     user_repository = providers.Factory(

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -46,7 +46,7 @@ class AppGroup(Group):
     singleton = providers.Factory(
         scope=Scope.APP,
         creator=create_singleton,
-        cache_settings=providers.CacheSettings()
+        cache=True
     )
 
 

--- a/docs/integrations/faststream.md
+++ b/docs/integrations/faststream.md
@@ -51,7 +51,7 @@ class AppGroup(Group):
     settings = providers.Factory(
         scope=Scope.APP,
         creator=Settings,
-        cache_settings=providers.CacheSettings(),
+        cache=True,
     )
     order_processor = providers.Factory(
         scope=Scope.REQUEST,

--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -41,7 +41,7 @@ class AppGroup(Group):
     singleton = providers.Factory(
         scope=Scope.APP,
         creator=create_singleton,
-        cache_settings=providers.CacheSettings()
+        cache=True
     )
 
 

--- a/docs/integrations/typer.md
+++ b/docs/integrations/typer.md
@@ -50,7 +50,7 @@ class AppGroup(Group):
     settings = providers.Factory(
         scope=Scope.APP,
         creator=Settings,
-        cache_settings=providers.CacheSettings(),
+        cache=True,
     )
     health_reporter = providers.Factory(
         scope=Scope.REQUEST,

--- a/docs/introduction/about-di.md
+++ b/docs/introduction/about-di.md
@@ -65,7 +65,7 @@ service = UserService(cache=MockCache())     # Testing
 
 ## Lifetime Management in DI
 
-Objects can have different lifetime cycles (singleton, scoped, transient). `modern-di` expresses this with [Scopes](../providers/scopes.md) — APP for process-wide singletons, REQUEST for per-request resources, and so on. In modern-di's own terms: a provider's scope (APP/SESSION/REQUEST/…) decides how long an instance lives, and the presence of `cache_settings` means one shared instance is reused while its absence means a fresh instance is created on each resolve. Here are examples:
+Objects can have different lifetime cycles (singleton, scoped, transient). `modern-di` expresses this with [Scopes](../providers/scopes.md) — APP for process-wide singletons, REQUEST for per-request resources, and so on. In modern-di's own terms: a provider's scope (APP/SESSION/REQUEST/…) decides how long an instance lives, and the presence of `cache` means one shared instance is reused while its absence means a fresh instance is created on each resolve. Here are examples:
 
 ```python
 
@@ -75,21 +75,21 @@ from modern_di import Group, Scope, providers
 
 class AppGroup(Group):
     # Cached for the whole app: one shared instance.
-    # CacheSettings() makes the provider a cached singleton (see the Factories page).
+    # cache=True makes the provider a cached singleton (see the Factories page).
     config = providers.Factory(
         scope=Scope.APP,
         creator=AppConfig,
-        cache_settings=providers.CacheSettings()
+        cache=True
     )
 
     # Cached per request: one shared instance per request
     db_session = providers.Factory(
         scope=Scope.REQUEST,
         creator=DatabaseSession,
-        cache_settings=providers.CacheSettings()
+        cache=True
     )
 
-    # No cache_settings: a fresh instance each resolve
+    # No cache: a fresh instance each resolve
     request_id = providers.Factory(
         scope=Scope.REQUEST,
         creator=lambda: str(uuid.uuid4())
@@ -137,7 +137,7 @@ class AppGroup(Group):
     config = providers.Factory(
         scope=Scope.APP,
         creator=AppConfig,
-        cache_settings=providers.CacheSettings()
+        cache=True
     )
     db = providers.Factory(scope=Scope.REQUEST, creator=DatabaseConnection)
     user_service = providers.Factory(scope=Scope.REQUEST, creator=UserService)
@@ -189,7 +189,7 @@ class AppGroup(Group):
     db_session = providers.Factory(
         scope=Scope.REQUEST,
         creator=DatabaseSession,
-        cache_settings=providers.CacheSettings(
+        cache=providers.CacheSettings(
             finalizer=lambda session: session.close()  # ✅ Define cleanup
         )
     )

--- a/docs/migration/from-that-depends.md
+++ b/docs/migration/from-that-depends.md
@@ -61,8 +61,8 @@ Use this table as the index for the rest of the guide.
 | `that-depends` | `modern-di` replacement | Where to look |
 |---|---|---|
 | `Factory` | `providers.Factory(...)` | [§4](#4-migrate-the-dependency-graph) |
-| `Singleton` | `providers.Factory(..., cache_settings=CacheSettings())` | [§4](#4-migrate-the-dependency-graph) |
-| `Resource` (sync gen / ctx mgr) | `providers.Factory(..., cache_settings=CacheSettings(finalizer=...))` | [§4](#4-migrate-the-dependency-graph) |
+| `Singleton` | `providers.Factory(..., cache=True)` | [§4](#4-migrate-the-dependency-graph) |
+| `Resource` (sync gen / ctx mgr) | `providers.Factory(..., cache=CacheSettings(finalizer=...))` | [§4](#4-migrate-the-dependency-graph) |
 | `Resource` (async gen / ctx mgr) | Lifespan + `ContextProvider` (or sync creator + async finalizer) | [§6](#6-async-resources) |
 | `ContextResource` | `providers.Factory(scope=Scope.REQUEST, ...)` | [§5](#5-context-resources-and-request-scope) |
 | `AsyncFactory` | Lifespan-managed; expose via `ContextProvider` | [§6](#6-async-resources) |
@@ -122,12 +122,12 @@ When a provider is passed inside `kwargs={...}`, `modern-di` detects it and reso
       class Dependencies(Group):
           database_engine = providers.Factory(
               creator=create_sa_engine,
-              cache_settings=providers.CacheSettings(finalizer=close_sa_engine),
+              cache=providers.CacheSettings(finalizer=close_sa_engine),
           )
           session = providers.Factory(
               scope=Scope.REQUEST,
               creator=create_session,
-              cache_settings=providers.CacheSettings(finalizer=close_session),
+              cache=providers.CacheSettings(finalizer=close_session),
               kwargs={"engine": database_engine},
           )
 
@@ -158,7 +158,7 @@ some_singleton = providers.Singleton(SomeClass)
 # modern-di
 some_singleton = providers.Factory(
     creator=SomeClass,
-    cache_settings=providers.CacheSettings(),
+    cache=True,
 )
 ```
 
@@ -171,7 +171,7 @@ some_resource = providers.Resource(create_resource)  # sync generator
 # modern-di — split the generator into a creator and a finalizer
 some_resource = providers.Factory(
     creator=create_resource,                # plain function returning the resource
-    cache_settings=providers.CacheSettings(finalizer=close_resource),
+    cache=providers.CacheSettings(finalizer=close_resource),
 )
 ```
 
@@ -187,7 +187,7 @@ class ApiKey(str): ...
 def _api_key() -> ApiKey:
     return ApiKey("secret-token")
 
-api_key = providers.Factory(creator=_api_key, cache_settings=providers.CacheSettings())
+api_key = providers.Factory(creator=_api_key, cache=True)
 ```
 
 If you only need the value passed into one downstream provider, skip the wrapper and put it directly in that provider's `kwargs`.
@@ -212,7 +212,7 @@ some_list = providers.Factory(creator=build_list)
 repo = providers.Factory(PostgresRepository).bind(Repository)
 
 # modern-di
-repo = providers.Factory(creator=PostgresRepository, cache_settings=providers.CacheSettings())
+repo = providers.Factory(creator=PostgresRepository, cache=True)
 abstract_repo = providers.Alias(source_type=PostgresRepository, bound_type=Repository)
 ```
 
@@ -228,7 +228,7 @@ The framework integration creates a `REQUEST`-scope child container per request 
 session = providers.Factory(
     scope=Scope.REQUEST,
     creator=create_session,
-    cache_settings=providers.CacheSettings(finalizer=close_session),
+    cache=providers.CacheSettings(finalizer=close_session),
     kwargs={"engine": database_engine},
 )
 ```
@@ -297,7 +297,7 @@ async def close_engine(engine: sqlalchemy.ext.asyncio.AsyncEngine) -> None:
 
 engine = providers.Factory(
     creator=create_engine,
-    cache_settings=providers.CacheSettings(finalizer=close_engine),
+    cache=providers.CacheSettings(finalizer=close_engine),
 )
 ```
 

--- a/docs/migration/to-2.x.md
+++ b/docs/migration/to-2.x.md
@@ -78,11 +78,11 @@ singleton = providers.Singleton(Scope.APP, create_singleton)
 
 **After (2.x):**
 ```python
-# Use Factory with cache settings
+# Use Factory with cache enabled
 singleton = providers.Factory(
     scope=Scope.APP, 
     creator=create_singleton,
-    cache_settings=providers.CacheSettings()
+    cache=True
 )
 ```
 
@@ -95,11 +95,11 @@ resource = providers.Resource(Scope.REQUEST, create_resource)
 
 **After (2.x):**
 ```python
-# Resources can be replaced with Factory with cache_settings with finalizer defined
+# Resources can be replaced with Factory with cache tuned with a finalizer
 resource = providers.Factory(
     scope=Scope.REQUEST,
     creator=create_resource,
-    cache_settings=providers.CacheSettings(
+    cache=providers.CacheSettings(
         finalizer=lambda resource: resource.close(),
     )
 )
@@ -171,16 +171,16 @@ singleton = providers.Singleton(Scope.APP, create_singleton)
 
 **After (2.x):**
 ```python
-# Explicit cache settings
+# Explicit cache
 singleton = providers.Factory(
     creator=create_singleton,
-    cache_settings=providers.CacheSettings()
+    cache=True
 )
 
-# Cache settings with finalizer
+# Cache tuned with a finalizer
 cached_with_cleanup = providers.Factory(
     creator=create_resource,
-    cache_settings=providers.CacheSettings(
+    cache=providers.CacheSettings(
         finalizer=lambda resource: resource.close(),
     )
 )

--- a/docs/providers/advanced-api.md
+++ b/docs/providers/advanced-api.md
@@ -40,3 +40,9 @@ To implement a custom provider, subclass `AbstractProvider` and implement:
 `CacheSettings.is_async_finalizer` is a computed bool field set at construction time via
 `inspect.iscoroutinefunction(finalizer)`. `Factory.resolve` and the cache registry use it to
 decide whether to `await` the finalizer during `close_async()` or treat it as sync.
+
+## Deprecated: `cache_settings=`
+
+`Factory(cache_settings=...)` is a deprecated alias of `cache=`. It still works but
+emits a `DeprecationWarning`; pass `cache=True` (defaults) or `cache=CacheSettings(...)`
+(tuned) instead. Passing both `cache` and `cache_settings` raises `TypeError`.

--- a/docs/providers/alias.md
+++ b/docs/providers/alias.md
@@ -42,7 +42,7 @@ class PostgresRepository:
 class Dependencies(Group):
     repo = providers.Factory(
         creator=PostgresRepository,
-        cache_settings=providers.CacheSettings(),
+        cache=True,
     )
     abstract_repo = providers.Alias(
         source_type=PostgresRepository,

--- a/docs/providers/factories.md
+++ b/docs/providers/factories.md
@@ -70,7 +70,7 @@ class Dependencies(Group):
     singleton = providers.Factory(
         scope=Scope.APP,
         creator=generate_random_number,
-        cache_settings=providers.CacheSettings()
+        cache=True
     )
 
 
@@ -82,9 +82,9 @@ singleton_instance2 = container.resolve_provider(Dependencies.singleton)
 assert singleton_instance1 is singleton_instance2
 ```
 
-#### Cache Settings
+#### Tuning the cache
 
-You can customize caching behavior with `CacheSettings`:
+You can customize caching behavior by passing a `CacheSettings` to `cache=`:
 
 ```python
 import contextlib
@@ -107,7 +107,7 @@ class Dependencies(Group):
     resource = providers.Factory(
         scope=Scope.APP,
         creator=create_resource,
-        cache_settings=providers.CacheSettings(
+        cache=providers.CacheSettings(
             finalizer=lambda res: res.close(),  # Cleanup function
         )
     )
@@ -138,9 +138,11 @@ Set to `None` to make the provider unresolvable by type.
 Manual values for creator parameters that override automatic dependency resolution.
 Use this to provide specific values for parameters or override automatically resolved dependencies.
 
-### cache_settings
+### cache
 
-Configuration for caching instances. Only applicable for cached factories. Use `providers.CacheSettings()` to enable caching with optional cleanup configuration. See [Lifecycle](lifecycle.md) for how caching, finalizers, and `close_async()` fit together.
+Enables caching for the provider. Pass `cache=True` to cache with default settings (no finalizer, cache cleared on close), or `cache=providers.CacheSettings(...)` to tune the finalizer and/or `clear_cache` behavior. Absent, `None`, or `False` means a fresh instance is created on every resolve. See [Lifecycle](lifecycle.md) for how caching, finalizers, and `close_async()` fit together.
+
+`cache_settings=` is a deprecated alias for `cache=` — see [Advanced API](advanced-api.md#deprecated-cache_settings).
 
 ### skip_creator_parsing
 
@@ -248,7 +250,7 @@ This is useful when `skip_creator_parsing=True` is in effect but you still want 
 
 If a creator raises an exception during resolution:
 
-- **Nothing is cached.** The failed instance is never stored in the cache registry, even if `cache_settings` is set.
+- **Nothing is cached.** The failed instance is never stored in the cache registry, even if `cache` is set.
 - **The next `resolve` call retries.** Subsequent resolves call the creator again from scratch, so a transiently-failing creator will eventually succeed once the underlying condition is fixed.
 - **Already-resolved dependencies are not rolled back.** Dependencies that were successfully resolved before the creator raised are still held in their respective containers and will be finalized normally when those containers are closed.
 
@@ -273,7 +275,7 @@ class Dependencies(Group):
     svc = providers.Factory(
         scope=Scope.APP,
         creator=flaky_creator,
-        cache_settings=providers.CacheSettings(),
+        cache=True,
     )
 
 

--- a/docs/providers/lifecycle.md
+++ b/docs/providers/lifecycle.md
@@ -30,11 +30,11 @@ container.resolve(Settings)
 session = providers.Factory(
     scope=Scope.REQUEST,
     creator=create_session,
-    cache_settings=providers.CacheSettings(finalizer=close_session),
+    cache=providers.CacheSettings(finalizer=close_session),
 )
 ```
 
-- **Caching.** With `cache_settings=CacheSettings()`, the provider returns the same instance for every resolve inside that scope's container. Without `cache_settings`, the provider creates a fresh instance every call.
+- **Caching.** With `cache=True`, the provider returns the same instance for every resolve inside that scope's container. Without `cache`, the provider creates a fresh instance every call.
 - **Finalizer.** A callable that runs on the cached instance when the container is closed. Sync or async — `CacheSettings` auto-detects via `inspect.iscoroutinefunction()`. The finalizer takes one argument: the cached instance.
 
 ```python

--- a/docs/recipes/async-lifespan.md
+++ b/docs/recipes/async-lifespan.md
@@ -56,7 +56,7 @@ The same pattern works for `asyncpg.create_pool(...)` (truly async), authenticat
 
 ## When a sync creator works instead
 
-Many "async" resources actually construct synchronously — `redis.asyncio.Redis.from_url(...)`, `sqlalchemy.ext.asyncio.create_async_engine(...)`, and `httpx.AsyncClient(...)` all return without awaiting. For those, prefer a normal `Factory` with `cache_settings=CacheSettings(finalizer=async_close_fn)` and skip the lifespan + `set_context` dance entirely. Use this recipe only when construction genuinely needs `await` or a running event loop.
+Many "async" resources actually construct synchronously — `redis.asyncio.Redis.from_url(...)`, `sqlalchemy.ext.asyncio.create_async_engine(...)`, and `httpx.AsyncClient(...)` all return without awaiting. For those, prefer a normal `Factory` with `cache=CacheSettings(finalizer=async_close_fn)` and skip the lifespan + `set_context` dance entirely. Use this recipe only when construction genuinely needs `await` or a running event loop.
 
 ## See also
 

--- a/docs/recipes/multi-group.md
+++ b/docs/recipes/multi-group.md
@@ -44,12 +44,12 @@ class Database(Group):
     engine = providers.Factory(
         scope=Scope.APP,
         creator=create_engine,
-        cache_settings=providers.CacheSettings(finalizer=close_engine),
+        cache=providers.CacheSettings(finalizer=close_engine),
     )
     session = providers.Factory(
         scope=Scope.REQUEST,
         creator=create_session,
-        cache_settings=providers.CacheSettings(finalizer=close_session),
+        cache=providers.CacheSettings(finalizer=close_session),
     )
 
 
@@ -57,7 +57,7 @@ class Cache(Group):
     redis_client = providers.Factory(
         scope=Scope.APP,
         creator=create_redis,
-        cache_settings=providers.CacheSettings(finalizer=close_redis),
+        cache=providers.CacheSettings(finalizer=close_redis),
     )
 
 

--- a/docs/recipes/request-scoped-engine.md
+++ b/docs/recipes/request-scoped-engine.md
@@ -48,13 +48,13 @@ class Dependencies(Group):
         scope=Scope.APP,
         creator=create_primary_engine,
         bound_type=PrimaryEngine,
-        cache_settings=providers.CacheSettings(finalizer=close_engine),
+        cache=providers.CacheSettings(finalizer=close_engine),
     )
     replica = providers.Factory(
         scope=Scope.APP,
         creator=create_replica_engine,
         bound_type=ReplicaEngine,
-        cache_settings=providers.CacheSettings(finalizer=close_engine),
+        cache=providers.CacheSettings(finalizer=close_engine),
     )
 
     # REQUEST-scope: picks per-request, cached for the rest of that request
@@ -62,14 +62,14 @@ class Dependencies(Group):
         scope=Scope.REQUEST,
         creator=choose_engine,
         kwargs={"primary": primary, "replica": replica},
-        cache_settings=providers.CacheSettings(),
+        cache=True,
     )
 
     # Sessions and repositories use the REQUEST-scoped engine
     session = providers.Factory(
         scope=Scope.REQUEST,
         creator=create_session,
-        cache_settings=providers.CacheSettings(finalizer=close_session),
+        cache=providers.CacheSettings(finalizer=close_session),
     )
 ```
 

--- a/docs/recipes/sqlalchemy.md
+++ b/docs/recipes/sqlalchemy.md
@@ -43,12 +43,12 @@ class Dependencies(Group):
     engine = providers.Factory(
         scope=Scope.APP,
         creator=create_engine,
-        cache_settings=providers.CacheSettings(finalizer=close_engine),
+        cache=providers.CacheSettings(finalizer=close_engine),
     )
     session = providers.Factory(
         scope=Scope.REQUEST,
         creator=create_session,
-        cache_settings=providers.CacheSettings(finalizer=close_session),
+        cache=providers.CacheSettings(finalizer=close_session),
     )
     user_repository = providers.Factory(
         scope=Scope.REQUEST,

--- a/docs/troubleshooting/scope-chain.md
+++ b/docs/troubleshooting/scope-chain.md
@@ -28,7 +28,7 @@ class Dependencies(Group):
     session = providers.Factory(
         scope=Scope.REQUEST,
         creator=create_session,
-        cache_settings=providers.CacheSettings(finalizer=close_session),
+        cache=providers.CacheSettings(finalizer=close_session),
     )
 
     # ❌ APP-scoped — fails validation

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -231,7 +231,7 @@ class Container:
         Context values are resolved live, so a value set here is picked up by
         subsequent resolves of **non-cached** providers — including factories in
         deeper-scoped child containers that read this container's context. A
-        **cached** provider (``Factory(cache_settings=...)``) is built once and
+        **cached** provider (``Factory(cache=...)``) is built once and
         its instance is *not* rebuilt by a later ``set_context``; set the context
         before its first resolve.
         """

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -31,16 +31,36 @@ class CacheSettings(typing.Generic[types.T_co]):
 class Factory(AbstractProvider[types.T_co]):
     __slots__ = ("_creator", "_kwargs", "_parsed_kwargs", "cache_settings")
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: C901, PLR0913
         self,
         *,
         scope: enum.IntEnum = Scope.APP,
         creator: typing.Callable[..., types.T_co],
         bound_type: type | None | types.UnsetType = types.UNSET,
         kwargs: dict[str, typing.Any] | None = None,
-        cache_settings: CacheSettings[types.T_co] | None = None,
+        cache: bool | CacheSettings[types.T_co] | None = None,
+        cache_settings: CacheSettings[types.T_co] | None | types.UnsetType = types.UNSET,
         skip_creator_parsing: bool = False,
     ) -> None:
+        if not isinstance(cache_settings, types.UnsetType):
+            if cache is not None:
+                msg = "pass only `cache`, not both `cache` and the deprecated `cache_settings`"
+                raise TypeError(msg)
+            if cache_settings is not None:
+                warnings.warn(
+                    "`cache_settings=` is deprecated; use `cache=` "
+                    "(pass cache=True for defaults, or cache=CacheSettings(...) to tune). "
+                    "It will be removed in a future release.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            cache = cache_settings
+        if cache is True:
+            resolved_cache: CacheSettings[types.T_co] | None = CacheSettings()
+        elif cache:  # a CacheSettings instance
+            resolved_cache = cache
+        else:  # None or False
+            resolved_cache = None
         if skip_creator_parsing:
             if bound_type is types.UNSET:
                 warnings.warn(
@@ -71,7 +91,7 @@ class Factory(AbstractProvider[types.T_co]):
         self._parsed_kwargs = parsed_kwargs
         super().__init__(scope=scope, bound_type=parsed_type if isinstance(bound_type, types.UnsetType) else bound_type)
         self._creator = creator
-        self.cache_settings = cache_settings
+        self.cache_settings = resolved_cache
         self._kwargs = kwargs
 
     @staticmethod

--- a/planning/changes/2026-07-04.01-factory-cache-arg/design.md
+++ b/planning/changes/2026-07-04.01-factory-cache-arg/design.md
@@ -1,0 +1,177 @@
+---
+summary: Add `Factory(cache=...)` accepting `bool | CacheSettings | None`; deprecate the `cache_settings=` alias so the common "just cache it" case is `cache=True`.
+---
+
+# Design: Ergonomic `cache=` toggle on `Factory`
+
+## Summary
+
+Enabling singleton caching on a `Factory` currently requires constructing an
+empty settings object and naming a nested type:
+`cache_settings=providers.CacheSettings()`. This design adds a `cache`
+argument that carries the whole caching spectrum in one axis —
+`cache=True` for the common case, `cache=CacheSettings(...)` for the tuned
+case, absent/`None`/`False` for no caching — and turns `cache_settings=` into a
+warn-only deprecated alias. `CacheSettings` itself is unchanged; the sugar lives
+entirely in `Factory.__init__`. No `Singleton` class is introduced.
+
+## Motivation
+
+The most common provider shape — a cached singleton with no finalizer and
+default eviction — forces the user to import `CacheSettings` and instantiate it
+just to flip a boolean:
+
+```python
+providers.Factory(scope=Scope.APP, creator=Database, cache_settings=providers.CacheSettings())
+```
+
+A cross-framework survey (dependency-injector, that-depends, .NET, Guice,
+Spring, Koin, get_it, InversifyJS, tsyringe, punq, wireup, lagom, injector,
+svcs, shaku, Go fx/wire) shows modern-di sits in the *least* ergonomic bucket
+for this toggle: a construction-time settings object. The ergonomic winners
+express the intent at verb/token level (Koin `single {}`, .NET
+`AddSingleton<T>()`). Both of modern-di's closest Python peers use a distinct
+`Singleton` provider class — including `that-depends`, which this project ships
+a migration guide *from*, so its users reach for `providers.Singleton` by muscle
+memory.
+
+The `bool | config-object` argument pattern is well-precedented in Python
+(`requests(verify=True | "/path")`, `pandas.read_csv(parse_dates=True | [...])`,
+`subprocess.run(capture_output=True)`), so a single upgradeable argument reads
+as idiomatic while collapsing the two-token ceremony to one.
+
+## Non-goals
+
+- No `Singleton` provider class. A `Singleton` preset would express "caching is
+  on" in *two* places (class name + a still-needed `cache_settings` for
+  finalizers), which can drift; the single `cache` axis avoids that. See the
+  decision record.
+- No change to `CacheSettings` — its fields (`clear_cache`, `finalizer`,
+  computed `is_async_finalizer`) and semantics are untouched.
+- No change to `resolve()`, the cache registry, or lifecycle/finalizer
+  behavior. This is an entry-point ergonomics change only.
+- No change to `ContextProvider`, `Alias`, or any provider other than `Factory`.
+
+## Design
+
+### 1. `Factory.__init__` signature
+
+```python
+Factory(
+    *,
+    scope: IntEnum = Scope.APP,
+    creator: Callable[..., T],
+    bound_type: type | None = UNSET,
+    kwargs: dict[str, Any] | None = None,
+    cache: bool | CacheSettings[T] | None = None,          # NEW primary toggle
+    cache_settings: CacheSettings[T] | None = UNSET,       # DEPRECATED alias
+    skip_creator_parsing: bool = False,
+)
+```
+
+`cache_settings` defaults to the `types.UNSET` sentinel (following `bound_type`)
+so an explicit pass is distinguishable from omission.
+
+Usage:
+
+```python
+providers.Factory(creator=Database)                                   # fresh each resolve
+providers.Factory(creator=Database, cache=True)                       # cached, defaults
+providers.Factory(creator=Database, cache=CacheSettings(finalizer=close))  # cached, tuned
+```
+
+### 2. Normalization (in `__init__`)
+
+The `cache` input is normalized once into the existing internal attribute
+`self.cache_settings`, which continues to hold a `CacheSettings | None`:
+
+```python
+if cache_settings is not types.UNSET:                 # deprecated path
+    if cache is not None:
+        raise TypeError(
+            "pass only `cache`, not both `cache` and the deprecated `cache_settings`"
+        )
+    if cache_settings is not None:
+        warnings.warn(
+            "`cache_settings=` is deprecated; use `cache=` "
+            "(pass cache=True for defaults, or cache=CacheSettings(...) to tune). "
+            "It will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    cache = cache_settings
+
+self.cache_settings = CacheSettings() if cache is True else (cache or None)
+```
+
+- `cache is True` uses identity so a truthy `CacheSettings` instance is not
+  mistaken for the boolean.
+- `cache or None` maps `False`/`None` → `None` and passes a `CacheSettings`
+  instance through unchanged.
+
+### 3. Everything downstream is unchanged
+
+Because `self.cache_settings` remains a normalized `CacheSettings | None`,
+`Factory.resolve`, `cache_registry` (`provider.cache_settings`), and `__repr__`
+change **zero** lines. The internal attribute keeps its accurate noun name; only
+the *parameter* is the ergonomic `cache`.
+
+### 4. Behavior decisions (confirmed)
+
+- **Internal attribute** stays `self.cache_settings` — no rename, no risk to
+  integrations reading `.cache_settings`.
+- **Both `cache` and `cache_settings` passed** → `TypeError` (conventional for
+  mutually-exclusive kwargs; no correct code reaches it).
+- **`cache_settings=None` passed explicitly** → no warning (a no-op equal to the
+  default; warning it would be noise). The `DeprecationWarning` fires only for a
+  real `CacheSettings` passed via the old name.
+- **Backward compatible** — every existing `cache_settings=CacheSettings(...)`
+  keeps working, now with a `DeprecationWarning`.
+
+## Testing
+
+TDD, failing test first per behavior. New/updated tests in
+`tests/providers/test_factory.py` and `tests/providers/test_singleton.py`; the
+full `just test-ci` run must stay at 100% line coverage.
+
+- `cache=True` → same instance across resolves; `provider.cache_settings` is a
+  `CacheSettings`; `__repr__` reports `cached=True`.
+- `cache=False` / `cache=None` / omitted → a fresh instance each resolve.
+- `cache=CacheSettings(finalizer=fn)` → cached and the finalizer fires on close
+  (sync and async finalizer variants).
+- `cache_settings=CacheSettings(...)` (deprecated) → still caches **and** emits
+  `DeprecationWarning` (assert via `pytest.warns`).
+- `cache_settings=None` explicit → no warning (assert via
+  `warnings.catch_warnings(record=True)` — no `DeprecationWarning` recorded).
+- `cache` and `cache_settings` both passed → `TypeError`.
+
+## Docs (this PR)
+
+Per the repo rule, the truth home is updated in the same PR:
+
+- `architecture/providers.md` — rewrite the `CacheSettings` section around the
+  `cache` argument; document the deprecated alias.
+- `architecture/resolution.md`, `architecture/containers.md` — update the
+  `cache_settings`-spelled references to the `cache` idiom where they show API.
+
+`docs/` example pages switch to the `cache=True` / `cache=CacheSettings(...)`
+idiom (`providers/factories.md`, `providers/lifecycle.md`, `index.md`,
+`introduction/about-di.md`, the integration pages, the recipes, and the
+migration tables in `migration/from-that-depends.md` and `migration/to-2.x.md`),
+plus a one-line deprecation note in `docs/providers/advanced-api.md`. Roughly
+15-20 files of mechanical find-replace. A `planning/decisions/` record captures
+why `cache=` won over the `Singleton`-class / `cached=` / `cache_settings=True`
+alternatives.
+
+## Risk
+
+- **Low — silent behavior drift.** None expected: `resolve`/registry paths are
+  untouched and operate on the same normalized attribute. Mitigation: the
+  existing caching test suite must pass unchanged alongside the new tests.
+- **Low — deprecation noise for existing users.** A `DeprecationWarning` on
+  every `cache_settings=` call could surprise. Mitigation: it is warn-only,
+  removal deferred to a future release (matching the `Alias.scope=` precedent),
+  and the message states the exact replacement.
+- **Low — docs drift.** A large mechanical sweep risks a missed page. Mitigation:
+  a repo-wide grep for `cache_settings=` gates the PR; remaining hits must be
+  intentional (migration prose describing the deprecated form, decision record).

--- a/planning/changes/2026-07-04.01-factory-cache-arg/plan.md
+++ b/planning/changes/2026-07-04.01-factory-cache-arg/plan.md
@@ -1,0 +1,333 @@
+# Factory `cache=` Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `cache` argument to `Factory` accepting `bool | CacheSettings | None`, so the common "just cache it" case is `cache=True`, and deprecate the `cache_settings=` alias.
+
+**Architecture:** All sugar lives in `Factory.__init__`: the new `cache` input is normalized once into the existing internal attribute `self.cache_settings` (still a `CacheSettings | None`), so `resolve()`, the cache registry, and `__repr__` are untouched. `cache_settings=` remains a warn-only deprecated alias. `CacheSettings` is unchanged.
+
+**Tech Stack:** Python 3.10+, `uv`, `just`, `pytest` (+ pytest-asyncio auto mode), `ruff` (`select=ALL`), `ty`.
+
+## Global Constraints
+
+- Zero runtime dependencies. Line length 120. `ruff` `select=["ALL"]` and `ty` must pass (`just lint-ci`).
+- Full gated suite `just test-ci` must stay at **100% line coverage** (`TYPE_CHECKING` blocks excluded).
+- All imports at module level. Annotate every function argument. Use `# ty: ignore`, never `# type: ignore`.
+- Resolution is sync-only; finalizers may be sync or async (unchanged here).
+- Conventional-commit subjects. Branch off `main` (suggested: `feat/factory-cache-arg`); ship via PR, never local-merge.
+- Spec: `planning/changes/2026-07-04.01-factory-cache-arg/design.md`. Decision record: `planning/decisions/2026-07-04-cache-arg-over-singleton-class.md`.
+
+---
+
+### Task 1: `cache=` argument, normalization, and `cache_settings=` deprecation
+
+**Files:**
+- Modify: `modern_di/providers/factory.py:34-75` (`Factory.__init__` signature + normalization; the assignment at line 74)
+- Test: `tests/providers/test_factory.py` (append new tests at end of file)
+
+**Interfaces:**
+- Consumes: `types.UNSET`, `types.UnsetType` (already imported in `factory.py`); `CacheSettings` (defined in the same module); `warnings` (already imported).
+- Produces: `Factory(*, ..., cache: bool | CacheSettings[T] | None = None, cache_settings: CacheSettings[T] | None | UnsetType = UNSET, ...)`. After construction, `provider.cache_settings` is a normalized `CacheSettings | None` (unchanged type). Later tasks (docs) rely only on the public spelling `cache=True` / `cache=CacheSettings(...)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/providers/test_factory.py` (imports `warnings`, `pytest`, `Container`, `Group`, `Scope`, `providers` are already present at the top of the file):
+
+```python
+def test_cache_true_returns_same_instance() -> None:
+    class G(Group):
+        f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=True)
+
+    container = Container(groups=[G])
+    assert container.resolve_provider(G.f) is container.resolve_provider(G.f)
+    assert isinstance(G.f.cache_settings, providers.CacheSettings)
+
+
+def test_cache_absent_returns_fresh_instances() -> None:
+    class G(Group):
+        f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"})
+
+    container = Container(groups=[G])
+    assert container.resolve_provider(G.f) is not container.resolve_provider(G.f)
+    assert G.f.cache_settings is None
+
+
+@pytest.mark.parametrize("cache_value", [False, None])
+def test_cache_falsy_disables_caching(cache_value: bool | None) -> None:
+    class G(Group):
+        f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=cache_value)
+
+    container = Container(groups=[G])
+    assert container.resolve_provider(G.f) is not container.resolve_provider(G.f)
+    assert G.f.cache_settings is None
+
+
+def test_cache_accepts_cache_settings_and_finalizes() -> None:
+    cleaned: list[object] = []
+
+    class G(Group):
+        f = providers.Factory(creator=dict, cache=providers.CacheSettings(finalizer=cleaned.append))
+
+    container = Container(groups=[G])
+    instance = container.resolve_provider(G.f)
+    assert container.resolve_provider(G.f) is instance
+    container.close_sync()
+    assert cleaned == [instance]
+
+
+def test_cache_settings_is_deprecated_but_functional() -> None:
+    with pytest.warns(DeprecationWarning, match="cache_settings"):
+        provider = providers.Factory(
+            creator=SimpleCreator, kwargs={"dep1": "x"}, cache_settings=providers.CacheSettings()
+        )
+    container = Container()
+    assert container.resolve_provider(provider) is container.resolve_provider(provider)
+
+
+def test_cache_settings_none_emits_no_deprecation_warning() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        provider = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache_settings=None)
+    assert provider.cache_settings is None
+
+
+def test_cache_and_cache_settings_together_raise() -> None:
+    with pytest.raises(TypeError, match="pass only `cache`"):
+        providers.Factory(
+            creator=SimpleCreator, kwargs={"dep1": "x"}, cache=True, cache_settings=providers.CacheSettings()
+        )
+
+
+def test_repr_reports_cached_for_cache_true() -> None:
+    provider = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=True)
+    assert "cached=True" in repr(provider)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just test tests/providers/test_factory.py -k "cache_true or cache_absent or cache_falsy or cache_accepts or deprecated or none_emits or together_raise or repr_reports"`
+Expected: FAIL — `Factory.__init__` has no `cache` parameter (`TypeError: __init__() got an unexpected keyword argument 'cache'`).
+
+- [ ] **Step 3: Implement the signature + normalization**
+
+In `modern_di/providers/factory.py`, replace the `__init__` signature and the start of its body. Change the signature (lines 34-43) to add `cache` and make `cache_settings` a sentinel-defaulted deprecated alias:
+
+```python
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        scope: enum.IntEnum = Scope.APP,
+        creator: typing.Callable[..., types.T_co],
+        bound_type: type | None | types.UnsetType = types.UNSET,
+        kwargs: dict[str, typing.Any] | None = None,
+        cache: bool | CacheSettings[types.T_co] | None = None,
+        cache_settings: CacheSettings[types.T_co] | None | types.UnsetType = types.UNSET,
+        skip_creator_parsing: bool = False,
+    ) -> None:
+        if not isinstance(cache_settings, types.UnsetType):
+            if cache is not None:
+                msg = "pass only `cache`, not both `cache` and the deprecated `cache_settings`"
+                raise TypeError(msg)
+            if cache_settings is not None:
+                warnings.warn(
+                    "`cache_settings=` is deprecated; use `cache=` "
+                    "(pass cache=True for defaults, or cache=CacheSettings(...) to tune). "
+                    "It will be removed in a future release.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            cache = cache_settings
+        if cache is True:
+            resolved_cache: CacheSettings[types.T_co] | None = CacheSettings()
+        elif cache:  # a CacheSettings instance
+            resolved_cache = cache
+        else:  # None or False
+            resolved_cache = None
+```
+
+The `CacheSettings` symbol is defined above `Factory` in the same file — no import needed. Then change the assignment (old line 74) from `self.cache_settings = cache_settings` to:
+
+```python
+        self.cache_settings = resolved_cache
+```
+
+Leave the rest of `__init__` (the `skip_creator_parsing` branch, `parse_creator`, `super().__init__`, `self._creator`, `self._kwargs`) unchanged.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `just test tests/providers/test_factory.py -k "cache_true or cache_absent or cache_falsy or cache_accepts or deprecated or none_emits or together_raise or repr_reports"`
+Expected: PASS (all 9 including the 2 parametrized).
+
+- [ ] **Step 5: Run lint + the full gated suite**
+
+Run: `just lint && just test-ci`
+Expected: lint clean; all tests pass at 100% coverage. (Pre-existing `cache_settings=` call-sites still pass — no `filterwarnings=error` is configured — they just emit `DeprecationWarning`, which Task 4 clears.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modern_di/providers/factory.py tests/providers/test_factory.py
+git commit -m "feat: add Factory(cache=...) toggle and deprecate cache_settings="
+```
+
+---
+
+### Task 2: Promote `cache=` into the `architecture/` truth home
+
+**Files:**
+- Modify: `architecture/providers.md` (signature block ~lines 35-45; the `## CacheSettings` section ~lines 84-106)
+- Modify: `architecture/containers.md` (user-facing `Factory(cache_settings=...)` spelling)
+
+**Interfaces:**
+- Consumes: the shipped `Factory(cache=...)` API from Task 1.
+- Produces: authoritative capability prose reviewers treat as truth. No code depends on this task.
+
+- [ ] **Step 1: Update the `Factory` signature block in `architecture/providers.md`**
+
+Replace the signature code block (the ```` ```python ```` block starting `Factory(` around lines 35-45) with:
+
+```python
+Factory(
+    *,
+    scope: IntEnum = Scope.APP,
+    creator: Callable[..., T],
+    bound_type: type | None = UNSET,
+    kwargs: dict[str, Any] | None = None,
+    cache: bool | CacheSettings[T] | None = None,
+    cache_settings: CacheSettings[T] | None = UNSET,  # deprecated alias of `cache`
+    skip_creator_parsing: bool = False,
+)
+```
+
+- [ ] **Step 2: Reframe the `## CacheSettings` section around `cache=`**
+
+In `architecture/providers.md`, replace the `## CacheSettings — singleton behavior` intro (the paragraph and example around lines 84-91) with prose stating: caching is opted into via the `cache` argument — `cache=True` enables it with defaults, `cache=CacheSettings(...)` tunes it (finalizer / `clear_cache`), and absent/`None`/`False` means a fresh instance each resolve. Show:
+
+```python
+providers.Factory(scope=Scope.APP, creator=Database, cache=True)
+providers.Factory(scope=Scope.APP, creator=Database, cache=providers.CacheSettings(finalizer=close))
+```
+
+Then add a short deprecation note: "`cache_settings=` is a deprecated alias of `cache` (it emits a `DeprecationWarning` and will be removed in a future release); passing both raises `TypeError`." Keep the existing `CacheSettings` field table (`clear_cache` / `finalizer` / `is_async_finalizer`) and the "Without caching, `Factory.resolve` calls the creator on every resolution" sentence — rewording the latter to reference "Without `cache`" instead of "Without `cache_settings`". Leave the `Public exports` section (`providers.CacheSettings` still exported) unchanged.
+
+- [ ] **Step 3: Update user-facing spelling in `architecture/containers.md`**
+
+Run `rg -n "cache_settings=" architecture/containers.md`. For each hit that is **user-facing API spelling** (e.g. the "A cached provider (`Factory(cache_settings=...)`)" mention around line 154), change `Factory(cache_settings=...)` to `Factory(cache=...)`. **Do not** change references to the `CacheSettings` type, its `.clear_cache` field, or the internal `.cache_settings` attribute — those names are unchanged.
+
+- [ ] **Step 4: Verify `architecture/resolution.md` needs no change**
+
+Run `rg -n "cache_settings" architecture/resolution.md`. Confirm every hit describes the **internal attribute** `self.cache_settings` or the resolve() algorithm (e.g. `if self.cache_settings and ...`). Because the attribute name is preserved, these stay correct — make no edits. (If any hit is user-facing `Factory(cache_settings=...)` API spelling, update it to `cache=`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add architecture/providers.md architecture/containers.md
+git commit -m "docs(architecture): promote cache= into the provider truth home"
+```
+
+---
+
+### Task 3: Switch `docs/` examples to the `cache=` idiom
+
+**Files (all under `docs/`, verify with the grep in Step 1):**
+- Modify: `docs/providers/factories.md`, `docs/providers/lifecycle.md`, `docs/providers/alias.md`, `docs/providers/advanced-api.md`, `docs/index.md`, `docs/introduction/about-di.md`, the integration pages (`docs/integrations/*.md`), the recipes (`docs/recipes/*.md`), the troubleshooting page (`docs/troubleshooting/scope-chain.md`), and the migration guides (`docs/migration/from-that-depends.md`, `docs/migration/to-2.x.md`).
+
+**Interfaces:**
+- Consumes: the shipped API and the deprecation contract from Task 1. No code depends on this task.
+
+- [ ] **Step 1: Inventory the call-sites**
+
+Run: `rg -n "cache_settings=" docs/`
+Expected: the ~30 doc hits listed in the design's Docs section. Keep this list to verify the sweep at the end.
+
+- [ ] **Step 2: Apply the two mechanical transformations**
+
+For each doc file, apply in this order (empty-parens first, then the general kwarg rename), handling both the `providers.CacheSettings` and bare `CacheSettings` spellings:
+
+1. Bare enable → `cache=True`:
+   - `cache_settings=providers.CacheSettings()` → `cache=True`
+   - `cache_settings=CacheSettings()` → `cache=True`
+2. Tuned (keeps the object, renames only the kwarg):
+   - `cache_settings=providers.CacheSettings(` → `cache=providers.CacheSettings(`
+   - `cache_settings=CacheSettings(` → `cache=CacheSettings(`
+
+Example transformations:
+- `docs/index.md`: `cache_settings=providers.CacheSettings(),  # one Settings for the whole app` → `cache=True,  # cache the singleton for the whole app`
+- `docs/recipes/sqlalchemy.md`: `cache_settings=providers.CacheSettings(finalizer=close_engine),` → `cache=providers.CacheSettings(finalizer=close_engine),`
+- Migration tables in `docs/migration/from-that-depends.md` (e.g. `| Singleton | providers.Factory(..., cache_settings=CacheSettings()) |`) → `| Singleton | providers.Factory(..., cache=True) |`; the `Resource` row's `cache_settings=CacheSettings(finalizer=...)` → `cache=CacheSettings(finalizer=...)`.
+
+Also update surrounding prose that names the argument (e.g. `about-di.md`'s "the presence of `cache_settings` means one shared instance" → "the presence of `cache` …"; `lifecycle.md`'s "With `cache_settings=CacheSettings()`, the provider returns the same instance" → "With `cache=True`, …"; `factories.md`'s `### cache_settings` heading and its body → `### cache`).
+
+- [ ] **Step 3: Add the deprecation note in `docs/providers/advanced-api.md`**
+
+Add a short subsection (the one place `cache_settings=` is mentioned intentionally):
+
+```markdown
+## Deprecated: `cache_settings=`
+
+`Factory(cache_settings=...)` is a deprecated alias of `cache=`. It still works but
+emits a `DeprecationWarning`; pass `cache=True` (defaults) or `cache=CacheSettings(...)`
+(tuned) instead. Passing both `cache` and `cache_settings` raises `TypeError`.
+```
+
+- [ ] **Step 4: Verify the sweep — only intentional mentions remain**
+
+Run: `rg -n "cache_settings=" docs/`
+Expected: the **only** remaining hits are intentional prose describing the deprecated alias — the new note in `docs/providers/advanced-api.md`, and any migration-guide sentence explicitly explaining the deprecation. Every code example must now read `cache=`. Fix any stragglers.
+
+- [ ] **Step 5: Verify docs render + lint**
+
+Run: `just lint-ci`
+Expected: passes (lint + planning-bundle validation). Manually skim the three highest-traffic pages (`docs/index.md`, `docs/providers/factories.md`, `docs/providers/lifecycle.md`) to confirm the examples read naturally.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/
+git commit -m "docs: switch examples to the cache= idiom and note the cache_settings deprecation"
+```
+
+---
+
+### Task 4: Dogfood the `cache=` spelling in the test suite
+
+> **Scope note (surface to the maintainer):** This goes one step beyond the design's explicit "Docs (this PR)" scope. It keeps the suite `DeprecationWarning`-free and makes the tests use the API we now recommend. Drop this task if you prefer to keep the PR strictly to the approved scope — the suite passes either way.
+
+**Files:**
+- Modify: `tests/providers/test_singleton.py` (22 sites), `tests/test_container.py` (3), `tests/providers/test_factory.py` (existing 4 sites — **not** the Task 1 additions), `tests/providers/test_alias.py` (2), `tests/providers/test_context_provider.py` (1), `tests/test_custom_scope.py` (1)
+
+**Interfaces:**
+- Consumes: the shipped API from Task 1. Keeps the Task 1 deprecation tests (`test_cache_settings_is_deprecated_but_functional`, `test_cache_settings_none_emits_no_deprecation_warning`, `test_cache_and_cache_settings_together_raise`) **using `cache_settings=`** — they are the coverage for the deprecated path and must not be migrated.
+
+- [ ] **Step 1: Apply the same two transformations to the test files**
+
+Apply the Task 3 Step 2 transformations to the test files listed above:
+- `cache_settings=providers.CacheSettings()` → `cache=True`
+- `cache_settings=providers.CacheSettings(` → `cache=providers.CacheSettings(`
+
+**Exclude** the three deprecation tests added in Task 1 — they intentionally exercise `cache_settings=`.
+
+- [ ] **Step 2: Verify only the deprecation tests still use `cache_settings=`**
+
+Run: `rg -n "cache_settings=" tests/`
+Expected: hits only inside `test_cache_settings_is_deprecated_but_functional`, `test_cache_settings_none_emits_no_deprecation_warning`, and `test_cache_and_cache_settings_together_raise` in `tests/providers/test_factory.py`. Everything else reads `cache=`.
+
+- [ ] **Step 3: Run the full gated suite**
+
+Run: `just test-ci`
+Expected: PASS at 100% coverage. The suite now emits no `DeprecationWarning` from its own provider declarations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/
+git commit -m "test: dogfood the cache= spelling across the suite"
+```
+
+---
+
+## Finalize the bundle (before opening the PR)
+
+- [ ] Finalize the `summary:` line in `planning/changes/2026-07-04.01-factory-cache-arg/design.md` to state the realized result.
+- [ ] Run `just check-planning` and `just lint-ci` one final time.
+- [ ] Push the branch and open a PR (never local-merge); watch CI. Add a `planning/releases/<next-version>.md` note only when cutting the release (separate, tag-driven flow).

--- a/planning/decisions/2026-07-04-cache-arg-over-singleton-class.md
+++ b/planning/decisions/2026-07-04-cache-arg-over-singleton-class.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+summary: Chose `Factory(cache=bool|CacheSettings)` over a `Singleton` class, a `cached=` flag, or `cache_settings=True`.
+supersedes: null
+superseded_by: null
+---
+
+# Ergonomic caching toggle: `cache=` argument, not a `Singleton` class
+
+**Decision:** Make `Factory`'s caching toggle a single `cache` argument accepting
+`bool | CacheSettings | None`, deprecating the `cache_settings=` alias — rather
+than reintroducing a `Singleton` provider class, adding a separate `cached=True`
+flag, or overloading the old `cache_settings=` to accept `True`.
+
+## Context
+
+`cache_settings=providers.CacheSettings()` is verbose for the common "just cache
+it" case. A cross-framework survey found modern-di in the least ergonomic bucket
+(a construction-time settings object); the ergonomic patterns are verb-level
+(Koin `single {}`, .NET `AddSingleton<T>()`) or a distinct `Singleton` class
+(dependency-injector, that-depends). Options considered:
+
+1. **`Singleton` provider class** — a thin `Factory` preset with caching on.
+2. **`cached=True` flag** — new boolean arg alongside `cache_settings=`.
+3. **`cache_settings=True`** — overload the existing arg to accept a bool.
+4. **`cache=` argument** (chosen) — rename to `cache`, accept
+   `bool | CacheSettings | None`, deprecate `cache_settings=`.
+
+## Decision & rationale
+
+`cache=` collapses caching onto one axis: absent/`None`/`False` off, `True` on
+with defaults, `CacheSettings(...)` on and tuned. One argument, one mental model,
+one place caching is expressed.
+
+- **Rejected `Singleton` class.** It expresses "caching is on" in two places —
+  the class name *and* a still-required `cache_settings` for finalizers (the most
+  common advanced case). Those two can drift, and forbidding `cache_settings` on
+  a `Singleton` would strand finalizers. It also reverses the 2.x "no separate
+  `Singleton` class" decision. A single `cache` axis has neither problem.
+- **Rejected `cached=True` flag.** Two arguments both meaning "cache" requires a
+  both-passed conflict rule and gives `cached=True` no path to a finalizer
+  without switching forms — the same two-places-can-drift smell.
+- **Rejected `cache_settings=True`.** Works and needs no new name, but the noun-y
+  argument reads wrong (`settings=True`). Renaming to `cache` keeps the
+  single-axis model *and* reads naturally in both forms (`cache=True` /
+  `cache=CacheSettings(...)`); the deprecation is a soft warn-only alias.
+
+`CacheSettings` is retained unchanged as the tuning object; only the entry point
+gets sugar. Internals are untouched — the sugar normalizes into the existing
+`self.cache_settings` attribute in `__init__`.
+
+## Revisit trigger
+
+Reopen if the `cache_settings=` deprecation is scheduled for removal (a major
+release), or if a caching mode arises that a single `bool | CacheSettings`
+argument cannot express cleanly.

--- a/tests/providers/test_alias.py
+++ b/tests/providers/test_alias.py
@@ -21,7 +21,7 @@ class PostgresRepository(AbstractRepository):
 
 
 class MyGroup(Group):
-    repo = providers.Factory(creator=PostgresRepository, cache_settings=providers.CacheSettings())
+    repo = providers.Factory(creator=PostgresRepository, cache=True)
     abstract_repo = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository)
 
 
@@ -166,7 +166,7 @@ class _ChainIfB: ...
 
 
 class _ChainGroup(Group):
-    impl = providers.Factory(scope=Scope.APP, creator=_ChainImpl, cache_settings=providers.CacheSettings())
+    impl = providers.Factory(scope=Scope.APP, creator=_ChainImpl, cache=True)
     if_a = providers.Alias(source_type=_ChainImpl, bound_type=_ChainIfA)
     if_b = providers.Alias(source_type=_ChainIfA, bound_type=_ChainIfB)
 

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -261,7 +261,7 @@ class _CachedCtxSvc:
 
 class _CachedCtxGroup(Group):
     ctx = providers.ContextProvider(scope=Scope.APP, context_type=_CrossCtx)
-    svc = providers.Factory(scope=Scope.APP, creator=_CachedCtxSvc, cache_settings=providers.CacheSettings())
+    svc = providers.Factory(scope=Scope.APP, creator=_CachedCtxSvc, cache=True)
 
 
 def test_late_context_does_not_rebuild_cached_singleton() -> None:

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -645,3 +645,72 @@ def test_nested_then_direct_resolve_does_not_leak_parent_breadcrumb() -> None:
         assert "Parent2" not in leaf_err, f"Parent2 leaked into leaf error: {leaf_err!r}"
     else:
         pytest.fail("Expected ResolutionError when resolving _Leaf2 directly")  # pragma: no cover
+
+
+def test_cache_true_returns_same_instance() -> None:
+    class G(Group):
+        f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=True)
+
+    container = Container(groups=[G])
+    assert container.resolve_provider(G.f) is container.resolve_provider(G.f)
+    assert isinstance(G.f.cache_settings, providers.CacheSettings)
+
+
+def test_cache_absent_returns_fresh_instances() -> None:
+    class G(Group):
+        f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"})
+
+    container = Container(groups=[G])
+    assert container.resolve_provider(G.f) is not container.resolve_provider(G.f)
+    assert G.f.cache_settings is None
+
+
+@pytest.mark.parametrize("cache_value", [False, None])
+def test_cache_falsy_disables_caching(cache_value: bool | None) -> None:
+    class G(Group):
+        f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=cache_value)
+
+    container = Container(groups=[G])
+    assert container.resolve_provider(G.f) is not container.resolve_provider(G.f)
+    assert G.f.cache_settings is None
+
+
+def test_cache_accepts_cache_settings_and_finalizes() -> None:
+    cleaned: list[object] = []
+
+    class G(Group):
+        f = providers.Factory(creator=dict, cache=providers.CacheSettings(finalizer=cleaned.append))
+
+    container = Container(groups=[G])
+    instance = container.resolve_provider(G.f)
+    assert container.resolve_provider(G.f) is instance
+    container.close_sync()
+    assert cleaned == [instance]
+
+
+def test_cache_settings_is_deprecated_but_functional() -> None:
+    with pytest.warns(DeprecationWarning, match="cache_settings"):
+        provider = providers.Factory(
+            creator=SimpleCreator, kwargs={"dep1": "x"}, cache_settings=providers.CacheSettings()
+        )
+    container = Container()
+    assert container.resolve_provider(provider) is container.resolve_provider(provider)
+
+
+def test_cache_settings_none_emits_no_deprecation_warning() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        provider = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache_settings=None)
+    assert provider.cache_settings is None
+
+
+def test_cache_and_cache_settings_together_raise() -> None:
+    with pytest.raises(TypeError, match="pass only `cache`"):
+        providers.Factory(
+            creator=SimpleCreator, kwargs={"dep1": "x"}, cache=True, cache_settings=providers.CacheSettings()
+        )
+
+
+def test_repr_reports_cached_for_cache_true() -> None:
+    provider = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=True)
+    assert "cached=True" in repr(provider)

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -242,7 +242,7 @@ def test_factory_repr() -> None:
 
 
 def test_factory_repr_cached() -> None:
-    provider = providers.Factory(creator=str, scope=Scope.APP, cache_settings=providers.CacheSettings())
+    provider = providers.Factory(creator=str, scope=Scope.APP, cache=True)
     assert repr(provider) == "Factory(creator=<class 'str'>, scope=<Scope.APP: 1>, cached=True)"
 
 
@@ -394,12 +394,12 @@ class _FlakyGroup(Group):
     dep = providers.Factory(
         scope=Scope.APP,
         creator=_FlakyDep,
-        cache_settings=providers.CacheSettings(finalizer=lambda _: _flaky_events.append("dep")),
+        cache=providers.CacheSettings(finalizer=lambda _: _flaky_events.append("dep")),
     )
     svc = providers.Factory(
         scope=Scope.APP,
         creator=_FlakySvc,
-        cache_settings=providers.CacheSettings(finalizer=lambda _: _flaky_events.append("svc")),
+        cache=providers.CacheSettings(finalizer=lambda _: _flaky_events.append("svc")),
     )
 
 
@@ -543,7 +543,7 @@ def test_skip_creator_parsing_missing_args_cached_raises_di_error() -> None:
         bound_type=int,
         skip_creator_parsing=True,
         kwargs={"a": 1},
-        cache_settings=providers.CacheSettings(),
+        cache=True,
     )
     container = Container(scope=Scope.APP)
     container.providers_registry.register(int, factory)

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -28,10 +28,10 @@ class MyGroup(Group):
     app_singleton = providers.Factory(
         creator=SimpleCreator,
         kwargs={"dep1": "original"},
-        cache_settings=providers.CacheSettings(),
+        cache=True,
     )
     request_singleton = providers.Factory(
-        scope=Scope.REQUEST, creator=DependentCreator, cache_settings=providers.CacheSettings(finalizer=async_finalizer)
+        scope=Scope.REQUEST, creator=DependentCreator, cache=providers.CacheSettings(finalizer=async_finalizer)
     )
 
 
@@ -42,7 +42,7 @@ async def test_app_singleton() -> None:
         singleton = providers.Factory(
             creator=SimpleCreator,
             kwargs={"dep1": "original"},
-            cache_settings=providers.CacheSettings(clear_cache=False, finalizer=sync_calls.append),
+            cache=providers.CacheSettings(clear_cache=False, finalizer=sync_calls.append),
         )
 
     app_container = Container(groups=[LocalGroup])
@@ -72,7 +72,7 @@ def test_close_does_not_re_finalize_with_clear_cache_false() -> None:
         f = providers.Factory(
             creator=lambda: "r",
             bound_type=str,
-            cache_settings=providers.CacheSettings(clear_cache=False, finalizer=calls.append),
+            cache=providers.CacheSettings(clear_cache=False, finalizer=calls.append),
         )
 
     container = Container(groups=[G])
@@ -90,7 +90,7 @@ def test_closed_container_refuses_re_resolve_with_clear_cache_true() -> None:
         f = providers.Factory(
             creator=lambda: "r",
             bound_type=str,
-            cache_settings=providers.CacheSettings(clear_cache=True, finalizer=calls.append),
+            cache=providers.CacheSettings(clear_cache=True, finalizer=calls.append),
         )
 
     container = Container(groups=[G])
@@ -110,7 +110,7 @@ async def test_close_async_runs_sync_finalizer() -> None:
         f = providers.Factory(
             creator=lambda: "r",
             bound_type=str,
-            cache_settings=providers.CacheSettings(finalizer=calls.append),
+            cache=providers.CacheSettings(finalizer=calls.append),
         )
 
     container = Container(groups=[G])
@@ -172,13 +172,13 @@ def test_sync_finalizer_exception_does_not_abort_remaining_cleanup() -> None:
         first = providers.Factory(
             creator=SimpleCreator,
             kwargs={"dep1": "first"},
-            cache_settings=providers.CacheSettings(finalizer=failing_finalizer),
+            cache=providers.CacheSettings(finalizer=failing_finalizer),
         )
         second = providers.Factory(
             creator=SimpleCreator,
             bound_type=None,
             kwargs={"dep1": "second"},
-            cache_settings=providers.CacheSettings(finalizer=good_finalizer),
+            cache=providers.CacheSettings(finalizer=good_finalizer),
         )
 
     app_container = Container(groups=[BrokenGroup])
@@ -207,13 +207,13 @@ async def test_async_finalizer_exception_does_not_abort_remaining_cleanup() -> N
         first = providers.Factory(
             creator=SimpleCreator,
             kwargs={"dep1": "first"},
-            cache_settings=providers.CacheSettings(finalizer=failing_finalizer),
+            cache=providers.CacheSettings(finalizer=failing_finalizer),
         )
         second = providers.Factory(
             creator=SimpleCreator,
             bound_type=None,
             kwargs={"dep1": "second"},
-            cache_settings=providers.CacheSettings(finalizer=good_finalizer),
+            cache=providers.CacheSettings(finalizer=good_finalizer),
         )
 
     app_container = Container(groups=[BrokenAsyncGroup])
@@ -237,7 +237,7 @@ def test_finalizer_runs_for_falsy_cached_resource_sync() -> None:
     class FalsyGroup(Group):
         empty_dict = providers.Factory(
             creator=dict,
-            cache_settings=providers.CacheSettings(finalizer=collect),
+            cache=providers.CacheSettings(finalizer=collect),
         )
 
     app_container = Container(groups=[FalsyGroup])
@@ -257,7 +257,7 @@ async def test_finalizer_runs_for_falsy_cached_resource_async() -> None:
     class FalsyGroup(Group):
         empty_list = providers.Factory(
             creator=list,
-            cache_settings=providers.CacheSettings(finalizer=collect),
+            cache=providers.CacheSettings(finalizer=collect),
         )
 
     app_container = Container(groups=[FalsyGroup])
@@ -283,7 +283,7 @@ def test_cached_none_is_returned_and_finalized() -> None:
     class NoneGroup(Group):
         none_resource = providers.Factory(
             creator=create_none,
-            cache_settings=providers.CacheSettings(finalizer=collect),
+            cache=providers.CacheSettings(finalizer=collect),
         )
 
     app_container = Container(groups=[NoneGroup])
@@ -309,7 +309,7 @@ def test_singleton_threading_concurrency() -> None:
         time.sleep(0.01)
         return ""
 
-    singleton = providers.Factory(creator=create_singleton, cache_settings=providers.CacheSettings())
+    singleton = providers.Factory(creator=create_singleton, cache=True)
 
     def resolve_singleton(container: Container) -> str:
         return container.resolve_provider(singleton)
@@ -348,17 +348,17 @@ class _LifoGroup(Group):
     leaf = providers.Factory(
         scope=Scope.APP,
         creator=_LifoLeaf,
-        cache_settings=providers.CacheSettings(finalizer=lambda _: _lifo_events.append("leaf")),
+        cache=providers.CacheSettings(finalizer=lambda _: _lifo_events.append("leaf")),
     )
     mid = providers.Factory(
         scope=Scope.APP,
         creator=_LifoMid,
-        cache_settings=providers.CacheSettings(finalizer=lambda _: _lifo_events.append("mid")),
+        cache=providers.CacheSettings(finalizer=lambda _: _lifo_events.append("mid")),
     )
     top = providers.Factory(
         scope=Scope.APP,
         creator=_LifoTop,
-        cache_settings=providers.CacheSettings(finalizer=lambda _: _lifo_events.append("top")),
+        cache=providers.CacheSettings(finalizer=lambda _: _lifo_events.append("top")),
     )
 
 
@@ -380,8 +380,8 @@ def test_singleton_resolution_is_reentrant() -> None:
             self.inner = container.resolve(Inner)
 
     class ReentrantGroup(Group):
-        inner = providers.Factory(creator=Inner, cache_settings=providers.CacheSettings())
-        outer = providers.Factory(creator=Outer, cache_settings=providers.CacheSettings())
+        inner = providers.Factory(creator=Inner, cache=True)
+        outer = providers.Factory(creator=Outer, cache=True)
 
     container = Container(groups=[ReentrantGroup])
     result: list[Outer] = []
@@ -416,7 +416,7 @@ class _AwaitableFinGroup(Group):
     svc = providers.Factory(
         scope=Scope.APP,
         creator=_AwaitableFinSvc,
-        cache_settings=providers.CacheSettings(finalizer=lambda obj: _real_cleanup(obj)),  # noqa: PLW0108
+        cache=providers.CacheSettings(finalizer=lambda obj: _real_cleanup(obj)),  # noqa: PLW0108
     )
 
 
@@ -452,14 +452,12 @@ class _CycleGroup(Group):
     broker = providers.Factory(
         scope=Scope.APP,
         creator=_PersistentBroker,
-        cache_settings=providers.CacheSettings(
-            clear_cache=False, finalizer=lambda _: _cycle_events.append("broker-finalized")
-        ),
+        cache=providers.CacheSettings(clear_cache=False, finalizer=lambda _: _cycle_events.append("broker-finalized")),
     )
     svc = providers.Factory(
         scope=Scope.APP,
         creator=_EphemeralSvc,
-        cache_settings=providers.CacheSettings(),  # clear_cache=True default
+        cache=True,  # clear_cache=True default
     )
 
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -74,7 +74,7 @@ def test_container_sync_context_manager() -> None:
         resource = providers.Factory(
             creator=lambda: "r",
             bound_type=str,
-            cache_settings=providers.CacheSettings(finalizer=cleaned_up.append),
+            cache=providers.CacheSettings(finalizer=cleaned_up.append),
         )
 
     with Container(groups=[G]) as container:
@@ -95,7 +95,7 @@ async def test_container_async_context_manager() -> None:
         resource = providers.Factory(
             creator=lambda: "r",
             bound_type=str,
-            cache_settings=providers.CacheSettings(finalizer=collect),
+            cache=providers.CacheSettings(finalizer=collect),
         )
 
     async with Container(groups=[G]) as container:
@@ -383,7 +383,7 @@ class _PersistentBroker: ...
 
 class _AppBrokerGroup(Group):
     broker = providers.Factory(
-        scope=Scope.APP, creator=_PersistentBroker, cache_settings=providers.CacheSettings(clear_cache=False)
+        scope=Scope.APP, creator=_PersistentBroker, cache=providers.CacheSettings(clear_cache=False)
     )
 
 

--- a/tests/test_custom_scope.py
+++ b/tests/test_custom_scope.py
@@ -92,7 +92,7 @@ def test_caching_isolated_across_tenant_containers() -> None:
         svc = providers.Factory(
             scope=MyScope.TENANT,
             creator=TenantService,
-            cache_settings=providers.CacheSettings(),
+            cache=True,
         )
 
     app_container = Container(groups=[TenantGroup])


### PR DESCRIPTION
## Summary

Enabling singleton caching on a `Factory` no longer requires constructing an empty settings object. The common case is now `cache=True`:

```python
providers.Factory(scope=Scope.APP, creator=Database, cache=True)                         # cached, defaults
providers.Factory(scope=Scope.APP, creator=Database, cache=providers.CacheSettings(finalizer=close))  # cached, tuned
providers.Factory(scope=Scope.APP, creator=Database)                                     # fresh each resolve
```

The `cache` argument carries the whole caching spectrum on one axis (`bool | CacheSettings | None`). `cache_settings=` becomes a warn-only **deprecated alias**; passing both raises `TypeError`. `CacheSettings` and its fields are unchanged.

## Why

A cross-framework survey put modern-di in the least ergonomic bucket for this toggle (a construction-time settings object). Both closest Python peers — including `that-depends`, which we ship a migration guide from — express it at verb level. `cache=True` matches that muscle memory while keeping the single "one universal `Factory`" model (no `Singleton` class). See the decision record for why `cache=` beat the `Singleton`-class / `cached=` / `cache_settings=True` alternatives.

## Design

All sugar lives in `Factory.__init__`: the `cache` input normalizes once into the existing internal `self.cache_settings` attribute (still `CacheSettings | None`), so `resolve()`, the cache registry, and `__repr__` are untouched. Fully backward compatible.

- Spec: `planning/changes/2026-07-04.01-factory-cache-arg/design.md`
- Decision: `planning/decisions/2026-07-04-cache-arg-over-singleton-class.md`

## Changes

- **Core:** `Factory(cache=...)` + normalization + `cache_settings=` deprecation, with full TDD coverage of every branch (both-passed `TypeError`, deprecated-warns, explicit-`None`-no-warn, `True`/`CacheSettings`/`False`/`None`).
- **`architecture/`:** promoted `cache=` into the provider truth home.
- **`docs/`:** swept ~17 example pages + migration tables to the `cache=` idiom; added a deprecation note in `advanced-api.md`.
- **Tests/benchmarks:** dogfooded the `cache=` spelling; kept dedicated deprecation-path tests.

## Verification

- `just test-ci`: 246 passed, **100% line coverage**
- `just lint-ci`: ruff format + ruff check + `ty` + planning index all pass
- `just docs-build --strict`: clean
- `just test -W error::DeprecationWarning`: no `DeprecationWarning` leaks from the suite's own declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)