### PR TITLE
ci: validate docs links/anchors under mkdocs --strict + pin docs deps

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs
-mkdocs-material
+mkdocs>=1.6,<2
+mkdocs-material>=9,<10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,12 @@ theme:
         icon: material/brightness-4
         name: Switch to system preference
 
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
 markdown_extensions:
   - toc:
       permalink: true


### PR DESCRIPTION
Ports the docs CI drift guard (from `faststream-outbox`) to this repo. This repo already runs `mkdocs --strict` as a PR `docs` job, so this adds only:

- **`mkdocs.yml`** — a `validation:` block so broken internal links, broken `#anchor` fragments, and orphaned pages fail the `--strict` build.
- **`docs/requirements.txt`** — pin `mkdocs>=1.6,<2`, `mkdocs-material>=9,<10` for a reproducible, MkDocs-2.0-proof build.

Verified: clean strict build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)