### PR TITLE
docs(release): add 2.24.0 notes

### DIFF
--- a/planning/releases/2.24.0.md
+++ b/planning/releases/2.24.0.md
@@ -1,0 +1,52 @@
+# modern-di 2.24.0 — grouped validation reports, two transitional warnings, to-3.x migration guide
+
+Back-compatible: no behavior flips. Validation errors render more readably, two transitional warnings
+land ahead of planned 3.0 changes, and the docs gain a migration guide with a warnings-as-errors
+readiness recipe.
+
+## Feature
+
+- **Grouped validation reports.** `ValidationFailedError` now groups its errors by kind with per-group
+  counts and indents multi-line sub-errors (so "Did you mean" suggestion blocks render intact), and
+  `CircularDependencyError` draws the cycle as a multi-line arrow chain instead of an inline
+  `A -> B -> A` string. Attributes (`.errors`, `.cycle_path`) and exception types are unchanged —
+  only the rendered message. **Note for test suites:** `str()` shapes of these two exceptions changed;
+  `pytest.raises(match=...)` against the old one-line texts must be updated (substring assertions on
+  the summary header still hold).
+- **[Migration guide to 3.x](https://modern-di.modern-python.org/migration/to-3.x/).** All five 3.0
+  switches with before/after code, plus a readiness recipe: escalate `DeprecationWarning` and
+  `FutureWarning` to errors and a green 2.x suite guarantees a clean 3.0 upgrade.
+
+## Deprecation
+
+- **`UnvalidatedContainerWarning` (a `FutureWarning`).** `Container(validate=)` is now tri-state
+  (`bool | None = None`). Building a **root** container without an explicit `validate` argument warns:
+  modern-di 3.0 runs `validate()` at root construction by default. Pass `validate=True` to adopt the
+  3.0 behavior now, or `validate=False` to keep validation off — an explicit `False` stays valid and
+  silent, also after 3.0. Child containers never warn.
+- **`ContextValueNoneWarning` (a `DeprecationWarning`).** Directly resolving an unset
+  `ContextProvider` still returns `None` but now warns: modern-di 3.0 raises the new
+  `ContextValueNotSetError` there instead (the class ships in this release, unraised, so you can
+  target it in `except` clauses today). Dependent-parameter behavior is unchanged — parameters with a
+  default or `| None` annotation are satisfied exactly as before, without warnings.
+
+## Why
+
+3.0 flips five switches, all now warned about on 2.x: the three previously announced
+(`ContainerClosedError`, `Alias(scope=)` removal, `Factory(cache_settings=)` removal) plus the two
+added here (default-on validation, raise on unset context value), as ruled in the 2026-07-05 UX
+research. The house pattern is to warn one full cycle ahead so `filterwarnings("error")` makes the
+upgrade mechanical — the migration guide documents the exact recipe.
+
+## Downstream
+
+No integration floor bump required: none of the official integrations constructs a root container
+internally (audited — the root always comes from your application code, so the new `FutureWarning`
+always points at a line you own). The integrations' own test suites and READMEs already pass explicit
+`validate=` org-wide. Applications: add `validate=True` (recommended) or `validate=False` to root
+`Container(...)` constructions to silence the warning.
+
+## Internals
+
+- 100% line coverage maintained across Python 3.10–3.14; `ruff` and `ty` clean.
+- Docs links and anchors now validated under `mkdocs --strict` in CI.


### PR DESCRIPTION
Release notes for the next minor at planning/releases/2.24.0.md (used verbatim as the GitHub Release body when 2.24.0 is tagged).

Covers PR #268: grouped ValidationFailedError reports + arrow-chain cycles (with the changed-str()-shapes caveat for downstream test suites), UnvalidatedContainerWarning and ContextValueNoneWarning/ContextValueNotSetError, and docs/migration/to-3.x.md. Downstream section reflects the integration audit (no floor bump needed; sibling repos already pass explicit validate=).

🤖 Generated with [Claude Code](https://claude.com/claude-code)