### PR TITLE
docs(release): extend 2.22.0 notes to cover Factory(cache=) feature + deprecation (#259)

### DIFF
--- a/planning/releases/2.22.0.md
+++ b/planning/releases/2.22.0.md
@@ -1,36 +1,65 @@
-# modern-di 2.22.0 — closed-container reuse is a deprecation, not a hard error
+# modern-di 2.22.0 — ergonomic `Factory(cache=…)`; closed-container reuse softened to a deprecation
 
-Reuse of a closed container no longer raises. `resolve` / `build_child_container`
-(and nested providers resolving at a closed ancestor scope) now emit a
-`ContainerClosedWarning` and self-reopen the container, restoring pre-2.16
-"close then resolve" behavior. The hard `ContainerClosedError` returns as the
-default in **3.0**.
+Two user-facing changes. `Factory` gains a `cache=` toggle so the common "just
+cache it" case is `cache=True` instead of `cache_settings=CacheSettings()`, and
+`cache_settings=` becomes a deprecated alias. Separately, reusing a closed
+container no longer raises — it emits a `ContainerClosedWarning` and self-reopens,
+restoring pre-2.16 behavior; the hard `ContainerClosedError` returns in **3.0**.
+
+## Feature
+
+- **`Factory(cache=…)` — one axis for the whole caching spectrum** (#259).
+  Enabling a cached singleton used to require constructing an empty settings
+  object: `Factory(scope=Scope.APP, creator=Database, cache_settings=CacheSettings())`.
+  Now:
+  - `cache=True` — cached with defaults (the common case).
+  - `cache=CacheSettings(...)` — cached and tuned (finalizer, `clear_cache`).
+  - `cache=False` / `cache=None` / omitted — not cached.
+
+  `CacheSettings` and all resolution/finalizer/lifecycle behavior are unchanged;
+  the sugar lives entirely in `Factory.__init__`. No `Singleton` class was added.
 
 ## Fix
 
-- **Closed-container reuse is transitional again.** The `ContainerClosedError`
-  introduced in 2.16.0 (#202) was a breaking change for lifecycles that close
-  then keep resolving. Reuse now warns (`exceptions.ContainerClosedWarning`, a
-  `DeprecationWarning`) and self-reopens instead of raising. The warning fires
-  once per container per closed→reopened transition — a resolve that crosses
-  several distinct closed containers emits one warning per container.
+- **Closed-container reuse is transitional again** (#261). The
+  `ContainerClosedError` introduced in 2.16.0 (#202) was a breaking change for
+  lifecycles that close then keep resolving. `resolve` / `build_child_container`
+  (and nested providers resolving at a closed ancestor scope) now warn
+  (`exceptions.ContainerClosedWarning`, a `DeprecationWarning`) and self-reopen
+  instead of raising. The warning fires once per container per closed→reopened
+  transition — a resolve that crosses several distinct closed containers emits
+  one warning per container.
 - **Concurrency note.** Under concurrent close + reuse without external
   synchronization, a resolving thread may now self-reopen and rebuild after
   another thread's finalizers already ran, matching pre-2.16 behavior instead
   of the 2.16–2.21 raise. This is user-managed synchronization territory, not
   a new bug.
 
-## Deprecation
+## Deprecations
 
-- Resolving from / building a child of a closed container is deprecated and will
-  raise `ContainerClosedError` in modern-di 3.0. Wrap the container in
-  `with` / `async with`, or call `open()`, before reuse. To fail fast today:
+- **`cache_settings=` on `Factory`** (#259) — use `cache=` instead
+  (`cache=True` for defaults, `cache=CacheSettings(...)` to tune). The old
+  kwarg still works but emits a `DeprecationWarning` and will be removed in a
+  future release. Passing both `cache=` and `cache_settings=` is a `TypeError`.
+- **Reusing a closed container** (#261) — deprecated; it will raise
+  `ContainerClosedError` in modern-di 3.0. Wrap the container in `with` /
+  `async with`, or call `open()`, before reuse. To fail fast today:
   `warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)`.
+
+## Docs
+
+- New integration usage guides for **aiohttp** (#257, #258) and **Starlette**
+  (#254, #255), a **"Writing an integration"** guide (#253), and an
+  accuracy/integration-parity pass across the docs set (#260). The retired,
+  separately-maintained `skills/modern-di/` agent-skill set was removed (#256).
 
 ## Downstream
 
-No action required to keep working. Integrations that reopen the root container
-on startup are already on the recommended path.
+No action required to keep working. Migrating off the deprecations is
+mechanical: rename `cache_settings=X` to `cache=X` (or `cache=True` where you
+passed an empty `CacheSettings()`), and reopen a container (`with` / `open()`)
+before reusing it after close. Integrations that reopen the root container on
+startup are already on the recommended path.
 
 ## Internals
 


### PR DESCRIPTION
The `planning/releases/2.22.0.md` draft (from #261) only documented the `ContainerClosedWarning` change. But #259 — `Factory(cache=…)` ergonomics and the `cache_settings=` deprecation — is also unreleased since `2.21.1` and ships in the same 2.22.0.

This broadens the notes to cover both user-facing code changes:

- **Feature:** `Factory(cache=True | CacheSettings(...) | False | None)` (#259).
- **Deprecation:** `cache_settings=` → `cache=` (`DeprecationWarning`; passing both raises `TypeError`) (#259), alongside the existing closed-container reuse deprecation (#261).
- A brief **Docs** section for the unreleased integration guides (aiohttp #257/#258, Starlette #254/#255, writing-integrations #253, accuracy pass #260, skill removal #256).

Verified: the only user-facing `modern_di/` package changes since `2.21.1` are #259 and #261, so these notes now cover the full release. `just check-planning` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)