### PR TITLE
feat: soften ContainerClosedError to a self-healing ContainerClosedWarning (restore hard error in 3.0)

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -40,7 +40,9 @@ Rules:
 - The child's scope must be strictly greater (deeper) than the parent's scope. Passing `scope=None`
   auto-increments to the next `IntEnum` value; if the parent is already at the maximum scope,
   `MaxScopeReachedError` is raised.
-- Building a child from a closed container raises `ContainerClosedError`.
+- Building a child from a closed container is transitional until modern-di 3.0: it emits
+  `ContainerClosedWarning` and self-reopens the container instead of raising `ContainerClosedError`
+  (see [Lifecycle: close and reopen](#lifecycle-close-and-reopen) below).
 
 The child gets its own, independent `scope_map` dict that includes all ancestors plus itself,
 enabling `find_container(scope)` to walk up to any ancestor scope in O(1).
@@ -94,8 +96,12 @@ The rest of this section documents what that close performs and how reopen works
    `AsyncFinalizerInSyncCloseError`; those items are left in `_creation_order` so a subsequent
    `close_async()` can clean them up.
 
-2. **`closed = True`** — always set in a `finally` block, even if finalizers raised. Subsequent
-   calls to `build_child_container` or `resolve_provider` raise `ContainerClosedError`.
+2. **`closed = True`** — always set in a `finally` block, even if finalizers raised. Until modern-di
+   3.0, a subsequent `resolve_provider` / `build_child_container` (or a nested provider resolving at
+   a closed ancestor scope) emits a `ContainerClosedWarning` and **self-reopens** the container, then
+   proceeds — preserving pre-2.16 "close then resolve" code. Escalate the warning
+   (`warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)`) to opt into the
+   strict behavior early. In 3.0 these paths raise `ContainerClosedError` instead.
 
 Additionally, when `close_sync()` or `close_async()` is called on a **root** container (one with
 no `parent_container`), all overrides are cleared from the shared `OverridesRegistry` before the

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -152,8 +152,10 @@ a type at call sites.
 ## Lifecycle rules
 
 - **Reopen the root container on startup.** A container that was closed on
-  shutdown raises `ContainerClosedError` if reused. Reopening on each startup
-  lets a second lifespan cycle (test client re-entry, broker restart) work.
+  shutdown emits a `ContainerClosedWarning` (and, in 3.0, raises
+  `ContainerClosedError`) if reused without reopening. Reopening on each
+  startup lets a second lifespan cycle (test client re-entry, broker restart)
+  work.
     - With a context-manager lifespan: `async with fetch_di_container(app): yield`
       — `__aenter__` reopens, `__aexit__` closes. Compose *around* any existing
       lifespan rather than replacing it.
@@ -345,8 +347,8 @@ Each official integration is its own repository and PyPI package, mirroring the
 - [ ] `fetch_di_container` reads the root container back out of framework state.
 - [ ] A per-unit-of-work builder opens a child container at the right scope,
       injects the connection as context, and closes it in `finally`.
-- [ ] Root container **reopens on startup** so restarts don't raise
-      `ContainerClosedError`.
+- [ ] Root container **reopens on startup** so restarts don't emit a
+      `ContainerClosedWarning` (or, in 3.0, raise `ContainerClosedError`).
 - [ ] `close_async` / `close_sync` matches the framework's async-ness.
 - [ ] `FromDI` accepts `AbstractProvider[T] | type[T]` and dispatches
       `resolve_provider` vs `resolve`.

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -60,9 +60,11 @@ Catch `ContainerError` for any container/scope failure.
   See [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md).
 - **`InvalidScopeTypeError`** — raised by the `Container` constructor when `scope` is not an
   `enum.IntEnum`.
-- **`ContainerClosedError`** — raised when you resolve from, or build a child of, a container that
-  has been closed (`close_sync()` / `close_async()` ran, or a `with` block exited). Re-enter the
-  `with` block to reopen it.
+- **`ContainerClosedError`** — raised in modern-di **3.0** when you resolve from, or build a child
+  of, a closed container. Until then that reuse emits a **`ContainerClosedWarning`** (a
+  `DeprecationWarning`) and the container self-reopens. Re-enter the `with` block or call `open()`
+  to reuse it cleanly; escalate the warning with
+  `warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)` to fail fast today.
 - **`ValidationFailedError`** — raised by `Container.validate()` (and `Container(..., validate=True)`)
   when the graph has problems. Catch this for validation results; its `.errors` attribute holds the
   list of individual issues (each itself a `ResolutionError` or `RegistrationError`), and `str()`

--- a/docs/providers/lifecycle.md
+++ b/docs/providers/lifecycle.md
@@ -135,6 +135,9 @@ How a cached instance survives this cycle depends on its `CacheSettings`:
   again — the *same object* (its finalizer runs once, at the first close, and is not
   re-run on later closes). Use this for a shared resource whose identity must stay stable
   across restarts.
+- Overrides are not part of this survival — closing a root container resets its
+  overrides registry, and self-reopen does not restore overrides set beforehand; only
+  cached instances (with `clear_cache=False`) survive close→reopen.
 
 !!! caution "The context manager is not reference-counted"
     Nesting `with container:` on the **same** object closes it on the inner `with` exit,

--- a/docs/providers/lifecycle.md
+++ b/docs/providers/lifecycle.md
@@ -109,10 +109,10 @@ Entering `with container:` (or `async with`) opens the container; exiting calls
 `close_sync()` / `close_async()`, which run the finalizers (in reverse-creation order, as
 above) and mark the container closed.
 
-While a container is closed, resolving a dependency — or building a child container —
-raises `ContainerClosedError` (see [Errors and exceptions](errors-and-exceptions.md) for full
-details). Attempting either outside of a re-entered context manager will always raise that error.
-Re-entering `with container:` reopens it, and resolution works again:
+While a container is closed, resolving a dependency — or building a child container — emits a
+`ContainerClosedWarning` and reopens the container so the call succeeds (transitional; modern-di
+3.0 will raise `ContainerClosedError` instead — see [Errors and exceptions](errors-and-exceptions.md)).
+Re-entering `with container:` reopens it cleanly, without a warning, and resolution works again:
 
 ```python
 container = Container(groups=[Dependencies])
@@ -121,7 +121,7 @@ with container:
     container.resolve(Settings)
 # closed here — finalizers ran
 
-# container.resolve(Settings)  -> raises ContainerClosedError
+# container.resolve(Settings)  -> warns (ContainerClosedWarning) and self-reopens
 
 with container:                 # reopened
     container.resolve(Settings)

--- a/docs/superpowers/plans/2026-07-05-soften-container-closed-error.md
+++ b/docs/superpowers/plans/2026-07-05-soften-container-closed-error.md
@@ -1,0 +1,569 @@
+# Soften ContainerClosedError to a Self-Healing Deprecation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reuse of a closed container (`resolve` / `build_child_container`) emits a `ContainerClosedWarning` and self-reopens instead of raising `ContainerClosedError`, restoring pre-2.16 "close then resolve" behavior; the hard error returns as the default in 3.0.
+
+**Architecture:** One private `Container._warn_and_reopen_if_closed()` helper replaces the four `if closed: raise ContainerClosedError(...)` sites. When called on a closed container it warns once and calls `self.open()`, then resolution proceeds. The two nested provider sites (`factory`, `context_provider`) call it on the `find_container(self.scope)` result, so a closed *ancestor* heals too. `ContainerClosedError` stays in the taxonomy (unraised until 3.0), covered by a direct unit test.
+
+**Tech Stack:** Python 3.10+ (`enum.IntEnum`, `warnings` stdlib), pytest (`asyncio_mode=auto`), `just`, `uv`, `ruff` (`select=ALL`), `ty`.
+
+**Spec:** [`docs/superpowers/specs/2026-07-05-soften-container-closed-error-design.md`](../specs/2026-07-05-soften-container-closed-error-design.md)
+
+## Global Constraints
+
+- **Zero runtime dependencies** — stdlib only (`warnings` is stdlib).
+- **Line length 120**; `ruff` `select=["ALL"]` (minimal ignores); `ty` for typing. Use `ty: ignore`, never `type: ignore`.
+- **All imports at module level**; annotate every function argument.
+- **Cross-class access to a `_`-prefixed method needs `# noqa: SLF001`** (precedent: `modern_di/providers/alias.py:63`).
+- **100% line coverage** on the gated run `just test-ci` (CI). Targeted `just test <path>` runs are ungated.
+- The emitted warning is a `DeprecationWarning` subclass.
+- Ships in **2.22.0** (backward-compatible). The hard `ContainerClosedError` default returns in **3.0** — wording in messages/docstrings/docs must say "modern-di 3.0", never a dated window.
+- Resolution is sync-only; finalizers may be sync or async — do not touch `close_sync`/`close_async` semantics.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `modern_di/exceptions.py` | Exception/warning taxonomy | Add `ContainerClosedWarning`; note 3.0 on `ContainerClosedError` docstring |
+| `modern_di/container.py` | Container lifecycle + resolution entry | Add `import warnings`; add `_warn_and_reopen_if_closed`; rewire 2 entry sites |
+| `modern_di/providers/factory.py` | Factory resolution | Rewire the closed-check at `resolve` |
+| `modern_di/providers/context_provider.py` | Context value lookup | Rewire the closed-check; drop now-unused `exceptions` import |
+| `tests/test_container.py` | Container behavior tests | Flip entry + nested reuse tests to `pytest.warns`; add warn/heal, strict-opt-in, error-class unit tests |
+| `tests/providers/test_singleton.py` | Factory/singleton tests | Flip 3 reuse-after-close sites; trim unused import |
+| `tests/providers/test_context_provider.py` | Context provider tests | Flip the closed-owner test; trim unused import |
+| `architecture/containers.md` | Truth home: container lifecycle | Promote: reuse warns + self-heals (3.0 restores raise) |
+| `docs/providers/lifecycle.md`, `docs/providers/errors-and-exceptions.md`, `docs/integrations/writing-integrations.md` | User docs | Match new behavior |
+| `planning/changes/2026-07-05.01-soften-container-closed-error/` | Change bundle (Full lane) | `design.md` + `plan.md` |
+| `planning/releases/2.22.0.md` | Release notes draft | New file |
+
+---
+
+### Task 1: Warning type, helper, and container entry sites
+
+**Files:**
+- Modify: `modern_di/exceptions.py` (after `ContainerClosedError`, ~line 118)
+- Modify: `modern_di/container.py` (imports; `build_child_container` ~98-99; `resolve_provider` ~138-139; add helper near `open()` ~254)
+- Test: `tests/test_container.py`, `tests/providers/test_singleton.py`
+
+**Interfaces:**
+- Produces: `modern_di.exceptions.ContainerClosedWarning(DeprecationWarning)` and `Container._warn_and_reopen_if_closed(self) -> None` (warns once + `self.open()` when `self.closed`, else no-op). Task 2 consumes the helper.
+
+- [ ] **Step 1: Write the failing warn-and-heal tests** in `tests/test_container.py`. First adjust imports: add `import warnings` to the stdlib block (after `import copy`), and add `ContainerClosedWarning` to the existing `from modern_di.exceptions import (...)` block (keep `ContainerClosedError` — the error-class test below uses it). Both are referenced by their bare imported names, matching this file's import style. Then add after `test_open_reopens_closed_container` (~line 414):
+
+```python
+def test_reuse_after_close_warns_and_reopens() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        resolved = container.resolve(Container)
+    assert resolved is container
+    assert container.closed is False
+
+
+def test_build_child_after_close_warns_and_reopens() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        child = container.build_child_container(scope=Scope.REQUEST)
+    assert container.closed is False
+    assert child.scope is Scope.REQUEST
+
+
+def test_reuse_warns_once_per_close_cycle() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        container.resolve(Container)
+        container.resolve(Container)
+    closed_warnings = [w for w in caught if issubclass(w.category, ContainerClosedWarning)]
+    assert len(closed_warnings) == 1
+
+
+def test_strict_opt_in_reuse_raises() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ContainerClosedWarning)
+        with pytest.raises(ContainerClosedWarning):
+            container.resolve(Container)
+
+
+def test_container_closed_error_message_and_attr() -> None:
+    err = ContainerClosedError(container_scope=Scope.APP)
+    assert err.container_scope is Scope.APP
+    assert "closed" in str(err)
+    assert "Create a new container" in str(err)
+```
+
+- [ ] **Step 2: Run the new tests — expect failure**
+
+  Run: `just test tests/test_container.py -k "reuse_after_close or build_child_after_close or reuse_warns_once or strict_opt_in or closed_error_message"`
+  Expected: FAIL — `AttributeError`/`ImportError` for `ContainerClosedWarning` (not defined yet), and the resolve calls currently raise `ContainerClosedError`.
+
+- [ ] **Step 3: Add `ContainerClosedWarning` and note 3.0 on the error** in `modern_di/exceptions.py`. Insert directly after the `ContainerClosedError` class (after line 118):
+
+```python
+class ContainerClosedWarning(DeprecationWarning):
+    """Reuse of a closed container (resolve / build a child) — transitional.
+
+    The reuse works today because the container self-reopens, but it will raise
+    :class:`ContainerClosedError` in modern-di 3.0. Opt into strict behavior now
+    by escalating this warning::
+
+        warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)
+    """
+```
+
+  Update the `ContainerClosedError` docstring (line 109) to:
+
+```python
+    """Operation attempted on a closed container. Attr: ``container_scope``. Raised in modern-di 3.0; until then reuse emits :class:`ContainerClosedWarning` and self-reopens."""
+```
+
+- [ ] **Step 4: Add `import warnings`** to `modern_di/container.py` stdlib imports (alphabetical: after `import typing`, line 3):
+
+```python
+import enum
+import threading
+import typing
+import warnings
+```
+
+- [ ] **Step 5: Add the helper** in `modern_di/container.py`. Insert immediately after the `open()` method (after line 254, before `__enter__`):
+
+```python
+    def _warn_and_reopen_if_closed(self) -> None:
+        """Transitional shim for reuse of a closed container.
+
+        Emits :class:`~modern_di.exceptions.ContainerClosedWarning` and reopens
+        (so pre-2.16 "close then resolve" code keeps working); modern-di 3.0
+        will raise :class:`~modern_di.exceptions.ContainerClosedError` here
+        instead. One warning per close→reuse transition, since it self-reopens.
+        """
+        if not self.closed:
+            return
+        warnings.warn(
+            f"Container (scope {self.scope.name}) is closed; resolving from it or building a child "
+            "is deprecated and will raise ContainerClosedError in modern-di 3.0. Re-enter the "
+            "container with `with`/`async with`, or call `open()`, before reusing it.",
+            exceptions.ContainerClosedWarning,
+            stacklevel=2,
+        )
+        self.open()
+```
+
+- [ ] **Step 6: Rewire the two entry sites** in `modern_di/container.py`.
+
+  In `build_child_container`, replace (lines 98-99):
+
+```python
+        if self.closed:
+            raise exceptions.ContainerClosedError(container_scope=self.scope)
+```
+
+  with:
+
+```python
+        self._warn_and_reopen_if_closed()
+```
+
+  In `resolve_provider`, replace (lines 138-139):
+
+```python
+        if self.closed:
+            raise exceptions.ContainerClosedError(container_scope=self.scope)
+```
+
+  with:
+
+```python
+        self._warn_and_reopen_if_closed()
+```
+
+- [ ] **Step 7: Run the new tests — expect pass**
+
+  Run: `just test tests/test_container.py -k "reuse_after_close or build_child_after_close or reuse_warns_once or strict_opt_in or closed_error_message"`
+  Expected: PASS (5 tests).
+
+- [ ] **Step 8: Flip the existing entry-path reuse tests in `tests/test_container.py`.**
+
+  `test_closed_container_refuses_resolve_and_child_building` → rename and rewrite:
+
+```python
+def test_closed_container_warns_and_reopens_on_resolve_and_child_building() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        container.resolve(Container)
+    container.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        container.build_child_container(scope=Scope.REQUEST)
+```
+
+  `test_closed_container_async_path`:
+
+```python
+async def test_closed_container_async_path() -> None:
+    container = Container(scope=Scope.APP)
+    await container.close_async()
+    with pytest.warns(ContainerClosedWarning):
+        assert container.resolve(Container) is container
+```
+
+  In `test_async_context_manager_reopens`, replace the `with pytest.raises(ContainerClosedError):` block with:
+
+```python
+    with pytest.warns(ContainerClosedWarning):
+        assert container.resolve(Container) is container
+```
+
+  In `test_open_reopens_closed_container`, replace the `with pytest.raises(ContainerClosedError):` block with:
+
+```python
+    with pytest.warns(ContainerClosedWarning):
+        assert container.resolve(Container) is container
+```
+
+- [ ] **Step 9: Flip the entry-path reuse tests in `tests/providers/test_singleton.py`.**
+
+  Add `ContainerClosedWarning` to the import (line 9):
+
+```python
+from modern_di.exceptions import (
+    AsyncFinalizerInSyncCloseError,
+    ContainerClosedWarning,
+    FinalizerError,
+)
+```
+
+  Remove `ContainerClosedError` from that import (it becomes unused in this file). Then replace each of the three blocks:
+
+  Around line 56:
+
+```python
+    with pytest.warns(ContainerClosedWarning):
+        app_container.resolve_provider(LocalGroup.singleton)
+```
+
+  Around line 100:
+
+```python
+    with pytest.warns(ContainerClosedWarning):
+        container.resolve(str)
+```
+
+  In `test_persistent_provider_survives_close_reopen_cycle` (around line 472), replace the `# resolving while closed raises` block:
+
+```python
+    # resolving while closed warns and self-reopens (transitional; 3.0 restores the raise)
+    with pytest.warns(ContainerClosedWarning):
+        container.resolve(_PersistentBroker)
+```
+
+- [ ] **Step 10: Run the touched test files**
+
+  Run: `just test tests/test_container.py tests/providers/test_singleton.py`
+  Expected: PASS (all).
+
+- [ ] **Step 11: Lint**
+
+  Run: `just lint`
+  Expected: no errors (autofix clean; no unused-import warnings).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add modern_di/exceptions.py modern_di/container.py tests/test_container.py tests/providers/test_singleton.py
+git commit -m "feat: soften closed-container reuse to self-healing ContainerClosedWarning at entry sites"
+```
+
+---
+
+### Task 2: Rewire the nested provider sites
+
+**Files:**
+- Modify: `modern_di/providers/factory.py` (`resolve`, ~243-246)
+- Modify: `modern_di/providers/context_provider.py` (`fetch_context_value`, ~48-52; imports line 4)
+- Test: `tests/test_container.py`, `tests/providers/test_context_provider.py`
+
+**Interfaces:**
+- Consumes: `Container._warn_and_reopen_if_closed()` from Task 1.
+
+- [ ] **Step 1: Write the failing nested warn-and-heal tests.**
+
+  In `tests/test_container.py`, rewrite `test_resolving_through_closed_parent_via_open_child_raises`:
+
+```python
+def test_resolving_through_closed_parent_via_open_child_warns_and_reopens() -> None:
+    app = Container(scope=Scope.APP, groups=[_AppBrokerGroup])
+    child = app.build_child_container(scope=Scope.REQUEST)
+    app.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        broker = child.resolve(_PersistentBroker)
+    assert isinstance(broker, _PersistentBroker)
+    assert app.closed is False
+```
+
+  In `tests/providers/test_context_provider.py`, rewrite `test_context_provider_through_closed_owning_container_raises`:
+
+```python
+def test_context_provider_through_closed_owning_container_warns_and_reopens() -> None:
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    app = Container(groups=[MyGroup], context={datetime.datetime: now})
+    child = app.build_child_container(scope=Scope.REQUEST)
+    app.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        assert child.resolve_provider(MyGroup.context_provider) == now
+    assert app.closed is False
+```
+
+  Update the import in `tests/providers/test_context_provider.py` (line 7) to drop `ContainerClosedError` (now unused there) and add `ContainerClosedWarning`:
+
+```python
+from modern_di.exceptions import ArgumentResolutionError, ContainerClosedWarning
+```
+
+- [ ] **Step 2: Run the new nested tests — expect failure**
+
+  Run: `just test tests/test_container.py::test_resolving_through_closed_parent_via_open_child_warns_and_reopens tests/providers/test_context_provider.py::test_context_provider_through_closed_owning_container_warns_and_reopens`
+  Expected: FAIL — the nested sites still raise `ContainerClosedError`, so `pytest.warns` sees an exception instead of a warning.
+
+- [ ] **Step 3: Rewire the factory site** in `modern_di/providers/factory.py`. Replace (lines 245-246):
+
+```python
+        if container.closed:
+            raise exceptions.ContainerClosedError(container_scope=container.scope)
+```
+
+  with:
+
+```python
+        container._warn_and_reopen_if_closed()  # noqa: SLF001
+```
+
+- [ ] **Step 4: Rewire the context-provider site** in `modern_di/providers/context_provider.py`. Replace (lines 50-51):
+
+```python
+        if container.closed:
+            raise exceptions.ContainerClosedError(container_scope=container.scope)
+```
+
+  with:
+
+```python
+        container._warn_and_reopen_if_closed()  # noqa: SLF001
+```
+
+  This removes the only `exceptions.` use in the file — change the import (line 4) from:
+
+```python
+from modern_di import exceptions, types
+```
+
+  to:
+
+```python
+from modern_di import types
+```
+
+- [ ] **Step 5: Run the nested tests — expect pass**
+
+  Run: `just test tests/test_container.py::test_resolving_through_closed_parent_via_open_child_warns_and_reopens tests/providers/test_context_provider.py::test_context_provider_through_closed_owning_container_warns_and_reopens`
+  Expected: PASS (2 tests).
+
+- [ ] **Step 6: Lint (catches SLF001 / unused-import mistakes)**
+
+  Run: `just lint`
+  Expected: no errors. If SLF001 fires, confirm the `# noqa: SLF001` is on the call line; if F401 fires on `exceptions`, confirm the import was trimmed in Step 4.
+
+- [ ] **Step 7: Full gated run**
+
+  Run: `just test-ci`
+  Expected: PASS with **100% line coverage**. (The removed `raise` branches are gone; the helper's two branches and `ContainerClosedError.__init__` are covered by Task 1 tests.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add modern_di/providers/factory.py modern_di/providers/context_provider.py tests/test_container.py tests/providers/test_context_provider.py
+git commit -m "feat: self-heal closed-ancestor reuse at factory and context-provider sites"
+```
+
+---
+
+### Task 3: Docs, architecture promotion, release notes, and change bundle
+
+**Files:**
+- Modify: `architecture/containers.md`, `docs/providers/lifecycle.md`, `docs/providers/errors-and-exceptions.md`, `docs/integrations/writing-integrations.md`
+- Create: `planning/changes/2026-07-05.01-soften-container-closed-error/design.md`, `.../plan.md`, `planning/releases/2.22.0.md`
+
+One task: it carries no runtime code, and its gate is `just lint-ci` (which validates planning bundles) plus a consistency read. Do not split — a reviewer would accept/reject the doc set as a unit.
+
+- [ ] **Step 1: Promote the truth home** — edit `architecture/containers.md` lifecycle section. Find the lines stating reuse raises `ContainerClosedError` (the "`closed = True` — always set … Subsequent calls to `build_child_container` or `resolve_provider` raise `ContainerClosedError`" bullet, ~line 97-98) and rewrite to describe the transitional behavior:
+
+  > **`closed = True`** — always set in a `finally` block, even if finalizers raised. Until modern-di 3.0, a subsequent `resolve_provider` / `build_child_container` (or a nested provider resolving at a closed ancestor scope) emits a `ContainerClosedWarning` and **self-reopens** the container, then proceeds — preserving pre-2.16 "close then resolve" code. Escalate the warning (`warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)`) to opt into the strict behavior early. In 3.0 these paths raise `ContainerClosedError` instead.
+
+  Keep the existing `open()` / context-manager reopen paragraphs; they are unchanged.
+
+- [ ] **Step 2: Update `docs/providers/lifecycle.md`** (§ "Closing and reopening", lines ~112-124). Replace the "raises `ContainerClosedError`" sentence and the `-> raises ContainerClosedError` code comment with the warn+self-heal description, e.g.:
+
+  Prose (line ~112):
+  > While a container is closed, resolving a dependency — or building a child container — emits a `ContainerClosedWarning` and reopens the container so the call succeeds (transitional; modern-di 3.0 will raise `ContainerClosedError` instead — see [Errors and exceptions](errors-and-exceptions.md)).
+
+  Code comment (line ~124):
+  ```python
+  # container.resolve(Settings)  -> warns (ContainerClosedWarning) and self-reopens
+  ```
+
+- [ ] **Step 3: Update `docs/providers/errors-and-exceptions.md`.** Add `ContainerClosedWarning` context to the `ContainerClosedError` bullet (lines ~63-65):
+
+  > **`ContainerClosedError`** — raised in modern-di **3.0** when you resolve from, or build a child of, a closed container. Until then that reuse emits a **`ContainerClosedWarning`** (a `DeprecationWarning`) and the container self-reopens. Re-enter the `with` block or call `open()` to reuse it cleanly; escalate the warning with `warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)` to fail fast today.
+
+  Leave the tree diagram's `ContainerClosedError` node (line ~22) as-is (it is still a real class).
+
+- [ ] **Step 4: Update `docs/integrations/writing-integrations.md`** (lines ~154-158 and the checklist item ~348-349). Soften "raises `ContainerClosedError` if reused" to "emits a `ContainerClosedWarning` (and, in 3.0, raises `ContainerClosedError`) if reused without reopening", keeping the "reopen the root container on startup" guidance as the recommended practice.
+
+- [ ] **Step 5: Create the change bundle** `planning/changes/2026-07-05.01-soften-container-closed-error/design.md`:
+
+```markdown
+---
+summary: Reuse of a closed container warns (ContainerClosedWarning) and self-reopens instead of raising; hard ContainerClosedError returns in 3.0.
+---
+
+# Design: Soften closed-container reuse to a self-healing deprecation
+
+## Summary
+
+The hard `ContainerClosedError` added in 2.16.0 broke "close then resolve"
+code (including maintainer projects) that relied on pre-2.16 lenient behavior.
+Reuse of a closed container now emits `ContainerClosedWarning` and self-reopens
+so the call succeeds; the error returns as the default in 3.0. Full brainstorm
+spec: `docs/superpowers/specs/2026-07-05-soften-container-closed-error-design.md`.
+
+## Motivation
+
+`resolve_provider` / `build_child_container` and two nested provider paths
+(`factory`, `context_provider`) started raising when `closed=True`. Downstream
+lifecycles that close then reuse require invasive rewrites. Making the change
+transitional removes that forced migration.
+
+## Non-goals
+
+- A `Container(strict_closed=...)` toggle — deferred; the `warnings` filter
+  covers strictness for now.
+- Changing `close_sync` / `close_async` / `open` semantics.
+
+## Design
+
+One private `Container._warn_and_reopen_if_closed()` replaces the four
+`if closed: raise` sites; it warns once and calls `self.open()`. Nested sites
+call it on the `find_container(self.scope)` result, healing a closed ancestor.
+`ContainerClosedError` is retained (unraised until 3.0) and covered by a direct
+unit test. New `ContainerClosedWarning(DeprecationWarning)` is filterable to an
+error for strict opt-in.
+
+## Testing
+
+Reuse-after-close tests flip from `pytest.raises(ContainerClosedError)` to
+`pytest.warns(ContainerClosedWarning)` + success assertions; added tests cover
+one-warning-per-cycle, nested-ancestor heal, strict opt-in, and the retained
+error class. `just test-ci` stays at 100% line coverage.
+
+## Risk
+
+Low. Behavior is strictly more permissive than 2.16–2.21; code that expected
+the error can escalate the warning. Main risk is doc drift — mitigated by the
+`architecture/containers.md` promotion in this PR.
+```
+
+- [ ] **Step 6: Create the bundle plan pointer** `planning/changes/2026-07-05.01-soften-container-closed-error/plan.md`:
+
+```markdown
+# soften-container-closed-error — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Ship the self-healing `ContainerClosedWarning` (2.22.0); restore the
+hard error in 3.0.
+
+**Spec:** [`design.md`](./design.md)
+
+**Full task breakdown:** `docs/superpowers/plans/2026-07-05-soften-container-closed-error.md`
+
+**Commit strategy:** Per-task commits (warning+entry sites · provider sites · docs).
+```
+
+- [ ] **Step 7: Create the release notes draft** `planning/releases/2.22.0.md`:
+
+```markdown
+# modern-di 2.22.0 — closed-container reuse is a deprecation, not a hard error
+
+Reuse of a closed container no longer raises. `resolve` / `build_child_container`
+(and nested providers resolving at a closed ancestor scope) now emit a
+`ContainerClosedWarning` and self-reopen the container, restoring pre-2.16
+"close then resolve" behavior. The hard `ContainerClosedError` returns as the
+default in **3.0**.
+
+## Fix
+
+- **Closed-container reuse is transitional again.** The `ContainerClosedError`
+  introduced in 2.16.0 (#202) was a breaking change for lifecycles that close
+  then keep resolving. Reuse now warns (`exceptions.ContainerClosedWarning`, a
+  `DeprecationWarning`) and self-reopens instead of raising. One warning fires
+  per close→reuse transition.
+
+## Deprecation
+
+- Resolving from / building a child of a closed container is deprecated and will
+  raise `ContainerClosedError` in modern-di 3.0. Wrap the container in
+  `with` / `async with`, or call `open()`, before reuse. To fail fast today:
+  `warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)`.
+
+## Downstream
+
+No action required to keep working. Integrations that reopen the root container
+on startup are already on the recommended path.
+
+## Internals
+
+- 100% line coverage across supported Python versions retained.
+```
+
+  Note: the maintainer finalizes/renames this file at release time (releases are tag-driven and may batch other changes).
+
+- [ ] **Step 8: Validate planning bundles and docs lint**
+
+  Run: `just check-planning && just lint-ci`
+  Expected: both PASS (bundle structure valid; no lint regressions — `docs/` is excluded from ruff, so this validates the bundle wiring).
+
+- [ ] **Step 9: Consistency read** — grep the repo for any remaining stale claim that reuse "raises `ContainerClosedError`" unconditionally:
+
+  Run: `grep -rn "raises \`ContainerClosedError\`\|raise ContainerClosedError\|-> raises ContainerClosedError" docs/ architecture/`
+  Expected: only 3.0-qualified mentions remain (no unconditional "raises" claims outside the retained-class descriptions).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add architecture/containers.md docs/providers/lifecycle.md docs/providers/errors-and-exceptions.md docs/integrations/writing-integrations.md planning/changes/2026-07-05.01-soften-container-closed-error planning/releases/2.22.0.md
+git commit -m "docs: document self-healing ContainerClosedWarning; add change bundle and 2.22.0 notes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 warning type → Task 1 Steps 3.
+- §2 helper + four call sites → Task 1 (helper + 2 entry sites), Task 2 (2 provider sites).
+- §3 reuse semantics unchanged → asserted via `is` / same-object checks (Task 1 async/persistent tests, Task 2 nested tests); no `open`/`close` edits.
+- §4 `ContainerClosedError` retained + covered → Task 1 docstring edit + `test_container_closed_error_message_and_attr`.
+- §5 tests (flip, one-warning, nested, strict opt-in, error unit) → Task 1 Steps 1/8/9, Task 2 Steps 1.
+- §6 docs + planning → Task 3.
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; every command has expected output.
+
+**Type/name consistency:** `ContainerClosedWarning`, `_warn_and_reopen_if_closed`, `ContainerClosedError(container_scope=...)`, and test names are used identically across tasks. `# noqa: SLF001` appears at both cross-class call sites.
+
+**Note on imported names:** Task 1 tests reference the bare imported `ContainerClosedWarning` / `ContainerClosedError` (added to each test file's `from modern_di.exceptions import ...` block), not an `exceptions.` prefix — matching each test file's existing import style.

--- a/docs/superpowers/specs/2026-07-05-soften-container-closed-error-design.md
+++ b/docs/superpowers/specs/2026-07-05-soften-container-closed-error-design.md
@@ -1,0 +1,140 @@
+# Design: soften `ContainerClosedError` to a self-healing deprecation
+
+## Problem
+
+In `2.16.0` (commit `b4c7f23`, PR #202) closing a container began setting
+`closed = True`, and `resolve_provider` / `build_child_container` started raising
+`ContainerClosedError` when the container is closed. Two nested provider paths
+(`factory.py`, `context_provider.py`) raise it too, checked against the
+container at the provider's own scope (via `find_container(self.scope)`).
+
+Before `2.16.0`, closing only ran finalizers and cleared the cache; a subsequent
+`resolve()` silently rebuilt instances, so "close then keep resolving" worked.
+The new hard error is a **breaking change** that forces invasive rewrites in
+downstream code (including the maintainer's own projects) built on the old
+lenient behavior.
+
+## Goal
+
+Make the change **transitional**, not permanent: restore the lenient
+"reuse-after-close works" behavior now, behind a `DeprecationWarning`, and
+reinstate the hard `ContainerClosedError` as the default in `3.0`. Downstream
+code keeps working today and migrates on its own schedule (wrap in `with`, or
+call `open()`).
+
+Non-goal: a `Container(strict_closed=...)` config toggle. It can be layered on
+later if a programmatic strict mode is actually wanted; the Pythonic
+`warnings.filterwarnings("error", ...)` escape hatch covers strictness for now.
+
+## Design
+
+### 1. New warning type
+
+Add `ContainerClosedWarning(DeprecationWarning)` to `modern_di/exceptions.py`,
+alongside the existing exception taxonomy. Plain subclass, no custom `__init__`,
+so users can target it precisely:
+
+```python
+warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)
+```
+
+Exceptions are surfaced only as `modern_di.exceptions.*` (no top-level
+re-export, no `__all__`); the warning follows the same convention.
+
+### 2. One helper, four call sites
+
+Add a private `Container` method:
+
+```python
+def _warn_and_reopen_if_closed(self) -> None:
+    if not self.closed:
+        return
+    warnings.warn(
+        f"Container (scope {self.scope.name}) is closed; resolving from it or building a child "
+        "is deprecated and will raise ContainerClosedError in modern-di 3.0. Re-enter the "
+        "container with `with`/`async with`, or call `open()`, before reusing it.",
+        ContainerClosedWarning,
+        stacklevel=2,
+    )
+    self.open()
+```
+
+Replace each of the four `if ...closed: raise ContainerClosedError(...)` sites
+with a call on the correct instance:
+
+| Site | Current | New |
+|---|---|---|
+| `container.py` `build_child_container` | `raise` on `self.closed` | `self._warn_and_reopen_if_closed()` |
+| `container.py` `resolve_provider` | `raise` on `self.closed` | `self._warn_and_reopen_if_closed()` |
+| `providers/factory.py` `resolve` | `raise` on `container.closed` | `container._warn_and_reopen_if_closed()` |
+| `providers/context_provider.py` `fetch_context_value` | `raise` on `container.closed` | `container._warn_and_reopen_if_closed()` |
+
+In the two provider sites `container` is the `find_container(self.scope)`
+result, so a resolve from an **open child** whose provider resolves at a
+**closed ancestor** scope heals that ancestor — matching pre-2.16 behavior.
+
+Because the helper calls `self.open()`, resolution proceeds on an open
+container and exactly **one** warning fires per close→reuse transition, not one
+per resolve (no warning spam, and `.closed` is coherent after the call).
+
+`stacklevel=2` is best-effort: the four sites sit at different call depths, so a
+single stacklevel cannot pinpoint user code from all of them. The actionable
+detail is the scope name carried in the message, not the reported line.
+
+### 3. Reuse semantics unchanged
+
+Auto-reopen is exactly today's `open()`: sets `closed = False`, leaves
+`cache_registry` and `context_registry` untouched. `CacheSettings(clear_cache=False)`
+instances survive the close→reopen cycle (same object returned); `clear_cache=True`
+instances were finalized at close and rebuild on the next resolve. This change
+only triggers the existing reopen implicitly — no new lifecycle behavior, and
+`close_sync`/`close_async` (including the root's override reset) are untouched.
+
+### 4. `ContainerClosedError` retained, unraised until 3.0
+
+Keep the class exported and update its docstring to note it is raised in
+modern-di `3.0` and is currently emitted as a `ContainerClosedWarning`. Its
+message text is unchanged (it is the future 3.0 text and is intentionally
+harsher than the transitional warning — "can no longer resolve … Create a new
+container" is only true once the error is reinstated).
+
+Because the class is no longer raised in the resolution flow, a direct unit test
+constructs it and asserts its message and `container_scope` attribute. That
+keeps it under the 100% line-coverage gate and locks the 3.0 contract.
+
+### 5. Tests
+
+- Flip existing `pytest.raises(ContainerClosedError)` reuse-after-close cases
+  (in `tests/test_container.py`, `tests/providers/test_singleton.py`,
+  `tests/providers/test_context_provider.py`) to `pytest.warns(ContainerClosedWarning)`
+  and assert the call **succeeds** and `container.closed is False` afterward.
+- New: only one warning per close→reuse transition (a second resolve is silent).
+- New: nested closed-ancestor case (resolve from open child, provider at closed
+  ancestor scope) warns once and heals.
+- New: `filterwarnings("error", ContainerClosedWarning)` makes reuse raise
+  (strict opt-in works).
+- New: direct `ContainerClosedError` construction test (covers §4).
+
+### 6. Docs + planning
+
+- `architecture/containers.md` lifecycle section (currently states reuse raises
+  `ContainerClosedError`) → document the transitional warn + self-heal and the
+  3.0 restoration.
+- `docs/providers/errors-and-exceptions.md` and `docs/providers/lifecycle.md`
+  updated to match.
+- Release notes at `planning/releases/2.22.0.md` (next minor after `2.21.1`).
+- A `planning/changes/` bundle per the repo's planning convention, validated by
+  `just check-planning`.
+
+## Versioning
+
+Ships in `2.22.0` — the softening is backward-compatible (code that broke on
+`>=2.16.0` works again; code that relied on the error now sees a warning it can
+escalate). The hard `ContainerClosedError` returns as the default in `3.0`.
+
+## Decisions owned by the maintainer
+
+- Target version `2.22.0`.
+- `stacklevel=2` best-effort rather than threading exact frame depths per site.
+- Defer the `Container(strict_closed=...)` toggle; rely on the warnings filter
+  for strictness in the meantime.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,10 @@ site_url: https://modern-di.modern-python.org
 repo_url: https://github.com/modern-python/modern-di
 docs_dir: docs
 edit_uri: edit/main/docs/
+# Superpowers brainstorm specs / implementation plans are in-repo process
+# artifacts, not published site pages — keep them out of the strict build.
+exclude_docs: |
+  superpowers/
 nav:
   - Quick-Start: index.md
   - Introduction:

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -1,6 +1,7 @@
 import enum
 import threading
 import typing
+import warnings
 
 from modern_di import exceptions, types
 from modern_di.group import Group
@@ -95,8 +96,7 @@ class Container:
         scope: enum.IntEnum | None = None,
         context: dict[type[typing.Any], typing.Any] | None = None,
     ) -> "typing_extensions.Self":
-        if self.closed:
-            raise exceptions.ContainerClosedError(container_scope=self.scope)
+        self._warn_and_reopen_if_closed()
 
         if scope is not None and scope <= self.scope:
             raise exceptions.InvalidChildScopeError(
@@ -135,8 +135,7 @@ class Container:
 
     def resolve_provider(self, provider: "AbstractProvider[types.T]") -> types.T:
         """Resolve a specific provider by reference (enforces closed-state and applies overrides)."""
-        if self.closed:
-            raise exceptions.ContainerClosedError(container_scope=self.scope)
+        self._warn_and_reopen_if_closed()
 
         if (
             self.overrides_registry.overrides
@@ -252,6 +251,25 @@ class Container:
         container is a no-op.
         """
         self.closed = False
+
+    def _warn_and_reopen_if_closed(self) -> None:
+        """Transitional shim for reuse of a closed container.
+
+        Emits :class:`~modern_di.exceptions.ContainerClosedWarning` and reopens
+        (so pre-2.16 "close then resolve" code keeps working); modern-di 3.0
+        will raise :class:`~modern_di.exceptions.ContainerClosedError` here
+        instead. One warning per close→reuse transition, since it self-reopens.
+        """
+        if not self.closed:
+            return
+        warnings.warn(
+            f"Container (scope {self.scope.name}) is closed; resolving from it or building a child "
+            "is deprecated and will raise ContainerClosedError in modern-di 3.0. Re-enter the "
+            "container with `with`/`async with`, or call `open()`, before reusing it.",
+            exceptions.ContainerClosedWarning,
+            stacklevel=2,
+        )
+        self.open()
 
     def __enter__(self) -> "typing_extensions.Self":
         self.open()

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -258,7 +258,10 @@ class Container:
         Emits :class:`~modern_di.exceptions.ContainerClosedWarning` and reopens
         (so pre-2.16 "close then resolve" code keeps working); modern-di 3.0
         will raise :class:`~modern_di.exceptions.ContainerClosedError` here
-        instead. One warning per close→reuse transition, since it self-reopens.
+        instead. The warning fires once per container transitioning from closed
+        to reopened — a single resolve that crosses several distinct closed
+        containers (e.g. a closed ancestor scope) emits one warning per closed
+        container it reopens; an already-open container emits none.
         """
         if not self.closed:
             return

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -106,7 +106,11 @@ class InvalidScopeTypeError(ContainerError):
 
 
 class ContainerClosedError(ContainerError):
-    """Operation attempted on a closed container. Attr: ``container_scope``; re-enter the ``with`` block to reopen."""
+    """Operation attempted on a closed container. Attr: ``container_scope``.
+
+    Raised in modern-di 3.0; until then reuse emits :class:`ContainerClosedWarning`
+    and self-reopens.
+    """
 
     __slots__ = ("container_scope",)
 
@@ -116,6 +120,17 @@ class ContainerClosedError(ContainerError):
             f"Container (scope {container_scope.name}) is closed and can no longer resolve dependencies "
             "or build child containers. Create a new container."
         )
+
+
+class ContainerClosedWarning(DeprecationWarning):
+    """Reuse of a closed container (resolve / build a child) — transitional.
+
+    The reuse works today because the container self-reopens, but it will raise
+    :class:`ContainerClosedError` in modern-di 3.0. Opt into strict behavior now
+    by escalating this warning::
+
+        warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)
+    """
 
 
 class ResolutionError(ModernDIError):

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -1,7 +1,7 @@
 import enum
 import typing
 
-from modern_di import exceptions, types
+from modern_di import types
 from modern_di.providers import AbstractProvider
 from modern_di.scope import Scope
 
@@ -47,6 +47,5 @@ class ContextProvider(AbstractProvider[types.T_co]):
 
     def fetch_context_value(self, container: "Container") -> types.T_co | object:
         container = container.find_container(self.scope)
-        if container.closed:
-            raise exceptions.ContainerClosedError(container_scope=container.scope)
+        container._warn_and_reopen_if_closed()  # noqa: SLF001
         return container.context_registry.find_context(self.context_type)

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -242,8 +242,7 @@ class Factory(AbstractProvider[types.T_co]):
 
     def resolve(self, container: "Container") -> types.T_co:
         container = container.find_container(self.scope)
-        if container.closed:
-            raise exceptions.ContainerClosedError(container_scope=container.scope)
+        container._warn_and_reopen_if_closed()  # noqa: SLF001
         cache_item = container.cache_registry.fetch_cache_item(self)
 
         if self.cache_settings and cache_item.cache is not types.UNSET:

--- a/planning/changes/2026-07-05.01-soften-container-closed-error/design.md
+++ b/planning/changes/2026-07-05.01-soften-container-closed-error/design.md
@@ -1,0 +1,48 @@
+---
+summary: Reuse of a closed container warns (ContainerClosedWarning) and self-reopens instead of raising; hard ContainerClosedError returns in 3.0.
+---
+
+# Design: Soften closed-container reuse to a self-healing deprecation
+
+## Summary
+
+The hard `ContainerClosedError` added in 2.16.0 broke "close then resolve"
+code (including maintainer projects) that relied on pre-2.16 lenient behavior.
+Reuse of a closed container now emits `ContainerClosedWarning` and self-reopens
+so the call succeeds; the error returns as the default in 3.0. Full brainstorm
+spec: `docs/superpowers/specs/2026-07-05-soften-container-closed-error-design.md`.
+
+## Motivation
+
+`resolve_provider` / `build_child_container` and two nested provider paths
+(`factory`, `context_provider`) started raising when `closed=True`. Downstream
+lifecycles that close then reuse require invasive rewrites. Making the change
+transitional removes that forced migration.
+
+## Non-goals
+
+- A `Container(strict_closed=...)` toggle — deferred; the `warnings` filter
+  covers strictness for now.
+- Changing `close_sync` / `close_async` / `open` semantics.
+
+## Design
+
+One private `Container._warn_and_reopen_if_closed()` replaces the four
+`if closed: raise` sites; it warns once and calls `self.open()`. Nested sites
+call it on the `find_container(self.scope)` result, healing a closed ancestor.
+`ContainerClosedError` is retained (unraised until 3.0) and covered by a direct
+unit test. New `ContainerClosedWarning(DeprecationWarning)` is filterable to an
+error for strict opt-in.
+
+## Testing
+
+Reuse-after-close tests flip from `pytest.raises(ContainerClosedError)` to
+`pytest.warns(ContainerClosedWarning)` + success assertions; added tests cover
+one-warning-per-cycle, nested-ancestor heal, strict opt-in, and the retained
+error class. `just test-ci` stays at 100% line coverage.
+
+## Risk
+
+Low. Behavior is strictly more permissive than 2.16–2.21; code that expected
+the error can escalate the warning. Main risk is doc drift — mitigated by the
+`architecture/containers.md` promotion in this PR.

--- a/planning/changes/2026-07-05.01-soften-container-closed-error/plan.md
+++ b/planning/changes/2026-07-05.01-soften-container-closed-error/plan.md
@@ -1,0 +1,13 @@
+# soften-container-closed-error — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Ship the self-healing `ContainerClosedWarning` (2.22.0); restore the
+hard error in 3.0.
+
+**Spec:** [`design.md`](./design.md)
+
+**Full task breakdown:** `docs/superpowers/plans/2026-07-05-soften-container-closed-error.md`
+
+**Commit strategy:** Per-task commits (warning+entry sites · provider sites · docs).

--- a/planning/releases/2.22.0.md
+++ b/planning/releases/2.22.0.md
@@ -11,8 +11,14 @@ default in **3.0**.
 - **Closed-container reuse is transitional again.** The `ContainerClosedError`
   introduced in 2.16.0 (#202) was a breaking change for lifecycles that close
   then keep resolving. Reuse now warns (`exceptions.ContainerClosedWarning`, a
-  `DeprecationWarning`) and self-reopens instead of raising. One warning fires
-  per close→reuse transition.
+  `DeprecationWarning`) and self-reopens instead of raising. The warning fires
+  once per container per closed→reopened transition — a resolve that crosses
+  several distinct closed containers emits one warning per container.
+- **Concurrency note.** Under concurrent close + reuse without external
+  synchronization, a resolving thread may now self-reopen and rebuild after
+  another thread's finalizers already ran, matching pre-2.16 behavior instead
+  of the 2.16–2.21 raise. This is user-managed synchronization territory, not
+  a new bug.
 
 ## Deprecation
 

--- a/planning/releases/2.22.0.md
+++ b/planning/releases/2.22.0.md
@@ -1,0 +1,31 @@
+# modern-di 2.22.0 — closed-container reuse is a deprecation, not a hard error
+
+Reuse of a closed container no longer raises. `resolve` / `build_child_container`
+(and nested providers resolving at a closed ancestor scope) now emit a
+`ContainerClosedWarning` and self-reopen the container, restoring pre-2.16
+"close then resolve" behavior. The hard `ContainerClosedError` returns as the
+default in **3.0**.
+
+## Fix
+
+- **Closed-container reuse is transitional again.** The `ContainerClosedError`
+  introduced in 2.16.0 (#202) was a breaking change for lifecycles that close
+  then keep resolving. Reuse now warns (`exceptions.ContainerClosedWarning`, a
+  `DeprecationWarning`) and self-reopens instead of raising. One warning fires
+  per close→reuse transition.
+
+## Deprecation
+
+- Resolving from / building a child of a closed container is deprecated and will
+  raise `ContainerClosedError` in modern-di 3.0. Wrap the container in
+  `with` / `async with`, or call `open()`, before reuse. To fail fast today:
+  `warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)`.
+
+## Downstream
+
+No action required to keep working. Integrations that reopen the root container
+on startup are already on the recommended path.
+
+## Internals
+
+- 100% line coverage across supported Python versions retained.

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -4,7 +4,7 @@ import datetime
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import ArgumentResolutionError, ContainerClosedError
+from modern_di.exceptions import ArgumentResolutionError, ContainerClosedWarning
 
 
 request_context_provider = providers.ContextProvider(scope=Scope.REQUEST, context_type=datetime.datetime)
@@ -146,13 +146,14 @@ def test_set_context_after_first_resolve_is_seen_by_later_resolves() -> None:
     assert second.ctx is value
 
 
-def test_context_provider_through_closed_owning_container_raises() -> None:
+def test_context_provider_through_closed_owning_container_warns_and_reopens() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app = Container(groups=[MyGroup], context={datetime.datetime: now})
     child = app.build_child_container(scope=Scope.REQUEST)
     app.close_sync()
-    with pytest.raises(ContainerClosedError):
-        child.resolve_provider(MyGroup.context_provider)
+    with pytest.warns(ContainerClosedWarning):
+        assert child.resolve_provider(MyGroup.context_provider) == now
+    assert app.closed is False
 
 
 # Q-12 — ContextProvider reads the registry at its OWN scope

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import AsyncFinalizerInSyncCloseError, ContainerClosedError, FinalizerError
+from modern_di.exceptions import AsyncFinalizerInSyncCloseError, ContainerClosedWarning, FinalizerError
 from modern_di.types import UNSET
 
 
@@ -53,7 +53,7 @@ async def test_app_singleton() -> None:
     app_container.close_sync()
     assert sync_calls == [singleton1]  # finalizer ran once on close
 
-    with pytest.raises(ContainerClosedError):
+    with pytest.warns(ContainerClosedWarning):
         app_container.resolve_provider(LocalGroup.singleton)
 
     # clear_cache=False: the instance survives the close and is returned again after reopen,
@@ -83,7 +83,7 @@ def test_close_does_not_re_finalize_with_clear_cache_false() -> None:
     assert calls == ["r"]
 
 
-def test_closed_container_refuses_re_resolve_with_clear_cache_true() -> None:
+def test_closed_container_warns_and_reopens_with_clear_cache_true() -> None:
     calls: list[str] = []
 
     class G(Group):
@@ -97,10 +97,11 @@ def test_closed_container_refuses_re_resolve_with_clear_cache_true() -> None:
     container.resolve(str)
     container.close_sync()
     assert calls == ["r"]
-    with pytest.raises(ContainerClosedError):
+    with pytest.warns(ContainerClosedWarning):
+        # self-reopens and rebuilds, since clear_cache=True cleared the cache on close
         container.resolve(str)
-    container.close_sync()  # close stays idempotent and never re-runs finalizers
-    assert calls == ["r"]
+    container.close_sync()
+    assert calls == ["r", "r"]  # the rebuilt instance is finalized again on this second close
 
 
 async def test_close_async_runs_sync_finalizer() -> None:
@@ -469,8 +470,8 @@ def test_persistent_provider_survives_close_reopen_cycle() -> None:
         svc1 = container.resolve(_EphemeralSvc)
     # exited → closed; finalizer ran once
     assert _cycle_events == ["broker-finalized"]
-    # resolving while closed raises
-    with pytest.raises(ContainerClosedError):
+    # resolving while closed warns and self-reopens (transitional; 3.0 restores the raise)
+    with pytest.warns(ContainerClosedWarning):
         container.resolve(_PersistentBroker)
     # re-enter → reopen
     with container:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import typing
+import warnings
 
 import pytest
 
@@ -9,6 +10,7 @@ from modern_di.exceptions import (
     ArgumentResolutionError,
     CircularDependencyError,
     ContainerClosedError,
+    ContainerClosedWarning,
     InvalidChildScopeError,
     InvalidScopeDependencyError,
     InvalidScopeTypeError,
@@ -362,20 +364,21 @@ def test_constructor_rejects_parent_with_non_increasing_scope() -> None:
         Container(scope=Scope.APP, parent_container=request)
 
 
-def test_closed_container_refuses_resolve_and_child_building() -> None:
+def test_closed_container_warns_and_reopens_on_resolve_and_child_building() -> None:
     container = Container(scope=Scope.APP)
     container.close_sync()
-    with pytest.raises(ContainerClosedError):
+    with pytest.warns(ContainerClosedWarning):
         container.resolve(Container)
-    with pytest.raises(ContainerClosedError):
+    container.close_sync()
+    with pytest.warns(ContainerClosedWarning):
         container.build_child_container(scope=Scope.REQUEST)
 
 
 async def test_closed_container_async_path() -> None:
     container = Container(scope=Scope.APP)
     await container.close_async()
-    with pytest.raises(ContainerClosedError):
-        container.resolve(Container)
+    with pytest.warns(ContainerClosedWarning):
+        assert container.resolve(Container) is container
 
 
 class _PersistentBroker: ...
@@ -399,8 +402,8 @@ async def test_async_context_manager_reopens() -> None:
     container = Container(scope=Scope.APP)
     async with container:
         pass
-    with pytest.raises(ContainerClosedError):
-        container.resolve(Container)
+    with pytest.warns(ContainerClosedWarning):
+        assert container.resolve(Container) is container
     async with container:
         assert container.resolve(Container) is container
 
@@ -408,11 +411,56 @@ async def test_async_context_manager_reopens() -> None:
 def test_open_reopens_closed_container() -> None:
     container = Container(scope=Scope.APP)
     container.close_sync()
-    with pytest.raises(ContainerClosedError):
-        container.resolve(Container)
+    with pytest.warns(ContainerClosedWarning):
+        assert container.resolve(Container) is container
     container.open()
     assert container.resolve(Container) is container
     assert container.build_child_container(scope=Scope.REQUEST).scope is Scope.REQUEST
+
+
+def test_reuse_after_close_warns_and_reopens() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        resolved = container.resolve(Container)
+    assert resolved is container
+    assert container.closed is False
+
+
+def test_build_child_after_close_warns_and_reopens() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with pytest.warns(ContainerClosedWarning):
+        child = container.build_child_container(scope=Scope.REQUEST)
+    assert container.closed is False
+    assert child.scope is Scope.REQUEST
+
+
+def test_reuse_warns_once_per_close_cycle() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        container.resolve(Container)
+        container.resolve(Container)
+    closed_warnings = [w for w in caught if issubclass(w.category, ContainerClosedWarning)]
+    assert len(closed_warnings) == 1
+
+
+def test_strict_opt_in_reuse_raises() -> None:
+    container = Container(scope=Scope.APP)
+    container.close_sync()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ContainerClosedWarning)
+        with pytest.raises(ContainerClosedWarning):
+            container.resolve(Container)
+
+
+def test_container_closed_error_message_and_attr() -> None:
+    err = ContainerClosedError(container_scope=Scope.APP)
+    assert err.container_scope is Scope.APP
+    assert "closed" in str(err)
+    assert "Create a new container" in str(err)
 
 
 def test_open_on_open_container_is_noop() -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -390,12 +390,14 @@ class _AppBrokerGroup(Group):
     )
 
 
-def test_resolving_through_closed_parent_via_open_child_raises() -> None:
+def test_resolving_through_closed_parent_via_open_child_warns_and_reopens() -> None:
     app = Container(scope=Scope.APP, groups=[_AppBrokerGroup])
     child = app.build_child_container(scope=Scope.REQUEST)
     app.close_sync()
-    with pytest.raises(ContainerClosedError):
-        child.resolve(_PersistentBroker)
+    with pytest.warns(ContainerClosedWarning):
+        broker = child.resolve(_PersistentBroker)
+    assert isinstance(broker, _PersistentBroker)
+    assert app.closed is False
 
 
 async def test_async_context_manager_reopens() -> None:


### PR DESCRIPTION
## What & why

`2.16.0` (#202) made reusing a **closed** container raise `ContainerClosedError` — resolving from, or building a child of, a container after `close_sync()` / `close_async()` (or a `with` exit). That was a breaking change for the common pre-2.16 pattern of "close, then keep resolving," and required invasive rewrites downstream.

This makes the change **transitional** instead of permanent:

- Reusing a closed container now emits a new **`ContainerClosedWarning`** (a `DeprecationWarning`) and **self-reopens** the container, so the call succeeds — restoring pre-2.16 behavior.
- The warning fires once per container `closed→reopened` transition (it self-reopens, so no per-resolve spam).
- The hard **`ContainerClosedError` returns as the default in modern-di 3.0**. The class is retained and documented for that.
- Strict opt-in today: `warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)`.

Full design/spec and implementation plan are included under `docs/superpowers/`.

## How it works

A single private helper, `Container._warn_and_reopen_if_closed()`, replaces all four previous `if closed: raise` sites:

- Entry points: `resolve_provider`, `build_child_container` (on `self`).
- Nested provider paths: `Factory.resolve`, `ContextProvider.fetch_context_value` (on the `find_container(self.scope)` result — so a resolve from an **open child** whose provider is anchored at a **closed ancestor** heals that ancestor too).

Reuse semantics match the existing `open()`: `closed=False`, cache/context untouched. `CacheSettings(clear_cache=False)` instances survive the close→reopen; `clear_cache=True` instances were finalized at close and rebuild on the next resolve. Note the one asymmetry (now documented): a root close resets overrides and reopen does **not** restore them.

## Tests

- Reuse-after-close tests flipped from `pytest.raises(ContainerClosedError)` to `pytest.warns(ContainerClosedWarning)` + success/self-heal assertions.
- Added: one-warning-per-close-cycle, nested closed-ancestor heal, strict opt-in (`filterwarnings("error", ...)` raises), and a direct `ContainerClosedError` unit test (keeps the retained class under the coverage gate).
- `just test-ci`: **251 passed, 100% line coverage**. `just lint-ci` and `just check-planning` clean. Verified no `ContainerClosedWarning` escapes uncaught (`pytest -W error::DeprecationWarning` passes).

## Docs & release

- Promoted into the truth home (`architecture/containers.md`) and user docs (`docs/providers/lifecycle.md`, `errors-and-exceptions.md`, `docs/integrations/writing-integrations.md`).
- `planning/changes/2026-07-05.01-soften-container-closed-error/` bundle + draft `planning/releases/2.22.0.md`.

Ships in **2.22.0** (backward-compatible); hard error restored in **3.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
