### PR TITLE
docs: accuracy + integration-parity pass

### DIFF
--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -69,6 +69,14 @@ child regardless of which handler ultimately serves it.
 
 A WebSocket handler runs for the whole life of the socket, so its `Scope.SESSION`
 container does too. Read the connection with `FromDI(aiohttp_websocket_provider)`.
+
+Unlike FastAPI and Litestar, aiohttp has no separate WebSocket object — a
+WebSocket is an upgraded `web.Request`. So `aiohttp_websocket_provider` binds
+`web.Request` too, and is declared `bound_type=None` (not resolvable by type,
+because `aiohttp_request_provider` already owns `web.Request`). That is why you
+wire it **explicitly** with `FromDI(aiohttp_websocket_provider)` rather than by
+type annotation.
+
 For per-message work, open a nested `Scope.REQUEST` child of the session
 container, fetched via `fetch_request_container`:
 
@@ -94,3 +102,15 @@ async def ws_handler(
                 ...  # resolve REQUEST-scoped providers for this message
     return ws
 ```
+
+## API
+
+| Symbol | Description |
+|---|---|
+| `setup_di(app, container)` | Opens the root container on startup, closes it on cleanup, and installs the middleware that builds a per-connection child container; returns the container. |
+| `FromDI(dependency)` | Marker (used with `@inject`) that resolves a provider or type from the per-connection child container. |
+| `inject` | Decorator for an `async def handler(request: web.Request, ...)`; resolves its `FromDI`-annotated parameters. |
+| `fetch_di_container(app)` | Returns the root `Container` stored on the app. |
+| `fetch_request_container(request)` | Returns the per-connection child container the middleware built (REQUEST for HTTP, SESSION for a WebSocket). |
+| `aiohttp_request_provider` | `ContextProvider` for `web.Request` (REQUEST scope), auto-registered by type. |
+| `aiohttp_websocket_provider` | `ContextProvider` for the WebSocket connection's `web.Request` (SESSION scope), `bound_type=None` — resolve via `FromDI(aiohttp_websocket_provider)`. |

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -70,7 +70,7 @@ child regardless of which handler ultimately serves it.
 A WebSocket handler runs for the whole life of the socket, so its `Scope.SESSION`
 container does too. Read the connection with `FromDI(aiohttp_websocket_provider)`.
 
-Unlike FastAPI and Litestar, aiohttp has no separate WebSocket object — a
+Unlike FastAPI, Litestar, and Starlette, aiohttp has no separate WebSocket object — a
 WebSocket is an upgraded `web.Request`. So `aiohttp_websocket_provider` binds
 `web.Request` too, and is declared `bound_type=None` (not resolvable by type,
 because `aiohttp_request_provider` already owns `web.Request`). That is why you

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -73,6 +73,7 @@ async def read_root(
 Usually our application uses only two scopes: `APP` and `REQUEST`.
 
 But when websockets are used, `SESSION` scope is used as well:
+
 - for the lifetime of websocket-connection we have `SESSION` scope
 - for each message we have `REQUEST` scope
 
@@ -112,6 +113,7 @@ Framework-specific context objects like `fastapi.Request` and `fastapi.WebSocket
 You can reference these context providers in your factories either implicitly through type annotations or explicitly by importing them.
 
 The following context providers are available for import:
+
 - `fastapi_request_provider` - Provides the current `fastapi.Request` object
 - `fastapi_websocket_provider` - Provides the current `fastapi.WebSocket` object
 

--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -99,6 +99,7 @@ If the same attribute name appears in multiple groups, a `UserWarning` is emitte
 Usually our application uses only two scopes: `APP` and `REQUEST`.
 
 But when websockets are used, `SESSION` scope is used as well:
+
 - for the lifetime of websocket-connection we have `SESSION` scope
 - for each message we have `REQUEST` scope
 
@@ -150,6 +151,7 @@ Framework-specific context objects like `litestar.Request` and `litestar.WebSock
 You can reference these context providers in your factories either implicitly through type annotations or explicitly by importing them.
 
 The following context providers are available for import:
+
 - `litestar_request_provider` - Provides the current `litestar.Request` object
 - `litestar_websocket_provider` - Provides the current `litestar.WebSocket` object
 

--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -206,3 +206,13 @@ class AppGroup(Group):
         kwargs={"request": modern_di_litestar.litestar_request_provider}
     )
 ```
+
+## API
+
+| Symbol | Description |
+|---|---|
+| `ModernDIPlugin(container, autowired_groups=None)` | Litestar `InitPlugin` that registers the container, composes the lifespan, and (if `autowired_groups` is given) exposes each provider in those groups as a Litestar dependency keyed by attribute name. |
+| `FromDI(dependency)` | Returns a Litestar `Provide` that resolves a provider or type from the per-request child container. |
+| `fetch_di_container(app)` | Returns the root `Container` stored on the Litestar app. |
+| `litestar_request_provider` | `ContextProvider` for `litestar.Request` (REQUEST scope), auto-registered. |
+| `litestar_websocket_provider` | `ContextProvider` for `litestar.WebSocket` (SESSION scope), auto-registered. |

--- a/docs/integrations/starlette.md
+++ b/docs/integrations/starlette.md
@@ -61,3 +61,91 @@ setup_di(app, Container(groups=[AppGroup], validate=True))
 An HTTP request opens a `Scope.REQUEST` child container; a WebSocket connection
 opens a `Scope.SESSION` one. Providers resolve from the connection's child
 container, so `Scope.REQUEST` providers live for exactly one request.
+
+The `Scope.SESSION` child for a WebSocket connection is entered automatically —
+the middleware builds it before your handler runs, and it stays open for the
+whole life of the connection.
+
+## Websockets
+
+A WebSocket connection opens a `Scope.SESSION` child container automatically and
+keeps it for the whole connection. For per-message work, open a nested
+`Scope.REQUEST` child of that session container:
+
+```python
+import typing
+
+import modern_di
+from modern_di import Scope, providers
+from modern_di_starlette import FromDI, inject
+from starlette.websockets import WebSocket
+
+
+@inject
+async def ws_handler(
+    websocket: WebSocket,
+    container: typing.Annotated[modern_di.Container, FromDI(providers.container_provider)],
+) -> None:
+    await websocket.accept()
+    async for message in websocket.iter_text():
+        async with container.build_child_container(scope=Scope.REQUEST) as request_container:
+            ...  # resolve REQUEST-scoped providers for this message
+```
+
+## Framework Context Objects
+
+Framework-specific context objects like `starlette.requests.Request` and
+`starlette.websockets.WebSocket` are automatically made available by the
+integration. You can reference these context providers implicitly through type
+annotations or explicitly by importing them.
+
+The following context providers are available for import:
+
+- `starlette_request_provider` — the current `starlette.requests.Request` (REQUEST scope)
+- `starlette_websocket_provider` — the current `starlette.websockets.WebSocket` (SESSION scope)
+
+### Implicit Usage (Type-based Resolution)
+
+```python
+from starlette.requests import Request
+from modern_di import Group, Scope, providers
+
+
+def create_request_info(request: Request) -> dict[str, str]:
+    return {"method": request.method, "url": str(request.url)}
+
+
+class AppGroup(Group):
+    request_info = providers.Factory(scope=Scope.REQUEST, creator=create_request_info)
+```
+
+### Explicit Usage (Provider-based Resolution)
+
+```python
+import modern_di_starlette
+from starlette.requests import Request
+from modern_di import Group, Scope, providers
+
+
+def create_request_info(request: Request) -> dict[str, str]:
+    return {"method": request.method, "url": str(request.url)}
+
+
+class AppGroup(Group):
+    request_info = providers.Factory(
+        scope=Scope.REQUEST,
+        creator=create_request_info,
+        kwargs={"request": modern_di_starlette.starlette_request_provider},
+    )
+```
+
+## API
+
+| Symbol | Description |
+|---|---|
+| `setup_di(app, container)` | Registers the container on `app.state`, composes the lifespan (opens/closes the container), and installs the middleware that builds a per-connection child container; returns the container. |
+| `FromDI(dependency)` | Marker (used with `@inject`) that resolves a provider or type from the per-connection child container. |
+| `inject` | Decorator for an `async def handler(connection: Request \| WebSocket, ...)`; resolves its `FromDI`-annotated parameters. |
+| `fetch_di_container(app)` | Returns the root `Container` stored on `app.state`. |
+| `starlette_request_provider` | `ContextProvider` for `starlette.requests.Request` (REQUEST scope), auto-registered. |
+| `starlette_websocket_provider` | `ContextProvider` for `starlette.websockets.WebSocket` (SESSION scope), auto-registered. |

--- a/docs/integrations/starlette.md
+++ b/docs/integrations/starlette.md
@@ -145,7 +145,7 @@ class AppGroup(Group):
 |---|---|
 | `setup_di(app, container)` | Registers the container on `app.state`, composes the lifespan (opens/closes the container), and installs the middleware that builds a per-connection child container; returns the container. |
 | `FromDI(dependency)` | Marker (used with `@inject`) that resolves a provider or type from the per-connection child container. |
-| `inject` | Decorator for an `async def handler(connection: Request \| WebSocket, ...)`; resolves its `FromDI`-annotated parameters. |
+| `inject` | Decorator for an `async def handler(connection: Request | WebSocket, ...)`; resolves its `FromDI`-annotated parameters. |
 | `fetch_di_container(app)` | Returns the root `Container` stored on `app.state`. |
 | `starlette_request_provider` | `ContextProvider` for `starlette.requests.Request` (REQUEST scope), auto-registered. |
 | `starlette_websocket_provider` | `ContextProvider` for `starlette.websockets.WebSocket` (SESSION scope), auto-registered. |

--- a/docs/introduction/about-di.md
+++ b/docs/introduction/about-di.md
@@ -202,7 +202,8 @@ with app_container.build_child_container(scope=Scope.REQUEST) as request_contain
 
 ### 5. Framework Integrations
 
-Works with FastAPI, Litestar, FastStream:
+Works with [every official framework integration](comparison.md#the-landscape).
+For example, with FastAPI:
 
 ```python
 from modern_di_fastapi import FromDI

--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -30,9 +30,9 @@ aiohttp, FastAPI, Litestar, FastStream, Starlette, and Typer.**
 
 | | modern-di | Dishka | dependency-injector | injector | FastAPI `Depends` |
 |---|---|---|---|---|---|
-| Style | type-based autowiring | type-based, provider classes | declarative containers + markers | Guice-style `@inject` | callable-based |
-| Scopes | APP→…→STEP (fixed chain) | RUNTIME→…→STEP (+ custom) | lifetimes (Singleton/Factory/Resource) | Singleton / Thread / None | request only |
-| Resolution | sync (by design) | sync + async | sync + async | sync | async |
+| Style | type-based autowiring | type-based autowiring (provider classes) | declarative containers + markers | Guice-style `@inject` | callable-based |
+| Scopes | APP→…→STEP + any IntEnum | RUNTIME→…→STEP (+ custom) | lifetimes (Singleton/Factory/Resource) | Singleton / Thread / None | request only |
+| Resolution | sync (async finalizers supported) | sync + async | sync + async | sync | async |
 | First-party pytest plugin | ✅ | ✘ | ✘ | ✘ | n/a |
 | Official integrations | 7 (aiohttp, FastAPI, Litestar, FastStream, Starlette, Typer, pytest) | ~20+ | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
 | Typed resolution | ✅ | ✅ | partial | ✅ | callable-keyed |
@@ -45,7 +45,7 @@ aiohttp, FastAPI, Litestar, FastStream, Starlette, and Typer.**
 
 Dishka is the closest library to modern-di — also typed, also scopes-first, also
 integrating with FastAPI/Litestar/FastStream — and it's more established, with
-many more integrations and a larger community. If you need **arbitrary custom
+many more integrations and a larger community. If you need **arbitrary *named*
 scopes**, **async resolution**, or an integration modern-di doesn't have yet
 (aiogram, Taskiq, gRPC, …), Dishka is an excellent choice.
 
@@ -53,9 +53,11 @@ modern-di's deliberate differences:
 
 - **A first-party pytest plugin** (`modern-di-pytest`) that turns any dependency
   into a fixture — Dishka has no built-in pytest integration yet.
-- **Sync-only resolution and a small, fixed scope chain** — a simpler model.
-  Dishka's own docs note that custom scopes are "hardly ever needed," which is
-  the honest case for modern-di's simpler design.
+- **Sync-only *resolution* (async finalizers still supported) and a small,
+  built-in scope chain you can still extend with any `IntEnum`** — a simpler
+  model. Dishka's own docs note that custom scopes are "hardly ever needed,"
+  which is the honest case for modern-di's simpler design. See
+  [Custom scopes](../providers/scopes.md#custom-scopes).
 - **All-official, uniformly-maintained integrations** under a single MIT-licensed
   project, as part of the broader [modern-python](https://github.com/modern-python)
   stack.

--- a/docs/introduction/design-decisions.md
+++ b/docs/introduction/design-decisions.md
@@ -4,7 +4,7 @@
 
 ## 1. Resolution is sync only
 
-Since 2.x, `Container.resolve(...)` and `resolve_provider(...)` are synchronous. There is no `await container.resolve(...)`, no `AsyncFactory`, no `AsyncSingleton`. Async work belongs in the framework's lifespan and per-request hooks; the container holds the already-constructed objects (see [Async resources via lifespan](../recipes/async-lifespan.md)).
+Since 2.x, `Container.resolve(...)` and `resolve_provider(...)` are synchronous. There is no `await container.resolve(...)`, no `AsyncFactory`, no `AsyncSingleton`. Async work belongs in the framework's lifespan and per-request hooks; the container holds the already-constructed objects (see [Async resources via lifespan](../recipes/async-lifespan.md)). Resolution being sync does not mean teardown is: finalizers may be sync or async (`close_sync` / `close_async`), so async cleanup is fully supported.
 
 This is a permanent choice, not a temporary limitation. There are no plans to reintroduce async resolution.
 
@@ -16,8 +16,15 @@ Cached `Factory` providers use a per-container reentrant lock (`threading.RLock`
 
 - **Cached / singleton creation is locked.** The per-container reentrant lock guards the create-and-store step, so two threads racing to resolve the same cached provider get the same single instance.
 - **Provider registration is safe.** `ProvidersRegistry` mutations (`register`, `add_providers`) are guarded by the registry's own lock, and iteration snapshots the provider dict (`iter(list(...))`), so registering providers concurrently — or while another thread iterates — will not corrupt the registry or raise "dict changed size during iteration".
-- **Intended usage still holds.** Register all providers and groups *before* serving concurrent resolutions. The registry guards keep concurrent registration from corrupting state, but a clean register-then-serve phase ordering is the supported model; resolving a type whose provider is registered mid-flight is racy by nature.
-- **`set_context` and overrides are last-write-wins.** They are not synchronized for ordering across threads — the most recent write wins, with no merge or queueing. Set context and configure overrides during setup (or per-request, on a request-local child container), not from competing threads.
+- **Registration is a setup phase, not a coordination tool.** The registry is
+  lock-guarded against corruption, but the supported model is register every
+  provider *before* serving. Registering a provider while other threads are
+  already resolving is timing-dependent by nature — nothing breaks, but whether
+  a given resolve sees the new provider is undefined.
+- **`set_context` and overrides are last-write-wins.** Both write into a
+  per-container dict with no ordering, queueing, or merge; concurrent writes to
+  the same key keep whichever landed last. Do them during setup, or per-request
+  on a request-local child container — never from competing threads.
 
 ## 3. No global state
 

--- a/docs/introduction/that-depends-or-modern-di.md
+++ b/docs/introduction/that-depends-or-modern-di.md
@@ -20,11 +20,16 @@ choose.
 | | that-depends | modern-di |
 |---|---|---|
 | Status | actively maintained, production-proven | recommended for new projects |
-| Resolution | async + sync (`AsyncFactory`, `await resolve`) | sync only (by design) |
+| Resolution | async + sync (`AsyncFactory`, `await resolve`) | sync resolution (async finalizers supported) |
 | Container model | the container class is both schema and runtime | `Group` (schema) and `Container` (runtime) are separate |
 | Scopes | context-based lifetimes | explicit, enforced scope chain (APP→…→STEP) |
 | Global state | resolves directly from the container class | none — you create and pass containers explicitly |
 | Integrations | bundled | separate adapter packages (install only what you need) |
+
+!!! note "\"Sync only\" means resolution, not teardown"
+    modern-di resolves synchronously, but finalizers may be sync **or** async
+    (`close_sync` / `close_async`), so async resource cleanup is fully
+    supported. See [Lifecycle](../providers/lifecycle.md).
 
 ## Choose that-depends if…
 

--- a/docs/migration/to-1.x.md
+++ b/docs/migration/to-1.x.md
@@ -9,6 +9,7 @@ This document describes the changes required to migrate from modern-di 0.x versi
 ## Overview
 
 The migration to modern-di 1.x involves several key changes in the API, including:
+
 - Updated import paths and class names
 - Changes in container initialization and usage
 - Modified provider resolution methods
@@ -154,6 +155,7 @@ instance = await container.resolve(SomeType)
 ```
 
 The key changes are:
+
 1. **Inverted dependency**: Resolution is now called on the container instead of the provider
 2. **Type-based resolution**: You can now resolve dependencies directly by type, not just by provider reference
 3. **Consistent naming**: `sync_resolve_provider()` and `resolve_provider()` for provider-based resolution, `sync_resolve()` and `resolve()` for type-based resolution

--- a/docs/migration/to-2.x.md
+++ b/docs/migration/to-2.x.md
@@ -5,6 +5,7 @@ This document describes the changes required to migrate from modern-di 1.x versi
 ## Overview
 
 The migration to modern-di 2.x involves several key changes in the API, including:
+
 - Simplified container architecture with a single `Container` class
 - Updated provider API with keyword-only arguments
 - Removal of several provider types (`Singleton`, `Resource`, `Dict`, `List`)

--- a/docs/providers/advanced-api.md
+++ b/docs/providers/advanced-api.md
@@ -2,25 +2,16 @@
 
 Lower-level public surface for library authors and advanced use-cases.
 
-## `Container` attributes and methods
+## Supported extension points
 
-- **`find_container(scope)`** — walks `scope_map` and returns the container registered at
-  `scope`; raises `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
-- **`parent_container`** — constructor kwarg and slot; the direct parent of a child container,
-  or `None` for a root. Passing a `scope ≤ parent.scope` raises `InvalidChildScopeError`.
-- **`scope_map`** — `dict[IntEnum, Container]` mapping every scope in the chain to its
-  container; built at construction time and inherited (plus the new scope) by each child.
-- **`lock`** — a `threading.RLock` instance, or `None` when the container was created with
-  `use_lock=False`. The lock gates singleton creation inside `Factory.resolve`.
-
-## `Group.get_providers()`
+### `Group.get_providers()`
 
 `Group.get_providers()` is a classmethod that traverses the MRO (excluding `Group` and
 `object`) and collects every class attribute that is an `AbstractProvider` instance, respecting
 MRO override order (subclass attribute shadows parent attribute of the same name). Use it to
 inspect or iterate all providers declared on a group hierarchy.
 
-## Subclassing `AbstractProvider`
+### Subclassing `AbstractProvider`
 
 To implement a custom provider, subclass `AbstractProvider` and implement:
 
@@ -35,14 +26,30 @@ To implement a custom provider, subclass `AbstractProvider` and implement:
   `Alias`) should override it to follow the source chain so that `Container.validate()` checks
   callers against the real target scope rather than any nominal scope on the wrapper itself.
 
-## `CacheSettings.is_async_finalizer`
+### `CacheSettings.is_async_finalizer`
 
 `CacheSettings.is_async_finalizer` is a computed bool field set at construction time via
 `inspect.iscoroutinefunction(finalizer)`. `Factory.resolve` and the cache registry use it to
 decide whether to `await` the finalizer during `close_async()` or treat it as sync.
 
-## Deprecated: `cache_settings=`
+### Deprecated: `cache_settings=`
 
 `Factory(cache_settings=...)` is a deprecated alias of `cache=`. It still works but
 emits a `DeprecationWarning`; pass `cache=True` (defaults) or `cache=CacheSettings(...)`
 (tuned) instead. Passing both `cache` and `cache_settings` raises `TypeError`.
+
+## Container internals — no stability guarantee
+
+!!! warning "Internal surface"
+    These attributes back the container's own machinery. They are documented
+    for debugging and deep integration work only, and may change without a
+    deprecation cycle. Do not build on them.
+
+- **`find_container(scope)`** — walks `scope_map` and returns the container registered at
+  `scope`; raises `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
+- **`parent_container`** — constructor kwarg and slot; the direct parent of a child container,
+  or `None` for a root. Passing a `scope ≤ parent.scope` raises `InvalidChildScopeError`.
+- **`scope_map`** — `dict[IntEnum, Container]` mapping every scope in the chain to its
+  container; built at construction time and inherited (plus the new scope) by each child.
+- **`lock`** — a `threading.RLock` instance, or `None` when the container was created with
+  `use_lock=False`. The lock gates singleton creation inside `Factory.resolve`.

--- a/docs/providers/factories.md
+++ b/docs/providers/factories.md
@@ -125,6 +125,7 @@ Defines the lifetime (scope) of the dependency. Defaults to `Scope.APP`. The ava
 
 The callable (function or class) that will be invoked to create instances of the dependency.
 Modern-DI analyzes the creator's signature to:
+
 1. Determine the return type (used for `bound_type` if not explicitly set)
 2. Identify parameter names and types for automatic dependency resolution
 
@@ -147,6 +148,7 @@ Enables caching for the provider. Pass `cache=True` to cache with default settin
 ### skip_creator_parsing
 
 Disables automatic dependency resolution. When `True`:
+
 - No automatic dependency resolution occurs
 - All parameters must be provided via the `kwargs` parameter
 - The `bound_type` will not be automatically inferred from the creator's return type; unless `bound_type` is explicitly provided, it defaults to `None`
@@ -199,8 +201,8 @@ The table below summarises how Modern-DI handles each parameter shape during **d
 | Parameter shape | Behaviour | When it fails |
 |---|---|---|
 | `param: SomeClass` — plain type annotation with a registered provider | Resolved and injected automatically. | `ArgumentResolutionError` at resolve if no provider is registered and there is no default. |
-| `param: X \| None` / `Optional[X]` | Provider injected if one is registered; otherwise `None`. | Never fails — see [Optional parameters](#optional-parameters). |
-| `param: A \| B` — union without `None` | First registered type from the union is injected. | `ArgumentResolutionError` at resolve if neither `A` nor `B` has a registered provider. |
+| `param: X &#124; None` / `Optional[X]` | Provider injected if one is registered; otherwise `None`. | Never fails — see [Optional parameters](#optional-parameters). |
+| `param: A &#124; B` — union without `None` | First registered type from the union is injected. | `ArgumentResolutionError` at resolve if neither `A` nor `B` has a registered provider. |
 | `param: list[X]` / any parameterized generic | **`UnsupportedCreatorParameterError` at declaration** unless the parameter has a default value or is covered by `kwargs`. | Raised at `Factory(...)` call time. |
 | Positional-only param (`def f(x: T, /)`) | **`UnsupportedCreatorParameterError` at declaration** unless the parameter has a default (in which case it is silently skipped). | Raised at `Factory(...)` call time. |
 | Unannotated param (`def f(x)`) | Parsed but unresolvable by type. | `ArgumentResolutionError` at resolve unless covered by `kwargs`. |

--- a/docs/providers/factories.md
+++ b/docs/providers/factories.md
@@ -201,8 +201,8 @@ The table below summarises how Modern-DI handles each parameter shape during **d
 | Parameter shape | Behaviour | When it fails |
 |---|---|---|
 | `param: SomeClass` — plain type annotation with a registered provider | Resolved and injected automatically. | `ArgumentResolutionError` at resolve if no provider is registered and there is no default. |
-| `param: X &#124; None` / `Optional[X]` | Provider injected if one is registered; otherwise `None`. | Never fails — see [Optional parameters](#optional-parameters). |
-| `param: A &#124; B` — union without `None` | First registered type from the union is injected. | `ArgumentResolutionError` at resolve if neither `A` nor `B` has a registered provider. |
+| `param: X | None` / `Optional[X]` | Provider injected if one is registered; otherwise `None`. | Never fails — see [Optional parameters](#optional-parameters). |
+| `param: A | B` — union without `None` | First registered type from the union is injected. | `ArgumentResolutionError` at resolve if neither `A` nor `B` has a registered provider. |
 | `param: list[X]` / any parameterized generic | **`UnsupportedCreatorParameterError` at declaration** unless the parameter has a default value or is covered by `kwargs`. | Raised at `Factory(...)` call time. |
 | Positional-only param (`def f(x: T, /)`) | **`UnsupportedCreatorParameterError` at declaration** unless the parameter has a default (in which case it is silently skipped). | Raised at `Factory(...)` call time. |
 | Unannotated param (`def f(x)`) | Parsed but unresolvable by type. | `ArgumentResolutionError` at resolve unless covered by `kwargs`. |

--- a/docs/providers/scopes.md
+++ b/docs/providers/scopes.md
@@ -72,7 +72,7 @@ async with app_container.build_child_container(scope=Scope.REQUEST) as request_c
 
 Use `async with` only when the scope holds providers with async finalizers; otherwise plain `with` is enough. Resolution itself is always synchronous.
 
-**Framework-managed.** Integration packages (`modern-di-fastapi`, `modern-di-litestar`, `modern-di-faststream`) build the REQUEST child container for each request and tear it down at the end. You only declare `scope=Scope.REQUEST` on the providers that need it.
+**Framework-managed.** The [framework integrations](../integrations/fastapi.md) build the per-request child container for each request (or per-message for brokers) and tear it down at the end. You only declare `scope=Scope.REQUEST` on the providers that need it.
 
 ## Resolving across scopes
 

--- a/docs/recipes/async-lifespan.md
+++ b/docs/recipes/async-lifespan.md
@@ -47,6 +47,11 @@ app = fastapi.FastAPI(lifespan=lifespan)
 
 The same pattern works for `asyncpg.create_pool(...)` (truly async), authenticated API clients that do a token exchange at startup, or anything else that needs `await` to be ready.
 
+`asyncpg.create_pool(...)` returns an awaitable `Pool` that only opens its
+connections when `await`ed (or entered with `async with`); modern-di has async
+*finalizers* but no async *initializer*, so the `await` has to happen in the
+lifespan.
+
 ## Pitfalls
 
 - **Set context *before* yielding.** The lifespan hands control to the app inside the `yield`. If you `set_context` after yielding, requests that arrive in between won't see the value.

--- a/planning/changes/2026-07-04.02-docs-accuracy-parity/design.md
+++ b/planning/changes/2026-07-04.02-docs-accuracy-parity/design.md
@@ -1,0 +1,223 @@
+---
+summary: Docs accuracy + integration-parity pass — rendering fixes, factual corrections, framework-list de-drift, and full API/websocket parity for aiohttp/Litestar/Starlette.
+---
+
+# Design: Docs accuracy and integration-parity pass
+
+**Date:** 2026-07-04
+**Goal:** Close a batch of documentation defects found in a read-through of the
+published site: broken Markdown rendering, factually wrong claims, framework
+lists that drift as integrations are added, and integration pages that lack the
+sections FastAPI's page has. Documentation-only; no library or integration code
+changes.
+
+## Summary
+
+One PR that (1) fixes Markdown rendering bugs (inline-collapsed lists, escaped
+pipes inside table code spans), (2) corrects factual errors (custom scopes,
+Dishka autowiring, the "sync only" framing), (3) reduces framework-list drift by
+collapsing generic enumerations to a single canonical list plus links and fixing
+the wrong subsets, and (4) brings the aiohttp, Litestar, and Starlette
+integration pages to parity with FastAPI (API tables; websocket + framework
+context sections where missing; the aiohttp websocket-wiring explanation).
+
+## Motivation
+
+A page-by-page review of <https://modern-di.modern-python.org> surfaced:
+
+- **Rendering.** `providers/factories.md#creator` renders its `1./2.` list
+  inline because there is no blank line before the list; the
+  `Creator-signature support matrix` shows literal backslashes
+  (`param: X \| None`) because `\|` inside a `` `code span` `` is literal, not an
+  escaped pipe.
+- **Wrong facts.** `introduction/comparison.md` implies modern-di has no custom
+  scopes (it does — any `IntEnum`, see `providers/scopes.md#custom-scopes`) and
+  frames autowiring as a modern-di differentiator over Dishka (Dishka autowires
+  by type too). `introduction/that-depends-or-modern-di.md` (and echoes in
+  `comparison.md`/`design-decisions.md`) reads "sync only" in a way that scares
+  readers off, without noting that finalizers may be sync **or** async.
+- **Framework-list drift.** The set of supported frameworks is enumerated in ~7
+  places. Two are correct full lists, several are precise subset-claims that are
+  fine, but `introduction/about-di.md:205` is a clipped/incorrect list
+  ("FastAPI, Litestar, FastStream") and `providers/scopes.md:75` names only
+  fastapi/litestar/faststream as building the per-request child container when
+  aiohttp and starlette do so as well. Every new integration multiplies the
+  update sites.
+- **Integration parity.** FastAPI's page has an `## API` table, a `## Websockets`
+  section, and `## Framework Context Objects`. aiohttp and Litestar lack the API
+  table; Starlette lacks all three beyond the basic example; the aiohttp
+  websocket section does not explain *why* wiring is explicit there.
+
+## Non-goals
+
+- Renaming `Container` internals (`find_container`, `parent_container`,
+  `scope_map`, `lock`) to underscore-private. It is a breaking public-API change
+  needing a deprecation path; tracked as a follow-up (see Out of scope).
+- Adding `mkdocstrings` or any auto-generated API reference. Docs tooling stays
+  plain `mkdocs` + `mkdocs-material`.
+- Any change to library or integration source. This bundle is docs-only.
+- Rewriting the concurrency semantics themselves — only the prose that describes
+  them (`design-decisions.md`) is tightened.
+
+## Design
+
+### 1. Rendering fixes (`providers/factories.md` + full-doc audit)
+
+- **Collapsed lists.** Markdown needs a blank line between a paragraph and the
+  list that follows it. Add it wherever missing. Confirmed offenders:
+  `factories.md` `### creator` (the `1./2.` list after "…signature to:") and
+  `### skip_creator_parsing` (the `-` list after "When `True`:"). Audit every
+  `docs/**/*.md` for the same pattern (a non-blank line immediately followed by
+  an `1.`/`-`/`*` list item) and fix each.
+- **Escaped pipes in table code spans.** In the
+  `### Creator-signature support matrix` table, replace `\|` inside inline code
+  with the HTML entity `&#124;` — e.g. `` `param: X &#124; None` ``. Inside a
+  `` `code span` `` a backslash is literal (renders `\|`), whereas the entity is
+  emitted into the `<code>` and the browser decodes it to `|`. pymdownx's table
+  extension passes the entity through correctly. Affected rows: the `X | None`,
+  `A | B`, and any other `|`-containing code spans in that table.
+
+### 2. Factual corrections
+
+- **Custom scopes (`comparison.md`).** Adjust the landscape table row and the
+  "vs Dishka" prose so they no longer say modern-di lacks custom scopes. Accurate
+  framing: modern-di accepts *any `IntEnum`* as a scope (strictly-greater int
+  than its parent), but does not offer an arbitrary *named* scope system the way
+  Dishka does — link to `providers/scopes.md#custom-scopes`.
+- **Dishka autowiring (`comparison.md`).** Reword row/prose so autowiring is not
+  framed as exclusive to modern-di; Dishka resolves by type as well. Keep the
+  genuine differentiators (first-party pytest plugin, small fixed core,
+  all-official uniformly-maintained integrations).
+- **"Sync only" framing.** Everywhere the phrase appears
+  (`that-depends-or-modern-di.md`, `comparison.md`, `design-decisions.md`), add a
+  short clause: resolution is synchronous, but finalizers may be sync **or**
+  async (`close_sync`/`close_async`), so async teardown is fully supported. Goal:
+  stop "sync only" from reading as "no async at all."
+- **Concurrency prose (`design-decisions.md`, bullets on register-then-serve and
+  last-write-wins).** Tighten to land the meaning faster. The meaning to
+  preserve: the registries are thread-safe against *corruption*, but concurrent
+  mutation is not a coordination mechanism — register providers in a setup phase
+  before serving, and do `set_context`/overrides during setup or on a
+  request-local child container, never from competing threads at serve time.
+- **asyncpg (`recipes/async-lifespan.md`).** Keep the claim; add a half-sentence
+  explaining *why* `asyncpg.create_pool(...)` belongs in the lifespan while the
+  cases in "When a sync creator works instead" do not: the pool must be
+  `await`ed (or `async with`) to open its connections, and modern-di has async
+  *finalizers* but no async *initializer*, so the only place to `await`
+  construction is the lifespan. (Verified against asyncpg docs: `create_pool`
+  returns an awaitable `Pool`; idiomatic use is `await`/`async with`.)
+
+### 3. Framework-list de-drift
+
+Establish two canonical enumeration sites and make everything else link rather
+than re-list:
+
+- **Canonical full list:** `index.md` (the Quick-Start bullet, already correct
+  and complete: aiohttp, FastAPI, FastStream, Litestar, Starlette, Typer, pytest)
+  and the `comparison.md` "Official integrations" table row (also correct).
+- **Convert generic enumerations to links.** Where prose only means "we support
+  many frameworks," replace the hardcoded name list with a link to the
+  Integrations section / comparison row. Primary target: `about-di.md:205`
+  ("Works with FastAPI, Litestar, FastStream:") becomes a correct/linked
+  statement.
+- **Fix wrong subsets.** `providers/scopes.md:75` ("Framework-managed…") should
+  not imply only fastapi/litestar/faststream build the per-request child — say
+  "the framework integrations" and link, since aiohttp and starlette do too.
+- **Leave precise subset-claims alone.** `writing-integrations.md`
+  ("Dependency generator (FastAPI, Litestar)"), `context-not-set.md`,
+  `request-scoped-engine.md`, etc. make accurate statements about specific
+  frameworks' mechanics — those are not drift and stay.
+
+### 4. Integration parity — aiohttp, Litestar, Starlette
+
+All symbols below are taken from each package's `__all__` / `main.py` as read
+during design; the plan must re-verify against source at implementation time.
+
+#### 4a. aiohttp (`integrations/aiohttp.md`)
+
+- **Add `## API` table** with: `setup_di(app, container)`, `FromDI(dependency)`,
+  `inject`, `fetch_di_container(app)`, `fetch_request_container(request)`,
+  `aiohttp_request_provider` (Request, REQUEST, auto-registered by type),
+  `aiohttp_websocket_provider` (Request, SESSION, `bound_type=None` —
+  reference-only, resolve via `FromDI`).
+- **Websocket section — add the missing explanation.** aiohttp has *no separate
+  WebSocket object*: a websocket is an upgraded `web.Request`, so
+  `aiohttp_websocket_provider` binds `web.Request` too and is declared
+  `bound_type=None` (not type-resolvable). That is exactly why it must be wired
+  **explicitly** via `FromDI(aiohttp_websocket_provider)` rather than by type —
+  unlike FastAPI/Litestar, which have distinct `WebSocket` objects. The existing
+  example already uses the right symbols (`fetch_request_container`); add the
+  prose that explains the explicit-wiring requirement.
+
+#### 4b. Litestar (`integrations/litestar.md`)
+
+- **Add `## API` table** with: `ModernDIPlugin(container, *, autowired_groups=...)`,
+  `FromDI(dependency)`, `fetch_di_container(app)`,
+  `litestar_request_provider`, `litestar_websocket_provider`. The page already
+  has Websockets and Framework-Context-Objects sections — only the API table is
+  missing.
+
+#### 4c. Starlette (`integrations/starlette.md`)
+
+Bring to full FastAPI parity. Behavior confirmed in `main.py`: the middleware
+opens a REQUEST child for HTTP and a SESSION child for websockets automatically;
+`starlette_request_provider` (REQUEST) and `starlette_websocket_provider`
+(SESSION) are auto-registered.
+
+- **Add `## Scopes`** note (HTTP → REQUEST, WebSocket → SESSION, auto-entered).
+- **Add `## Websockets`** section. One asymmetry to resolve at implementation
+  time: Starlette exposes **no public `fetch_request_container`** (aiohttp does).
+  For a per-message nested REQUEST scope inside a Starlette websocket handler,
+  verify the clean way to obtain the SESSION container — likely `@inject` +
+  `FromDI(container_provider)` or type-based `Container` injection (the
+  auto-registered `container_provider`). Document whatever is verified to work;
+  if none is clean, document the limitation explicitly rather than inventing an
+  API.
+- **Add `## Framework Context Objects`** section mirroring FastAPI/Litestar
+  (implicit type-based + explicit provider-based usage of
+  `starlette_request_provider` / `starlette_websocket_provider`).
+- **Add `## API` table** with: `setup_di(app, container)`, `FromDI(dependency)`,
+  `inject`, `fetch_di_container(app)`, `starlette_request_provider`,
+  `starlette_websocket_provider`.
+
+### 5. advanced-api.md restructure (docs-only)
+
+Split `providers/advanced-api.md` into two clearly-labelled parts: **supported
+extension points** (`AbstractProvider` subclassing, `Group.get_providers()`,
+`CacheSettings.is_async_finalizer`, the deprecated `cache_settings=` note) vs. a
+**Container internals — no stability guarantee** subsection (`find_container`,
+`parent_container`, `scope_map`, `lock`) that states these are advanced/internal
+and may change without notice. No symbol renames (that is the follow-up below).
+
+## Out of scope
+
+- **Underscore-privatizing `Container` internals.** Research during design
+  confirmed `find_container`/`parent_container`/`scope_map`/`lock` are referenced
+  only inside `modern_di` core — none of the six integration packages use them —
+  so a rename would not break the official integrations. But `find_container` is
+  documented public advanced API, so the rename is still a breaking change for
+  advanced/library-author users and needs its own bundle with a deprecation
+  decision. `advanced-api.md` is still restructured in this PR (Design §5) but
+  nothing is renamed.
+- Adding `mkdocstrings`.
+
+## Testing
+
+- `mkdocs build --strict` locally — catches broken links and (with the fixes)
+  confirms the pages build. Manually eyeball the rendered `factories.md` list and
+  signature matrix, and the three integration pages.
+- `just lint-ci` — no-autofix lint plus planning-bundle validation
+  (`just check-planning` must pass for this bundle).
+- No pytest impact (docs-only); `just test-ci` coverage gate is unaffected.
+
+## Risk
+
+- **Low overall — documentation only, no runtime code touched.**
+- **`&#124;` entity not rendering as `|`** in some viewer: low; it is the
+  standard pymdownx-tables workaround. Verified by `mkdocs build` + visual check.
+- **Starlette websocket container-access pattern** turning out to have no clean
+  public path: medium-likelihood, low-impact — mitigated by the design's
+  instruction to document the verified pattern or the limitation, never an
+  invented API.
+- **Framework-list link strategy** could under-link and leave a stale subset
+  somewhere: low; the audit enumerates every current site.

--- a/planning/changes/2026-07-04.02-docs-accuracy-parity/plan.md
+++ b/planning/changes/2026-07-04.02-docs-accuracy-parity/plan.md
@@ -1,0 +1,615 @@
+# docs-accuracy-parity — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship one documentation-only PR that fixes Markdown rendering bugs,
+corrects factual errors, de-drifts framework lists, and brings the aiohttp /
+Litestar / Starlette integration pages to parity with FastAPI's.
+
+**Spec:** [`design.md`](./design.md)
+
+**Branch:** `docs/accuracy-parity` (already created and holds the design commit).
+
+**Commit strategy:** Per-task commits.
+
+## Global Constraints
+
+- **Docs only.** No file under `modern_di/`, `tests/`, or any integration repo
+  changes. Only `docs/**/*.md` and this bundle.
+- **Line length 120** (matches repo style) for prose where practical; do not
+  reflow unrelated lines.
+- **Verification per task:** `just docs-build` (runs
+  `mkdocs build --strict`, fails on broken links/nav) must pass. `just docs-build`
+  uses `uvx --with-requirements docs/requirements.txt mkdocs build --strict`.
+- **All symbol names in API tables are copied from each integration's
+  `main.py` / `__all__`.** Do not invent symbols. Re-verify against source if in
+  doubt: `src/pypi/modern-di-<pkg>/modern_di_<pkg>/__init__.py`.
+- Run `just check-planning` before the final push (this bundle must stay valid).
+
+---
+
+### Task 1: Rendering fixes — collapsed lists and escaped pipes
+
+**Files:**
+- Modify: `docs/providers/factories.md`
+- Modify: `docs/integrations/fastapi.md`
+- Modify: `docs/integrations/litestar.md`
+- Modify: `docs/migration/to-1.x.md`
+- Modify: `docs/migration/to-2.x.md`
+
+Add the missing blank line before every paragraph-followed-by-list (the list
+otherwise renders inline), and fix the two escaped-pipe code spans in the
+signature-support matrix.
+
+- [ ] **Step 1: Audit — confirm the collapsed-list set**
+
+  Run this from repo root to list every paragraph line (ends with `:`)
+  immediately followed by a list item, ignoring code fences:
+
+  ```bash
+  cd docs && for f in $(find . -name '*.md'); do \
+    awk 'prev ~ /:[[:space:]]*$/ && $0 ~ /^[[:space:]]*([-*+]|[0-9]+\.)[[:space:]]/ {print FILENAME":"NR} {prev=$0}' "$f"; \
+  done
+  ```
+
+  Expected exactly these 9 lines (the list's first item; insert a blank line
+  *above* each):
+  `providers/factories.md:128`, `providers/factories.md:150`,
+  `integrations/fastapi.md:76`, `integrations/fastapi.md:115`,
+  `integrations/litestar.md:102`, `integrations/litestar.md:153`,
+  `migration/to-1.x.md:12`, `migration/to-1.x.md:157`, `migration/to-2.x.md:8`.
+  (Line numbers shift as you edit top-to-bottom; edit by matching the text
+  below, not by number.)
+
+- [ ] **Step 2: Fix `factories.md` — `### creator` list**
+
+  Insert a blank line so the intro paragraph is separated from the list:
+
+  ```
+  Modern-DI analyzes the creator's signature to:
+
+  1. Determine the return type (used for `bound_type` if not explicitly set)
+  2. Identify parameter names and types for automatic dependency resolution
+  ```
+
+- [ ] **Step 3: Fix `factories.md` — `### skip_creator_parsing` list**
+
+  ```
+  Disables automatic dependency resolution. When `True`:
+
+  - No automatic dependency resolution occurs
+  ```
+
+- [ ] **Step 4: Fix `factories.md` — signature matrix escaped pipes**
+
+  Replace `\|` with `&#124;` inside the two code spans (browser decodes the
+  entity to `|` inside `<code>`; a backslash there is literal). Change:
+
+  ```
+  | `param: X \| None` / `Optional[X]` |
+  ```
+  to
+  ```
+  | `param: X &#124; None` / `Optional[X]` |
+  ```
+  and
+  ```
+  | `param: A \| B` — union without `None` |
+  ```
+  to
+  ```
+  | `param: A &#124; B` — union without `None` |
+  ```
+
+- [ ] **Step 5: Fix the remaining collapsed lists**
+
+  Insert a blank line before the first list item in each:
+
+  - `integrations/fastapi.md` after `But when websockets are used, `SESSION` scope is used as well:`
+  - `integrations/fastapi.md` after `The following context providers are available for import:`
+  - `integrations/litestar.md` after `But when websockets are used, `SESSION` scope is used as well:`
+  - `integrations/litestar.md` after `The following context providers are available for import:`
+  - `migration/to-1.x.md` after `The migration to modern-di 1.x involves several key changes in the API, including:`
+  - `migration/to-1.x.md` after `The key changes are:`
+  - `migration/to-2.x.md` after `The migration to modern-di 2.x involves several key changes in the API, including:`
+
+- [ ] **Step 6: Verify the audit is now clean and the site builds**
+
+  ```bash
+  cd docs && for f in $(find . -name '*.md'); do \
+    awk 'prev ~ /:[[:space:]]*$/ && $0 ~ /^[[:space:]]*([-*+]|[0-9]+\.)[[:space:]]/ {print FILENAME":"NR} {prev=$0}' "$f"; \
+  done
+  # Expected: no output
+  cd .. && grep -rn '\\|' docs
+  # Expected: no output
+  just docs-build
+  # Expected: build succeeds, no warnings
+  ```
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add docs/providers/factories.md docs/integrations/fastapi.md \
+    docs/integrations/litestar.md docs/migration/to-1.x.md docs/migration/to-2.x.md
+  git commit -m "docs: fix collapsed lists and escaped pipes in tables"
+  ```
+
+---
+
+### Task 2: Factual corrections
+
+**Files:**
+- Modify: `docs/introduction/comparison.md`
+- Modify: `docs/introduction/that-depends-or-modern-di.md`
+- Modify: `docs/introduction/design-decisions.md`
+- Modify: `docs/recipes/async-lifespan.md`
+
+Correct custom-scopes and Dishka-autowiring claims, clarify "sync only" vs async
+finalizers, tighten the concurrency prose, and explain why asyncpg needs the
+lifespan.
+
+- [ ] **Step 1: `comparison.md` — custom scopes in the landscape table**
+
+  Change the `Scopes` row modern-di cell from
+  `APP→…→STEP (fixed chain)` to `APP→…→STEP + any IntEnum`. Leave the Dishka
+  cell (`RUNTIME→…→STEP (+ custom)`) unchanged.
+
+- [ ] **Step 2: `comparison.md` — Dishka autowiring in the landscape table**
+
+  Change the `Style` row so autowiring is not framed as exclusive. Set the Dishka
+  cell to `type-based autowiring (provider classes)` (was `type-based, provider
+  classes`). Leave the modern-di cell (`type-based autowiring`) unchanged.
+
+- [ ] **Step 3: `comparison.md` — "vs Dishka" prose**
+
+  In the paragraph beginning "If you need **arbitrary custom scopes**…", change
+  `arbitrary custom scopes` to `arbitrary *named* scopes` (modern-di already
+  supports any `IntEnum` scope). In the bullet
+  "**Sync-only resolution and a small, fixed scope chain**…", replace it with:
+
+  ```
+  - **Sync-only *resolution* (async finalizers still supported) and a small,
+    built-in scope chain you can still extend with any `IntEnum`** — a simpler
+    model. Dishka's own docs note that custom scopes are "hardly ever needed,"
+    which is the honest case for modern-di's simpler design. See
+    [Custom scopes](../providers/scopes.md#custom-scopes).
+  ```
+
+- [ ] **Step 4: `comparison.md` — Resolution row footnote for async finalizers**
+
+  In the `Resolution` row, change the modern-di cell from `sync (by design)` to
+  `sync (async finalizers supported)`.
+
+- [ ] **Step 5: `that-depends-or-modern-di.md` — clarify sync-only**
+
+  In the `Resolution` table row, change the modern-di cell from
+  `sync only (by design)` to `sync resolution (async finalizers supported)`.
+  Then, immediately after the "How they differ" table, add a note:
+
+  ```
+  !!! note "\"Sync only\" means resolution, not teardown"
+      modern-di resolves synchronously, but finalizers may be sync **or** async
+      (`close_sync` / `close_async`), so async resource cleanup is fully
+      supported. See [Lifecycle](../providers/lifecycle.md).
+  ```
+
+- [ ] **Step 6: `design-decisions.md` — clarify §1 sync-only**
+
+  At the end of the first paragraph of "## 1. Resolution is sync only" (after the
+  "(see [Async resources via lifespan]…)" sentence), append:
+
+  ```
+  Resolution being sync does not mean teardown is: finalizers may be sync or
+  async (`close_sync` / `close_async`), so async cleanup is fully supported.
+  ```
+
+- [ ] **Step 7: `design-decisions.md` — tighten the concurrency bullets**
+
+  Replace the two bullets currently reading "**Intended usage still holds.**…"
+  and "**`set_context` and overrides are last-write-wins.**…" with:
+
+  ```
+  - **Registration is a setup phase, not a coordination tool.** The registry is
+    lock-guarded against corruption, but the supported model is register every
+    provider *before* serving. Registering a provider while other threads are
+    already resolving is timing-dependent by nature — nothing breaks, but whether
+    a given resolve sees the new provider is undefined.
+  - **`set_context` and overrides are last-write-wins.** Both write into a
+    per-container dict with no ordering, queueing, or merge; concurrent writes to
+    the same key keep whichever landed last. Do them during setup, or per-request
+    on a request-local child container — never from competing threads.
+  ```
+
+- [ ] **Step 8: `async-lifespan.md` — explain why asyncpg needs the lifespan**
+
+  After the sentence "The same pattern works for `asyncpg.create_pool(...)`
+  (truly async), …anything else that needs `await` to be ready." append:
+
+  ```
+  `asyncpg.create_pool(...)` returns an awaitable `Pool` that only opens its
+  connections when `await`ed (or entered with `async with`); modern-di has async
+  *finalizers* but no async *initializer*, so the `await` has to happen in the
+  lifespan.
+  ```
+
+- [ ] **Step 9: Verify and commit**
+
+  ```bash
+  just docs-build   # Expected: build succeeds
+  git add docs/introduction/comparison.md docs/introduction/that-depends-or-modern-di.md \
+    docs/introduction/design-decisions.md docs/recipes/async-lifespan.md
+  git commit -m "docs: correct custom-scopes/autowiring claims and sync-only framing"
+  ```
+
+---
+
+### Task 3: Framework-list de-drift
+
+**Files:**
+- Modify: `docs/introduction/about-di.md`
+- Modify: `docs/providers/scopes.md`
+
+Point generic "we support frameworks" prose at the canonical list instead of
+re-enumerating, and drop the under-inclusive integration subset in `scopes.md`.
+
+- [ ] **Step 1: `about-di.md` — replace the clipped list with a link**
+
+  In "### 5. Framework Integrations", replace:
+
+  ```
+  Works with FastAPI, Litestar, FastStream:
+  ```
+  with:
+  ```
+  Works with [every official framework integration](comparison.md#the-landscape).
+  For example, with FastAPI:
+  ```
+  (Leave the FastAPI code block below it unchanged — it is an illustrative
+  example, not a claim about coverage.)
+
+- [ ] **Step 2: `scopes.md` — de-enumerate the framework-managed note**
+
+  Replace the "**Framework-managed.**" sentence:
+
+  ```
+  **Framework-managed.** Integration packages (`modern-di-fastapi`, `modern-di-litestar`, `modern-di-faststream`) build the REQUEST child container for each request and tear it down at the end. You only declare `scope=Scope.REQUEST` on the providers that need it.
+  ```
+  with:
+  ```
+  **Framework-managed.** The [framework integrations](../integrations/fastapi.md) build the per-request child container for each request (or per-message for brokers) and tear it down at the end. You only declare `scope=Scope.REQUEST` on the providers that need it.
+  ```
+
+- [ ] **Step 3: Verify and commit**
+
+  ```bash
+  just docs-build   # Expected: build succeeds, links resolve
+  git add docs/introduction/about-di.md docs/providers/scopes.md
+  git commit -m "docs: link to canonical framework list instead of re-enumerating"
+  ```
+
+---
+
+### Task 4: Restructure `advanced-api.md`
+
+**Files:**
+- Modify: `docs/providers/advanced-api.md`
+
+Split the page into supported extension points vs. no-guarantee Container
+internals. No symbol renames.
+
+- [ ] **Step 1: Rewrite the page structure**
+
+  Keep all existing content, but reorganize under two top-level parts. Replace
+  the current `## `Container` attributes and methods` heading and its bullet
+  list with an internals subsection carrying an explicit stability caveat. Final
+  structure:
+
+  ```
+  # Advanced / low-level API
+
+  Lower-level public surface for library authors and advanced use-cases.
+
+  ## Supported extension points
+
+  ### `Group.get_providers()`
+  <existing Group.get_providers paragraph, unchanged>
+
+  ### Subclassing `AbstractProvider`
+  <existing subclassing section, unchanged>
+
+  ### `CacheSettings.is_async_finalizer`
+  <existing is_async_finalizer paragraph, unchanged>
+
+  ### Deprecated: `cache_settings=`
+  <existing deprecated section, unchanged>
+
+  ## Container internals — no stability guarantee
+
+  !!! warning "Internal surface"
+      These attributes back the container's own machinery. They are documented
+      for debugging and deep integration work only, and may change without a
+      deprecation cycle. Do not build on them.
+
+  - **`find_container(scope)`** — <existing text, unchanged>
+  - **`parent_container`** — <existing text, unchanged>
+  - **`scope_map`** — <existing text, unchanged>
+  - **`lock`** — <existing text, unchanged>
+  ```
+
+- [ ] **Step 2: Verify and commit**
+
+  ```bash
+  just docs-build   # Expected: build succeeds
+  git add docs/providers/advanced-api.md
+  git commit -m "docs: split advanced-api into extension points vs internals"
+  ```
+
+---
+
+### Task 5: aiohttp integration parity
+
+**Files:**
+- Modify: `docs/integrations/aiohttp.md`
+
+Add the explicit-wiring explanation to the WebSocket section and an `## API`
+table. Symbols from `modern_di_aiohttp/__init__.py`.
+
+- [ ] **Step 1: Expand the WebSocket section with the "why explicit" explanation**
+
+  In "### 4. WebSockets and per-message scope", after the sentence "Read the
+  connection with `FromDI(aiohttp_websocket_provider)`." insert:
+
+  ```
+  Unlike FastAPI and Litestar, aiohttp has no separate WebSocket object — a
+  WebSocket is an upgraded `web.Request`. So `aiohttp_websocket_provider` binds
+  `web.Request` too, and is declared `bound_type=None` (not resolvable by type,
+  because `aiohttp_request_provider` already owns `web.Request`). That is why you
+  wire it **explicitly** with `FromDI(aiohttp_websocket_provider)` rather than by
+  type annotation.
+  ```
+
+- [ ] **Step 2: Add the `## API` table at the end of the page**
+
+  ```
+  ## API
+
+  | Symbol | Description |
+  |---|---|
+  | `setup_di(app, container)` | Opens the root container on startup, closes it on cleanup, and installs the middleware that builds a per-connection child container; returns the container. |
+  | `FromDI(dependency)` | Marker (used with `@inject`) that resolves a provider or type from the per-connection child container. |
+  | `inject` | Decorator for an `async def handler(request: web.Request, ...)`; resolves its `FromDI`-annotated parameters. |
+  | `fetch_di_container(app)` | Returns the root `Container` stored on the app. |
+  | `fetch_request_container(request)` | Returns the per-connection child container the middleware built (REQUEST for HTTP, SESSION for a WebSocket). |
+  | `aiohttp_request_provider` | `ContextProvider` for `web.Request` (REQUEST scope), auto-registered by type. |
+  | `aiohttp_websocket_provider` | `ContextProvider` for the WebSocket connection's `web.Request` (SESSION scope), `bound_type=None` — resolve via `FromDI(aiohttp_websocket_provider)`. |
+  ```
+
+- [ ] **Step 3: Verify and commit**
+
+  ```bash
+  just docs-build   # Expected: build succeeds
+  git add docs/integrations/aiohttp.md
+  git commit -m "docs: aiohttp — explain explicit ws wiring, add API table"
+  ```
+
+---
+
+### Task 6: Litestar integration parity
+
+**Files:**
+- Modify: `docs/integrations/litestar.md`
+
+Add the missing `## API` table (the page already has Websockets and
+Framework-Context-Objects sections). Symbols from
+`modern_di_litestar/__init__.py` and `main.py`.
+
+- [ ] **Step 1: Add the `## API` table at the end of the page**
+
+  ```
+  ## API
+
+  | Symbol | Description |
+  |---|---|
+  | `ModernDIPlugin(container, autowired_groups=None)` | Litestar `InitPlugin` that registers the container, composes the lifespan, and (if `autowired_groups` is given) exposes each provider in those groups as a Litestar dependency keyed by attribute name. |
+  | `FromDI(dependency)` | Returns a Litestar `Provide` that resolves a provider or type from the per-request child container. |
+  | `fetch_di_container(app)` | Returns the root `Container` stored on the Litestar app. |
+  | `litestar_request_provider` | `ContextProvider` for `litestar.Request` (REQUEST scope), auto-registered. |
+  | `litestar_websocket_provider` | `ContextProvider` for `litestar.WebSocket` (SESSION scope), auto-registered. |
+  ```
+
+- [ ] **Step 2: Verify and commit**
+
+  ```bash
+  just docs-build   # Expected: build succeeds
+  git add docs/integrations/litestar.md
+  git commit -m "docs: litestar — add API table"
+  ```
+
+---
+
+### Task 7: Starlette integration parity
+
+**Files:**
+- Modify: `docs/integrations/starlette.md`
+
+Bring Starlette to FastAPI parity: Scopes note, Websockets section (with a
+verified container-access pattern), Framework Context Objects, and an `## API`
+table. Symbols from `modern_di_starlette/main.py`.
+
+- [ ] **Step 1: Verify the websocket container-access pattern before writing it**
+
+  Starlette exposes **no** public `fetch_request_container`. Confirm how to reach
+  the SESSION container inside a Starlette websocket handler for a nested
+  per-message REQUEST scope. Write and run a throwaway check (scratchpad, do not
+  commit) that starts a Starlette app via `setup_di`, opens a websocket, and
+  resolves the container via `@inject` + type-based `Container` injection (the
+  auto-registered `container_provider` resolves to the active container):
+
+  ```python
+  # scratchpad probe — confirm Container is injectable inside a ws handler
+  import typing, modern_di
+  from modern_di_starlette import FromDI, inject
+  # @inject async def ws(websocket, container: typing.Annotated[modern_di.Container, FromDI(modern_di.providers.container_provider)]): ...
+  ```
+
+  If type/`container_provider` injection yields the SESSION child container,
+  document that in Step 3. If it does not work cleanly, document the limitation
+  explicitly instead (state that per-message REQUEST scope inside a Starlette ws
+  handler has no first-class accessor yet) — **do not invent an API.**
+
+- [ ] **Step 2: Add a `### 4. Scopes` note (after the existing "### 3. Scopes")**
+
+  Note the page's existing "### 3. Scopes" already covers HTTP→REQUEST /
+  WebSocket→SESSION. Rename nothing; instead expand it if needed so it states the
+  SESSION scope is entered automatically for websockets (mirroring aiohttp's
+  wording). If it already says this, skip.
+
+- [ ] **Step 3: Add the Websockets section**
+
+  Append after the Scopes section. Use the pattern confirmed in Step 1. Skeleton
+  (fill the handler body with the verified accessor):
+
+  ```
+  ## Websockets
+
+  A WebSocket connection opens a `Scope.SESSION` child container automatically and
+  keeps it for the whole connection. For per-message work, open a nested
+  `Scope.REQUEST` child of that session container:
+
+  ```python
+  import typing
+
+  import modern_di
+  from modern_di import Scope, providers
+  from modern_di_starlette import FromDI, inject
+  from starlette.websockets import WebSocket
+
+
+  @inject
+  async def ws_handler(
+      websocket: WebSocket,
+      container: typing.Annotated[modern_di.Container, FromDI(providers.container_provider)],
+  ) -> None:
+      await websocket.accept()
+      async for message in websocket.iter_text():
+          async with container.build_child_container(scope=Scope.REQUEST) as request_container:
+              ...  # resolve REQUEST-scoped providers for this message
+  ```
+  ```
+
+  (If Step 1 showed `container_provider` injection does not return the SESSION
+  child, replace this block with the documented-limitation note from Step 1.)
+
+- [ ] **Step 4: Add the Framework Context Objects section**
+
+  Mirror FastAPI/Litestar. Append:
+
+  ```
+  ## Framework Context Objects
+
+  Framework-specific context objects like `starlette.requests.Request` and
+  `starlette.websockets.WebSocket` are automatically made available by the
+  integration. You can reference these context providers implicitly through type
+  annotations or explicitly by importing them.
+
+  The following context providers are available for import:
+
+  - `starlette_request_provider` — the current `starlette.requests.Request` (REQUEST scope)
+  - `starlette_websocket_provider` — the current `starlette.websockets.WebSocket` (SESSION scope)
+
+  ### Implicit Usage (Type-based Resolution)
+
+  ```python
+  from starlette.requests import Request
+  from modern_di import Group, Scope, providers
+
+
+  def create_request_info(request: Request) -> dict[str, str]:
+      return {"method": request.method, "url": str(request.url)}
+
+
+  class AppGroup(Group):
+      request_info = providers.Factory(scope=Scope.REQUEST, creator=create_request_info)
+  ```
+
+  ### Explicit Usage (Provider-based Resolution)
+
+  ```python
+  import modern_di_starlette
+  from starlette.requests import Request
+  from modern_di import Group, Scope, providers
+
+
+  def create_request_info(request: Request) -> dict[str, str]:
+      return {"method": request.method, "url": str(request.url)}
+
+
+  class AppGroup(Group):
+      request_info = providers.Factory(
+          scope=Scope.REQUEST,
+          creator=create_request_info,
+          kwargs={"request": modern_di_starlette.starlette_request_provider},
+      )
+  ```
+  ```
+
+- [ ] **Step 5: Add the `## API` table**
+
+  ```
+  ## API
+
+  | Symbol | Description |
+  |---|---|
+  | `setup_di(app, container)` | Registers the container on `app.state`, composes the lifespan (opens/closes the container), and installs the middleware that builds a per-connection child container; returns the container. |
+  | `FromDI(dependency)` | Marker (used with `@inject`) that resolves a provider or type from the per-connection child container. |
+  | `inject` | Decorator for an `async def handler(connection: Request \| WebSocket, ...)`; resolves its `FromDI`-annotated parameters. |
+  | `fetch_di_container(app)` | Returns the root `Container` stored on `app.state`. |
+  | `starlette_request_provider` | `ContextProvider` for `starlette.requests.Request` (REQUEST scope), auto-registered. |
+  | `starlette_websocket_provider` | `ContextProvider` for `starlette.websockets.WebSocket` (SESSION scope), auto-registered. |
+  ```
+
+  Note: the `Request \| WebSocket` cell uses a real escaped pipe *outside* a code
+  span, which renders as `|`. (Do not use `&#124;` here — that trick is only for
+  pipes inside `` `code spans` ``.)
+
+- [ ] **Step 6: Verify and commit**
+
+  ```bash
+  just docs-build   # Expected: build succeeds, all anchors/links resolve
+  git add docs/integrations/starlette.md
+  git commit -m "docs: starlette — add websockets, context objects, and API table"
+  ```
+
+---
+
+### Task 8: Final validation
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Full docs build + planning check**
+
+  ```bash
+  just docs-build      # Expected: success
+  just check-planning  # Expected: planning: OK
+  ```
+
+- [ ] **Step 2: Finalize the bundle summary**
+
+  Confirm `design.md`'s `summary:` still describes the shipped result; adjust if
+  any task changed scope (e.g. the Starlette ws limitation path). Commit any edit:
+
+  ```bash
+  git add planning/changes/2026-07-04.02-docs-accuracy-parity/design.md
+  git commit -m "docs: finalize docs-accuracy-parity bundle summary" || true
+  ```
+
+- [ ] **Step 3: Push and open the PR**
+
+  ```bash
+  git push -u origin docs/accuracy-parity
+  gh pr create --fill --title "docs: accuracy + integration-parity pass"
+  ```
+  Then watch CI (the `docs-build` and lint jobs) until green.


### PR DESCRIPTION
Documentation-only pass fixing rendering bugs, factual errors, framework-list drift, and integration-page parity gaps found in a read-through of the published site. No library or integration source changes.

Spec + plan: `planning/changes/2026-07-04.02-docs-accuracy-parity/`.

## What changed

**Rendering**
- 9 paragraph-then-list collapses fixed (missing blank line made ordered/bulleted lists render inline), incl. the `factories.md` `creator`/`skip_creator_parsing` lists.
- Signature-support-matrix and Starlette `inject` table cells now use a raw `|` inside code spans. Both `\|` and `&#124;` render as literal text under mkdocs-material's table extension; a raw pipe renders `|` and does not split the table (verified in the built HTML).

**Factual corrections**
- `comparison.md`: custom scopes no longer denied (modern-di accepts any `IntEnum`; links to `scopes.md#custom-scopes`), and Dishka autowiring is no longer framed as exclusive to modern-di.
- "Sync only" clarified in comparison / that-depends / design-decisions: resolution is sync, but finalizers may be sync **or** async.
- `design-decisions.md` concurrency bullets tightened (register-before-serve; `set_context`/overrides last-write-wins) without changing their meaning.
- `async-lifespan.md`: explains why `asyncpg.create_pool` needs the lifespan (awaitable pool; no async initializer).

**Framework-list de-drift**
- `about-di.md` and `scopes.md` link to the canonical list instead of re-enumerating; fixed the clipped/under-inclusive subsets.

**API surface**
- `advanced-api.md` split into supported extension points vs. no-guarantee Container internals (no symbol renames).

**Integration parity (aiohttp / Litestar / Starlette)**
- Added `## API` tables to all three, grounded in each package's `__all__`.
- aiohttp: explained why WebSocket wiring is explicit (a WebSocket is an upgraded `web.Request`; `aiohttp_websocket_provider` is `bound_type=None`).
- Starlette brought to FastAPI parity: Scopes note, Websockets section, Framework Context Objects, API table. The websocket example (obtain the SESSION child via `FromDI(container_provider)`, then nest a REQUEST child) was verified end-to-end with a Starlette TestClient probe and by tracing the integration source.

## Deliberately deferred
- Underscore-privatizing the Container internals (`find_container`, `parent_container`, `scope_map`, `lock`) — a breaking public-API change; needs its own bundle with a deprecation decision. Confirmed none of the six integrations consume them.

## Verification
`just docs-build` (mkdocs `--strict`) clean; `just check-planning` OK. Docs-only, no pytest impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
