### PR TITLE
chore: privatize Container scope_map/lock internals

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -44,7 +44,7 @@ Rules:
   `ContainerClosedWarning` and self-reopens the container instead of raising `ContainerClosedError`
   (see [Lifecycle: close and reopen](#lifecycle-close-and-reopen) below).
 
-The child gets its own, independent `scope_map` dict that includes all ancestors plus itself,
+The child gets its own, independent `_scope_map` dict that includes all ancestors plus itself,
 enabling `find_container(scope)` to walk up to any ancestor scope in O(1).
 
 ## Registry sharing

--- a/docs/providers/advanced-api.md
+++ b/docs/providers/advanced-api.md
@@ -38,6 +38,13 @@ decide whether to `await` the finalizer during `close_async()` or treat it as sy
 emits a `DeprecationWarning`; pass `cache=True` (defaults) or `cache=CacheSettings(...)`
 (tuned) instead. Passing both `cache` and `cache_settings` raises `TypeError`.
 
+### `find_container(scope)`
+
+`find_container(scope)` walks `_scope_map` and returns the container registered at
+`scope`; raises `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
+It is the primitive a custom `AbstractProvider.resolve` calls to locate the container at
+its scope — see [Subclassing `AbstractProvider`](#subclassing-abstractprovider) above.
+
 ## Container internals — no stability guarantee
 
 !!! warning "Internal surface"
@@ -45,11 +52,12 @@ emits a `DeprecationWarning`; pass `cache=True` (defaults) or `cache=CacheSettin
     for debugging and deep integration work only, and may change without a
     deprecation cycle. Do not build on them.
 
-- **`find_container(scope)`** — walks `scope_map` and returns the container registered at
-  `scope`; raises `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
 - **`parent_container`** — constructor kwarg and slot; the direct parent of a child container,
   or `None` for a root. Passing a `scope ≤ parent.scope` raises `InvalidChildScopeError`.
-- **`scope_map`** — `dict[IntEnum, Container]` mapping every scope in the chain to its
+- **`_scope_map`** — `dict[IntEnum, Container]` mapping every scope in the chain to its
   container; built at construction time and inherited (plus the new scope) by each child.
-- **`lock`** — a `threading.RLock` instance, or `None` when the container was created with
+- **`_lock`** — a `threading.RLock` instance, or `None` when the container was created with
   `use_lock=False`. The lock gates singleton creation inside `Factory.resolve`.
+
+The former public names `scope_map` and `lock` remain as read-only properties that emit
+`DeprecationWarning` and will be removed in a future release.

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -28,15 +28,15 @@ class Container:
     """
 
     __slots__ = (
+        "_lock",
+        "_scope_map",
         "cache_registry",
         "closed",
         "context_registry",
-        "lock",
         "overrides_registry",
         "parent_container",
         "providers_registry",
         "scope",
-        "scope_map",
     )
 
     def __init__(  # noqa: PLR0913
@@ -64,12 +64,12 @@ class Container:
                 child_scope=scope,
                 allowed_scopes=[x.name for x in type(parent_container.scope) if x > parent_container.scope],
             )
-        self.lock = threading.RLock() if use_lock else None
+        self._lock = threading.RLock() if use_lock else None
         self.closed = False
         self.scope = scope
         self.parent_container = parent_container
-        self.scope_map: dict[enum.IntEnum, typing_extensions.Self] = (
-            {**parent_container.scope_map, scope: self} if parent_container else {scope: self}
+        self._scope_map: dict[enum.IntEnum, typing_extensions.Self] = (
+            {**parent_container._scope_map, scope: self} if parent_container else {scope: self}  # noqa: SLF001
         )
         self.cache_registry = CacheRegistry()
         self.context_registry = ContextRegistry(context=context or {})
@@ -113,14 +113,32 @@ class Container:
                 raise exceptions.MaxScopeReachedError(parent_scope=self.scope)
             scope = min(deeper_scopes)
 
-        return self.__class__(scope=scope, parent_container=self, context=context, use_lock=self.lock is not None)
+        return self.__class__(scope=scope, parent_container=self, context=context, use_lock=self._lock is not None)
 
     def find_container(self, scope: enum.IntEnum) -> "typing_extensions.Self":
-        if scope not in self.scope_map:
+        if scope not in self._scope_map:
             if scope > self.scope:
                 raise exceptions.ScopeNotInitializedError(provider_scope=scope, container_scope=self.scope)
             raise exceptions.ScopeSkippedError(provider_scope=scope, container_scope=self.scope)
-        return self.scope_map[scope]
+        return self._scope_map[scope]
+
+    @property
+    def scope_map(self) -> "dict[enum.IntEnum, typing_extensions.Self]":
+        warnings.warn(
+            "`Container.scope_map` is private; it will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._scope_map
+
+    @property
+    def lock(self) -> "threading.RLock | None":
+        warnings.warn(
+            "`Container.lock` is private; it will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._lock
 
     def resolve(self, dependency_type: type[types.T]) -> types.T:
         """Resolve a dependency by its type."""

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -257,8 +257,8 @@ class Factory(AbstractProvider[types.T_co]):
         if not self.cache_settings:
             return self._call_creator(resolved_kwargs)
 
-        if container.lock:
-            container.lock.acquire()
+        if container._lock:  # noqa: SLF001
+            container._lock.acquire()  # noqa: SLF001
 
         try:
             if cache_item.cache is not types.UNSET:
@@ -269,5 +269,5 @@ class Factory(AbstractProvider[types.T_co]):
             container.cache_registry.mark_created(cache_item)
             return instance
         finally:
-            if container.lock:
-                container.lock.release()
+            if container._lock:  # noqa: SLF001
+                container._lock.release()  # noqa: SLF001

--- a/planning/changes/2026-07-05.02-privatize-container-internals/design.md
+++ b/planning/changes/2026-07-05.02-privatize-container-internals/design.md
@@ -1,0 +1,166 @@
+---
+summary: Privatize Container.scope_map and Container.lock to _scope_map/_lock behind deprecated property aliases; promote find_container to a documented extension point.
+---
+
+# Design: Privatize `Container.scope_map` and `Container.lock`
+
+**Date:** 2026-07-05
+**Goal:** Shrink the `Container` public surface by making its two genuinely-internal
+attributes private, without breaking anyone — using the project's established
+deprecation-shim pattern. Reclassify `find_container` as a supported extension
+point in the same pass.
+
+## Summary
+
+`Container` exposes four low-level members that the docs currently label
+"internal, no stability guarantee": `find_container`, `parent_container`,
+`scope_map`, `lock`. Two of them (`scope_map`, `lock`) are pure machinery with
+no legitimate external use. This change renames those two to `_scope_map` and
+`_lock`, keeps the old names working as `@property` aliases that emit
+`DeprecationWarning`, and switches internal callers to the private names. The
+other two are deliberately left public: `find_container` is the resolution
+primitive custom providers call (promoted to a documented extension point), and
+`parent_container` remains a public low-level construction/navigation API.
+
+## Motivation
+
+The docs-accuracy PR (`2026-07-04.02-docs-accuracy-parity`) split
+`advanced-api.md` into "supported extension points" vs. "Container internals —
+no stability guarantee" and flagged the underscore-rename as a follow-up
+decision. Research during that work established:
+
+- `scope_map` is referenced only inside `container.py`. `lock` only inside
+  `container.py` and `factory.py`. Neither appears in any of the six official
+  integration packages (the `.lock` hits there are all `uv.lock`).
+- `find_container` is called by `Factory.resolve` and `ContextProvider.resolve`
+  to locate the container at a provider's scope; the documented "subclass
+  `AbstractProvider`" extension point implies custom providers need it too. It
+  is an extension point, not an internal — so it stays public.
+- `parent_container` is both a stored attribute and the constructor kwarg
+  `build_child_container` passes; it is a legitimate low-level API and stays
+  public.
+
+The project reserves major versions for large rewrites (the 1.x→2.x break) and
+handles smaller public-API changes within 2.x with deprecation warnings — the
+`cache_settings=` → `cache=` change (commit 4d5fdf5) is the direct precedent
+this change mirrors.
+
+## Non-goals
+
+- Touching `find_container` or `parent_container` (kwarg or attribute) — both
+  stay public.
+- Renaming or deprecating the `use_lock=` constructor parameter or the
+  `Container(...)` constructor — the public thread-safety knob is unchanged.
+- Adding any new public helper (e.g. a `resolve_at_scope` wrapper) —
+  `find_container` already fills that role. YAGNI.
+- A hard/breaking rename. The old names keep working until a future major.
+
+## Design
+
+### 1. Rename the two slots
+
+In `modern_di/container.py`, change `__slots__` entries `"lock"` → `"_lock"`
+and `"scope_map"` → `"_scope_map"`, and set them under the new names in
+`__init__`:
+
+- `self._lock = threading.RLock() if use_lock else None`
+- `self._scope_map = {**parent_container._scope_map, scope: self} if parent_container else {scope: self}`
+
+### 2. Switch internal callers to the private names
+
+All internal reads/writes move to `_scope_map` / `_lock`. Verified call sites
+(the plan must re-grep to confirm none were missed):
+
+- `container.py`:
+  - `__init__` — sets `self._lock`, `self._scope_map`; child inherits
+    `parent_container._scope_map`.
+  - `build_child_container` — `use_lock=self._lock is not None`.
+  - `find_container` — `if scope not in self._scope_map` / `return self._scope_map[scope]`.
+- `factory.py` — `Factory.resolve` lock gate:
+  `if container._lock: container._lock.acquire()` / `container._lock.release()`.
+
+Because internal code uses the underscore names, the deprecated property
+(step 3) is never triggered on the resolve hot path.
+
+### 3. Add deprecated property aliases
+
+Add two class-level properties on `Container`, keeping the old names readable:
+
+```python
+@property
+def scope_map(self) -> "dict[enum.IntEnum, typing_extensions.Self]":
+    warnings.warn(
+        "`Container.scope_map` is private; it will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return self._scope_map
+
+@property
+def lock(self) -> "threading.RLock | None":
+    warnings.warn(
+        "`Container.lock` is private; it will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return self._lock
+```
+
+`stacklevel=2` and the "will be removed in a future release" phrasing match the
+existing `cache_settings=` deprecation. Properties are class descriptors and
+coexist with `__slots__` because the slot names (`_lock`, `_scope_map`) now
+differ from the property names. `warnings` is already imported in `container.py`
+(verified). No setters — these were never meant to be assigned externally.
+
+### 4. Docs
+
+- `docs/providers/advanced-api.md`:
+  - Move `find_container(scope)` out of "Container internals — no stability
+    guarantee" and into "Supported extension points" (it is the primitive a
+    custom `AbstractProvider.resolve` calls to find its scope's container).
+  - In the internals section, rename the `scope_map` and `lock` bullets to
+    `_scope_map` / `_lock`, and note that the old names remain as
+    deprecated read-only properties that emit `DeprecationWarning`.
+  - Leave the `parent_container` bullet as-is (public).
+- `architecture/containers.md`: update any mention of `scope_map` / `lock`
+  to the private names (the repo's promotion rule — same PR).
+
+### 5. Release notes
+
+Add a deprecation entry to the next `planning/releases/<version>.md` (a bare
+semver tag off green `main` drives the release): note that `Container.scope_map`
+and `Container.lock` are now private (`_scope_map` / `_lock`) with deprecated
+aliases, and that `find_container` is confirmed a supported extension point.
+
+## Testing
+
+TDD; the 100%-line-coverage gate (`just test-ci`) applies, so the property
+getters and their warning branches must be exercised.
+
+- **Internal rename is transparent:** existing scope-resolution and
+  `use_lock`/threading tests still pass (resolution walks `_scope_map`;
+  cached-singleton creation still locks via `_lock`).
+- **Private attributes exist and back the machinery:** a child container's
+  `_scope_map` contains every ancestor scope; `use_lock=False` ⇒ `_lock is None`;
+  `use_lock=True` ⇒ `_lock` is an `RLock`.
+- **Deprecated aliases warn and forward:** `pytest.warns(DeprecationWarning,
+  match="scope_map")` around a `.scope_map` read returns the same object as
+  `._scope_map`; same for `.lock` vs `._lock`.
+- **No warning on the happy path:** resolving providers (which touches `_lock`
+  and `_scope_map` internally) emits no `DeprecationWarning`
+  (`warnings.catch_warnings` / `pytest.warns(None)`-style assertion).
+
+## Risk
+
+- **Low.** The rename is mechanical and contained to two files' internals; the
+  aliases preserve backward compatibility, and both attributes were already
+  documented "no stability guarantee."
+- **`__slots__`/property collision** if a slot and property share a name:
+  avoided by renaming the slots to `_lock`/`_scope_map` first. A class-creation
+  `ValueError` would surface immediately in any test run if botched.
+- **Missed internal caller** still compiles but would hit the deprecated
+  property and warn (or, if it assigned the attribute, fail — there are no
+  external assigners). Mitigation: the plan greps the whole `modern_di/` tree
+  for `.lock`/`.scope_map` before finishing and asserts no `DeprecationWarning`
+  on the resolve happy path.
+- **Coverage gate** on the two warning branches: covered by the alias tests.

--- a/planning/changes/2026-07-05.02-privatize-container-internals/plan.md
+++ b/planning/changes/2026-07-05.02-privatize-container-internals/plan.md
@@ -1,0 +1,320 @@
+# privatize-container-internals — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Container.scope_map` and `Container.lock` private (`_scope_map` /
+`_lock`) behind deprecated property aliases, switching all internal callers to
+the private names; update docs and release notes.
+
+**Spec:** [`design.md`](./design.md)
+
+**Branch:** `chore/privatize-container-internals` (already created; holds the spec commit).
+
+**Commit strategy:** Per-task commits.
+
+## Global Constraints
+
+- **Only two attributes are renamed:** `lock`→`_lock`, `scope_map`→`_scope_map`.
+  Do **not** touch `find_container`, `parent_container` (attribute or constructor
+  kwarg), or `use_lock=`.
+- **Backward compatible:** old names remain readable via `@property` that emits
+  `DeprecationWarning`. No setters.
+- **Warning style matches the existing `cache_settings=` deprecation:**
+  `warnings.warn(<msg>, DeprecationWarning, stacklevel=2)`, message ending
+  "will be removed in a future release." `warnings` is already imported in
+  `modern_di/container.py`.
+- **100% line coverage** is gated by `just test-ci` (CI). Targeted runs use
+  `just test <path>` (no coverage gate). Lint/type via `just lint-ci`.
+- **No `DeprecationWarning` on the resolve hot path** — internal code uses
+  `_lock` / `_scope_map` directly.
+- Run `just check-planning` before the final push (bundle must stay valid).
+
+---
+
+### Task 1: Rename internals + deprecation shim + tests
+
+**Files:**
+- Modify: `modern_di/container.py`
+- Modify: `modern_di/providers/factory.py`
+- Modify: `tests/test_container.py`
+
+Rename the two slots and every internal caller, add the deprecated property
+aliases, update the one existing test that reads `.lock`, and add tests for the
+new private attributes + deprecated aliases. This is one atomic change: the
+suite is red between the slot rename and the caller updates, so they land in a
+single commit.
+
+- [ ] **Step 1: Write the new tests (they fail first)**
+
+  Append to `tests/test_container.py` (`warnings`, `pytest`, `Container`,
+  `Group`, `Scope`, `providers` are already imported there; no new imports
+  needed). Imports must stay at module level, never inside a function body.
+
+```python
+def test_private_lock_and_scope_map_back_the_machinery() -> None:
+    root = Container(use_lock=True)
+    child = root.build_child_container(scope=Scope.REQUEST)
+
+    # _lock is a reentrant lock (threading.RLock is a factory, not a type, so
+    # assert behavior, not isinstance)
+    assert root._lock is not None
+    assert root._lock.acquire()
+    assert root._lock.acquire()  # reentrant
+    root._lock.release()
+    root._lock.release()
+    # child inherits the parent's scope map plus its own scope
+    assert set(child._scope_map) == {Scope.APP, Scope.REQUEST}
+    assert child._scope_map[Scope.APP] is root
+
+
+def test_use_lock_false_yields_no_private_lock() -> None:
+    root = Container(use_lock=False)
+    child = root.build_child_container(scope=Scope.REQUEST)
+    assert root._lock is None
+    assert child._lock is None
+
+
+def test_scope_map_alias_warns_and_forwards() -> None:
+    container = Container()
+    with pytest.warns(DeprecationWarning, match="scope_map"):
+        aliased = container.scope_map
+    assert aliased is container._scope_map
+
+
+def test_lock_alias_warns_and_forwards() -> None:
+    container = Container(use_lock=True)
+    with pytest.warns(DeprecationWarning, match="lock"):
+        aliased = container.lock
+    assert aliased is container._lock
+
+
+def test_resolve_emits_no_deprecation_warning() -> None:
+    class _Dep:
+        pass
+
+    class _Group(Group):
+        dep = providers.Factory(scope=Scope.APP, creator=_Dep, cache=True)
+
+    container = Container(groups=[_Group])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        container.resolve(_Dep)  # touches _lock and _scope_map internally
+        container.build_child_container(scope=Scope.REQUEST)
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+  Run: `just test tests/test_container.py -k "private_lock_and_scope_map or use_lock_false_yields or scope_map_alias or lock_alias or resolve_emits_no"`
+  Expected: FAIL (AttributeError: `_lock`/`_scope_map` don't exist; `.scope_map`/`.lock` don't warn).
+
+- [ ] **Step 3: Rename the slots in `modern_di/container.py`**
+
+  In `__slots__`, change `"lock",` → `"_lock",` and `"scope_map",` → `"_scope_map",`.
+
+- [ ] **Step 4: Update `__init__` and navigation in `container.py`**
+
+  - The line `self.lock = threading.RLock() if use_lock else None` becomes
+    `self._lock = threading.RLock() if use_lock else None`.
+  - The `scope_map` assignment becomes:
+    ```python
+    self._scope_map: dict[enum.IntEnum, typing_extensions.Self] = (
+        {**parent_container._scope_map, scope: self} if parent_container else {scope: self}
+    )
+    ```
+  - In `build_child_container`, the return line's `use_lock=self.lock is not None`
+    becomes `use_lock=self._lock is not None`.
+  - In `find_container`, `if scope not in self.scope_map:` → `if scope not in self._scope_map:`
+    and `return self.scope_map[scope]` → `return self._scope_map[scope]`.
+
+- [ ] **Step 5: Add the deprecated property aliases in `container.py`**
+
+  Insert immediately after the `find_container` method (before `resolve`):
+
+```python
+    @property
+    def scope_map(self) -> "dict[enum.IntEnum, typing_extensions.Self]":
+        warnings.warn(
+            "`Container.scope_map` is private; it will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._scope_map
+
+    @property
+    def lock(self) -> "threading.RLock | None":
+        warnings.warn(
+            "`Container.lock` is private; it will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._lock
+```
+
+- [ ] **Step 6: Update the lock gate in `modern_di/providers/factory.py`**
+
+  In `Factory.resolve`, change the four references:
+  - `if container.lock:` → `if container._lock:`
+  - `container.lock.acquire()` → `container._lock.acquire()`
+  - `if container.lock:` → `if container._lock:`
+  - `container.lock.release()` → `container._lock.release()`
+
+- [ ] **Step 7: Update the existing test that reads `.lock`**
+
+  In `tests/test_container.py`, `test_build_child_container_propagates_use_lock_false`:
+  change `assert root.lock is None` → `assert root._lock is None` and
+  `assert child.lock is None` → `assert child._lock is None`.
+
+- [ ] **Step 8: Confirm no stray internal callers remain**
+
+  Run: `grep -rnE "self\.lock\b|self\.scope_map\b|container\.lock\b|container\.scope_map\b" modern_di/`
+  Expected: no output — every internal attribute access now uses the underscore
+  name. (This pattern deliberately ignores the property `def scope_map`/`def lock`
+  and the warning-message strings, which are not attribute reads.) If any hit
+  remains, fix it to the private name.
+
+- [ ] **Step 9: Run the full suite with the coverage gate**
+
+  Run: `just test-ci`
+  Expected: PASS, 100% line coverage (the two property warning branches are
+  covered by the alias tests).
+
+- [ ] **Step 10: Lint / type check**
+
+  Run: `just lint-ci`
+  Expected: clean (`ruff`, `ty`, planning validation).
+
+- [ ] **Step 11: Commit**
+
+  ```bash
+  git add modern_di/container.py modern_di/providers/factory.py tests/test_container.py
+  git commit -m "chore: privatize Container.scope_map/lock behind deprecated aliases"
+  ```
+
+---
+
+### Task 2: Docs — extension point vs internals
+
+**Files:**
+- Modify: `docs/providers/advanced-api.md`
+- Modify: `architecture/containers.md`
+
+Promote `find_container` to a supported extension point, and update the internals
+section for the renamed attributes.
+
+- [ ] **Step 1: `advanced-api.md` — move `find_container` to extension points**
+
+  Move the `find_container(scope)` bullet out of the
+  `## Container internals — no stability guarantee` section and into
+  `## Supported extension points` as its own `### find_container(scope)`
+  subsection. Keep the existing description text, and add one sentence framing it
+  as the primitive a custom `AbstractProvider.resolve` calls to locate the
+  container at its scope. Cross-reference the "Subclassing `AbstractProvider`"
+  subsection.
+
+- [ ] **Step 2: `advanced-api.md` — update the internals bullets**
+
+  In `## Container internals — no stability guarantee`, rename the bullets:
+  - `**`scope_map`**` → `**`_scope_map`**` (keep the description).
+  - `**`lock`**` → `**`_lock`**` (keep the description).
+  Add one line after the two bullets: "The former public names `scope_map` and
+  `lock` remain as read-only properties that emit `DeprecationWarning` and will
+  be removed in a future release." Leave the `parent_container` bullet unchanged.
+
+- [ ] **Step 3: `architecture/containers.md` — update the scope_map mention**
+
+  Lines ~47-48 describe the child's `scope_map` dict and
+  `find_container(scope)`. Change `scope_map` → `_scope_map` in that prose
+  (the attribute is now private); `find_container(scope)` stays as written (it
+  is public). Keep the meaning identical.
+
+- [ ] **Step 4: Build the docs**
+
+  Run: `just docs-build`
+  Expected: success (mkdocs `--strict`).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add docs/providers/advanced-api.md architecture/containers.md
+  git commit -m "docs: find_container is an extension point; _scope_map/_lock are internal"
+  ```
+
+---
+
+### Task 3: Release notes
+
+**Files:**
+- Create: `planning/releases/2.22.0.md`
+
+Pre-stage the deprecation entry. `2.22.0` is the next minor (a deprecation is
+additive/back-compatible); the maintainer may adjust the version at tag time.
+
+- [ ] **Step 1: Write the release notes**
+
+  Create `planning/releases/2.22.0.md`, mirroring the house style of
+  `planning/releases/2.21.0.md`:
+
+```markdown
+# modern-di 2.22.0 — private `Container` internals
+
+Back-compatible. Two `Container` attributes become private, with deprecated aliases; one member is reclassified as a supported extension point.
+
+## Deprecation
+
+- **`Container.scope_map` and `Container.lock` are now private** (`_scope_map` / `_lock`). Reading the old names still works but emits `DeprecationWarning` and will be removed in a future release. These attributes were already documented "internal, no stability guarantee"; the thread-safety knob `use_lock=` and the `Container(...)` constructor are unchanged.
+
+## Clarification
+
+- **`find_container(scope)` is a supported extension point.** It is the primitive a custom `AbstractProvider.resolve` calls to locate the container at its scope, and is now documented as such (moved out of the internals section).
+
+## Downstream
+
+No action required. Nothing in the official integrations reads `scope_map` or `lock`. Advanced users who inspected them should switch to `_scope_map` / `_lock` (or, for scope lookup, `find_container`).
+
+## Internals
+
+- 100% line coverage maintained across Python 3.10–3.14; `ruff` and `ty` clean.
+```
+
+- [ ] **Step 2: Validate the bundle and commit**
+
+  Run: `just check-planning`  (Expected: `planning: OK`)
+  ```bash
+  git add planning/releases/2.22.0.md
+  git commit -m "docs: release notes for 2.22.0 (private Container internals)"
+  ```
+
+---
+
+### Task 4: Final validation, push, PR
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Full gates**
+
+  ```bash
+  just test-ci      # Expected: PASS, 100% coverage
+  just lint-ci      # Expected: clean
+  just docs-build   # Expected: success
+  just check-planning  # Expected: planning: OK
+  ```
+
+- [ ] **Step 2: Finalize the bundle summary**
+
+  Confirm `design.md`'s `summary:` still matches the shipped result; edit if the
+  scope shifted. Commit any change:
+  ```bash
+  git add planning/changes/2026-07-05.02-privatize-container-internals/design.md
+  git commit -m "docs: finalize privatize-container-internals bundle summary" || true
+  ```
+
+- [ ] **Step 3: Push and open the PR**
+
+  ```bash
+  git push -u origin chore/privatize-container-internals
+  gh pr create --fill --title "chore: privatize Container scope_map/lock internals"
+  ```
+  Then watch CI (lint, pytest 3.10–3.14, docs) until green.

--- a/planning/changes/2026-07-05.02-privatize-container-internals/plan.md
+++ b/planning/changes/2026-07-05.02-privatize-container-internals/plan.md
@@ -247,18 +247,18 @@ section for the renamed attributes.
 ### Task 3: Release notes
 
 **Files:**
-- Create: `planning/releases/2.22.0.md`
+- Create: `planning/releases/2.23.0.md`
 
-Pre-stage the deprecation entry. `2.22.0` is the next minor (a deprecation is
+Pre-stage the deprecation entry. `2.23.0` is the next minor (a deprecation is
 additive/back-compatible); the maintainer may adjust the version at tag time.
 
 - [ ] **Step 1: Write the release notes**
 
-  Create `planning/releases/2.22.0.md`, mirroring the house style of
+  Create `planning/releases/2.23.0.md`, mirroring the house style of
   `planning/releases/2.21.0.md`:
 
 ```markdown
-# modern-di 2.22.0 — private `Container` internals
+# modern-di 2.23.0 — private `Container` internals
 
 Back-compatible. Two `Container` attributes become private, with deprecated aliases; one member is reclassified as a supported extension point.
 
@@ -283,8 +283,8 @@ No action required. Nothing in the official integrations reads `scope_map` or `l
 
   Run: `just check-planning`  (Expected: `planning: OK`)
   ```bash
-  git add planning/releases/2.22.0.md
-  git commit -m "docs: release notes for 2.22.0 (private Container internals)"
+  git add planning/releases/2.23.0.md
+  git commit -m "docs: release notes for 2.23.0 (private Container internals)"
   ```
 
 ---

--- a/planning/releases/2.23.0.md
+++ b/planning/releases/2.23.0.md
@@ -1,0 +1,19 @@
+# modern-di 2.23.0 — private `Container` internals
+
+Back-compatible. Two `Container` attributes become private, with deprecated aliases; one member is reclassified as a supported extension point.
+
+## Deprecation
+
+- **`Container.scope_map` and `Container.lock` are now private** (`_scope_map` / `_lock`). Reading the old names still works but emits `DeprecationWarning` and will be removed in a future release. These attributes were already documented "internal, no stability guarantee"; the thread-safety knob `use_lock=` and the `Container(...)` constructor are unchanged.
+
+## Clarification
+
+- **`find_container(scope)` is a supported extension point.** It is the primitive a custom `AbstractProvider.resolve` calls to locate the container at its scope, and is now documented as such (moved out of the internals section).
+
+## Downstream
+
+No action required. Nothing in the official integrations reads `scope_map` or `lock`. Advanced users who inspected them should switch to `_scope_map` / `_lock` (or, for scope lookup, `find_container`).
+
+## Internals
+
+- 100% line coverage maintained across Python 3.10–3.14; `ruff` and `ty` clean.

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -329,8 +329,8 @@ def test_validation_failed_error_str_renders_inner_errors() -> None:
 def test_build_child_container_propagates_use_lock_false() -> None:
     root = Container(use_lock=False)
     child = root.build_child_container(scope=Scope.REQUEST)
-    assert root.lock is None
-    assert child.lock is None
+    assert root._lock is None  # noqa: SLF001
+    assert child._lock is None  # noqa: SLF001
 
 
 def test_container_provider_resolves_on_subclasses() -> None:
@@ -470,3 +470,54 @@ def test_open_on_open_container_is_noop() -> None:
     container.open()
     assert container.closed is False
     assert container.resolve(Container) is container
+
+
+def test_private_lock_and_scope_map_back_the_machinery() -> None:
+    root = Container(use_lock=True)
+    child = root.build_child_container(scope=Scope.REQUEST)
+
+    # _lock is a reentrant lock (threading.RLock is a factory, not a type, so
+    # assert behavior, not isinstance)
+    assert root._lock is not None  # noqa: SLF001
+    assert root._lock.acquire()  # noqa: SLF001
+    assert root._lock.acquire()  # reentrant  # noqa: SLF001
+    root._lock.release()  # noqa: SLF001
+    root._lock.release()  # noqa: SLF001
+    # child inherits the parent's scope map plus its own scope
+    assert set(child._scope_map) == {Scope.APP, Scope.REQUEST}  # noqa: SLF001
+    assert child._scope_map[Scope.APP] is root  # noqa: SLF001
+
+
+def test_use_lock_false_yields_no_private_lock() -> None:
+    root = Container(use_lock=False)
+    child = root.build_child_container(scope=Scope.REQUEST)
+    assert root._lock is None  # noqa: SLF001
+    assert child._lock is None  # noqa: SLF001
+
+
+def test_scope_map_alias_warns_and_forwards() -> None:
+    container = Container()
+    with pytest.warns(DeprecationWarning, match="scope_map"):
+        aliased = container.scope_map
+    assert aliased is container._scope_map  # noqa: SLF001
+
+
+def test_lock_alias_warns_and_forwards() -> None:
+    container = Container(use_lock=True)
+    with pytest.warns(DeprecationWarning, match="lock"):
+        aliased = container.lock
+    assert aliased is container._lock  # noqa: SLF001
+
+
+def test_resolve_emits_no_deprecation_warning() -> None:
+    class _Dep:
+        pass
+
+    class _Group(Group):
+        dep = providers.Factory(scope=Scope.APP, creator=_Dep, cache=True)
+
+    container = Container(groups=[_Group])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        container.resolve(_Dep)  # touches _lock and _scope_map internally
+        container.build_child_container(scope=Scope.REQUEST)


### PR DESCRIPTION
Privatizes the two genuinely-internal `Container` attributes behind deprecated aliases, following the project's `cache_settings=` deprecation precedent. Backward compatible; no integration touches these.

Spec + plan: `planning/changes/2026-07-05.02-privatize-container-internals/`.

## What changed

- **`Container.scope_map` → `_scope_map`** and **`Container.lock` → `_lock`**. All internal callers (`container.py`, `factory.py`) switch to the private names.
- The old names remain as **read-only `@property` aliases** that emit `DeprecationWarning` (`stacklevel=2`, "will be removed in a future release"). Because internal code uses the underscore names, the deprecated property never fires on the resolve hot path — a regression test (`test_resolve_emits_no_deprecation_warning`) guards this.
- **`find_container(scope)` reclassified as a supported extension point** (it's the primitive a custom `AbstractProvider.resolve` calls to locate its scope's container) — moved out of "internals" in `advanced-api.md`.

## Deliberately unchanged

- `find_container`, `parent_container` (attribute **and** constructor kwarg), the `use_lock=` knob, and the `Container(...)` constructor. These stay public.
- No hard break — old attribute reads keep working until a future major.

## Docs / release notes

- `advanced-api.md`: `find_container` promoted to extension points; internals bullets renamed to `_scope_map`/`_lock` with the deprecation note.
- `architecture/containers.md`: prose updated to `_scope_map`.
- `planning/releases/2.23.0.md` pre-staged (2.22.0 was already cut; maintainer confirms the version at tag time).

## Verification

`just test-ci` — 256 passed, 100% line coverage (the two property warning branches covered). `just lint-ci` clean (ruff + ty + planning). `just docs-build --strict` clean. The `SLF001` noqa on cross-object private access matches existing convention (`context_provider.py`, `alias.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
