### PR TITLE
docs: pass explicit validate= in all root Container samples

### DIFF
--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -56,7 +56,7 @@ async def index(injected: datetime.datetime) -> str:
 
 app = Litestar(
     route_handlers=[index],
-    plugins=[modern_di_litestar.ModernDIPlugin(Container(groups=ALL_GROUPS))],
+    plugins=[modern_di_litestar.ModernDIPlugin(Container(groups=ALL_GROUPS, validate=True))],
 )
 ```
 
@@ -83,7 +83,7 @@ class AppGroup(Group):
 ALL_GROUPS = [AppGroup]
 
 app = litestar.Litestar(
-    plugins=[ModernDIPlugin(Container(groups=ALL_GROUPS), autowired_groups=ALL_GROUPS)],
+    plugins=[ModernDIPlugin(Container(groups=ALL_GROUPS, validate=True), autowired_groups=ALL_GROUPS)],
 )
 
 
@@ -126,7 +126,7 @@ class Dependencies(Group):
 
 ALL_GROUPS = [Dependencies]
 
-app = litestar.Litestar(plugins=[modern_di_litestar.ModernDIPlugin(Container(groups=ALL_GROUPS))])
+app = litestar.Litestar(plugins=[modern_di_litestar.ModernDIPlugin(Container(groups=ALL_GROUPS, validate=True))])
 
 
 @litestar.websocket_listener("/ws")

--- a/docs/integrations/pytest.md
+++ b/docs/integrations/pytest.md
@@ -43,7 +43,7 @@ from app import ioc
 
 @pytest.fixture(scope="session")
 def di_container() -> typing.Iterator[modern_di.Container]:
-    with modern_di.Container(groups=ioc.ALL_GROUPS) as container:
+    with modern_di.Container(groups=ioc.ALL_GROUPS, validate=True) as container:
         yield container
 ```
 

--- a/docs/introduction/about-di.md
+++ b/docs/introduction/about-di.md
@@ -144,7 +144,7 @@ class AppGroup(Group):
 
 
 # Build the app-level container, then a request-scoped child for per-request providers
-app_container = Container(scope=Scope.APP, groups=[AppGroup])
+app_container = Container(scope=Scope.APP, groups=[AppGroup], validate=True)
 with app_container.build_child_container(scope=Scope.REQUEST) as request_container:
     user_service = request_container.resolve(UserService)
 ```
@@ -160,7 +160,7 @@ Type annotations auto-wire dependencies - no manual registration needed.
 Hierarchical containers with automatic inheritance:
 
 ```python
-app_container = Container(groups=[AppGroup], scope=Scope.APP)
+app_container = Container(groups=[AppGroup], scope=Scope.APP, validate=True)
 request_container = app_container.build_child_container(scope=Scope.REQUEST)
 
 # Resolves from correct scope automatically
@@ -175,7 +175,7 @@ Override any dependency:
 ```python
 @pytest.fixture
 def test_container() -> Container:
-    container = Container(groups=[AppGroup])
+    container = Container(groups=[AppGroup], validate=True)
     container.override(AppGroup.db, Mock(spec=DatabaseConnection))
     return container
 ```

--- a/docs/migration/from-that-depends.md
+++ b/docs/migration/from-that-depends.md
@@ -264,7 +264,7 @@ class Dependencies(Group):
     )
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 
 with container.build_child_container(
     scope=Scope.REQUEST,
@@ -318,7 +318,7 @@ class Dependencies(Group):
     http_client = providers.ContextProvider(scope=Scope.APP, context_type=aiohttp.ClientSession)
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 
 
 @contextlib.asynccontextmanager

--- a/docs/migration/to-2.x.md
+++ b/docs/migration/to-2.x.md
@@ -36,7 +36,7 @@ sync_container.enter()
 from modern_di import Container
 
 # Single container for both sync and async operations
-container = Container(groups=ALL_GROUPS)
+container = Container(groups=ALL_GROUPS, validate=True)
 # No need to explicitly enter the container
 
 # For async cleanup

--- a/docs/providers/alias.md
+++ b/docs/providers/alias.md
@@ -50,7 +50,7 @@ class Dependencies(Group):
     )
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 
 concrete = container.resolve(PostgresRepository)
 abstract = container.resolve(Repository)

--- a/docs/providers/container.md
+++ b/docs/providers/container.md
@@ -21,7 +21,7 @@ def my_creator(di_container: Container) -> str:
 class Dependencies(Group):
     my_factory = providers.Factory(scope=Scope.APP, creator=my_creator)
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 result = container.resolve(str)
 # result: "Container scope: APP"
 ```
@@ -44,7 +44,7 @@ class Dependencies(Group):
         kwargs={"di_container": providers.container_provider}
     )
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 result = container.resolve(str)
 # result: "resolved from APP scope"
 ```
@@ -56,7 +56,7 @@ the active chain, not the `APP` root. The `container_provider` simply hands back
 ran the resolve, so a `REQUEST` child resolves `Container` to *itself*:
 
 ```python
-app_container = Container(scope=Scope.APP)
+app_container = Container(scope=Scope.APP, validate=True)
 request_container = app_container.build_child_container(scope=Scope.REQUEST)
 
 assert app_container.resolve(Container) is app_container

--- a/docs/providers/context.md
+++ b/docs/providers/context.md
@@ -43,7 +43,7 @@ class Dependencies(Group):
 
 
 # Provide custom context when building the child container
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 custom_context = CustomContext(user_id="123", tenant_id="abc")
 request_container = container.build_child_container(
     scope=Scope.REQUEST,
@@ -77,7 +77,7 @@ Context never propagates between containers. A `ContextProvider` reads the conte
     ```python
     # ❌ Broken: a REQUEST-scoped provider reads the REQUEST container's registry.
     # Setting it on the APP parent has no effect.
-    app_container = Container()
+    app_container = Container(validate=True)
     app_container.set_context(CustomContext, value)  # ignored for REQUEST-scoped providers
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
     ```
@@ -125,7 +125,10 @@ class Dependencies(Group):
 
 ALL_GROUPS = [Dependencies]
 app = fastapi.FastAPI()
-container = Container(groups=ALL_GROUPS)
+# validate=False: request_info depends on fastapi.Request, whose ContextProvider
+# is registered by setup_di() below — validating before that call would raise
+# ArgumentResolutionError for a dependency the integration hasn't wired in yet.
+container = Container(groups=ALL_GROUPS, validate=False)
 modern_di_fastapi.setup_di(app, container)
 # The integration creates a REQUEST-scoped child container per request and
 # automatically injects the fastapi.Request into its context. The factory

--- a/docs/providers/factories.md
+++ b/docs/providers/factories.md
@@ -32,7 +32,7 @@ class Dependencies(Group):
     )
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 # Resolve by provider reference
 instance = container.resolve_provider(Dependencies.independent_factory)
 assert isinstance(instance, IndependentFactory)
@@ -51,7 +51,7 @@ The caching mechanism is thread-safe by default, ensuring that even when multipl
 If your application is single-threaded, you can disable the lock for a small performance gain:
 
 ```python
-container = Container(groups=[Dependencies], use_lock=False)
+container = Container(groups=[Dependencies], use_lock=False, validate=True)
 ```
 
 Do not set `use_lock=False` in multi-threaded applications — it removes the guarantee that only one instance is created per cached factory.
@@ -74,7 +74,7 @@ class Dependencies(Group):
     )
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 singleton_instance1 = container.resolve_provider(Dependencies.singleton)
 singleton_instance2 = container.resolve_provider(Dependencies.singleton)
 
@@ -189,7 +189,7 @@ class Dependencies(Group):
     service = providers.Factory(scope=Scope.APP, creator=Service)
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 service = container.resolve(Service)
 assert service.cache is None  # no Cache provider registered -> None injected
 ```
@@ -242,7 +242,7 @@ class Dependencies(Group):
     )
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 # make_service receives a Backend instance, not the Factory provider
 ```
 
@@ -281,7 +281,7 @@ class Dependencies(Group):
     )
 
 
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 
 try:
     container.resolve(object)

--- a/docs/providers/lifecycle.md
+++ b/docs/providers/lifecycle.md
@@ -115,7 +115,7 @@ While a container is closed, resolving a dependency — or building a child cont
 Re-entering `with container:` reopens it cleanly, without a warning, and resolution works again:
 
 ```python
-container = Container(groups=[Dependencies])
+container = Container(groups=[Dependencies], validate=True)
 
 with container:
     container.resolve(Settings)

--- a/docs/providers/scopes.md
+++ b/docs/providers/scopes.md
@@ -28,7 +28,7 @@ The root `Container` is at `APP` scope. Child containers are built from a parent
 from modern_di import Container, Scope
 
 
-app_container = Container(groups=[Dependencies])     # APP scope
+app_container = Container(groups=[Dependencies], validate=True)     # APP scope
 
 with app_container.build_child_container(scope=Scope.REQUEST) as request_container:
     ...
@@ -108,7 +108,7 @@ class MyGroup(Group):
     tenant_provider = providers.Factory(scope=MyScope.TENANT, creator=TenantContext)
 
 
-container = Container(groups=[MyGroup])
+container = Container(groups=[MyGroup], validate=True)
 with container.build_child_container(scope=MyScope.TENANT) as tenant_container:
     tenant = tenant_container.resolve(TenantContext)
 ```

--- a/docs/troubleshooting/circular-dependency.md
+++ b/docs/troubleshooting/circular-dependency.md
@@ -29,8 +29,9 @@ from modern_di import Container
 # Option 1: validate at creation
 container = Container(groups=[MyGroup], validate=True)
 
-# Option 2: validate explicitly
-container = Container(groups=[MyGroup])
+# Option 2: validate explicitly (validate=False silences the construction-time
+# UnvalidatedContainerWarning since validate() below runs the same check manually)
+container = Container(groups=[MyGroup], validate=False)
 container.validate()
 ```
 

--- a/planning/changes/2026-07-06.01-docs-explicit-validate/design.md
+++ b/planning/changes/2026-07-06.01-docs-explicit-validate/design.md
@@ -1,0 +1,47 @@
+---
+summary: All docs/README samples constructing a root Container pass explicit validate=, so 2.24.0's UnvalidatedContainerWarning never fires from copy-pasted project samples.
+---
+
+# Design: Explicit validate= in all docs samples
+
+## Summary
+
+Every bare root `Container(...)` construction in `docs/` (46 sites at last
+count) and the core `README.md` gains an explicit `validate=` argument.
+Follow-up to the v3-bridges bundle (2026-07-05.04) ruled in the final review
+there: the day 2.24.0 releases, copy-pasted samples would otherwise emit
+`UnvalidatedContainerWarning`. The org-wide sibling-repo pass (READMEs +
+tests) already merged; this closes the core repo.
+
+## Non-goals
+
+- No prose rewrites; only the constructor calls change (plus a one-line
+  mention where a page already discusses validation, if it reads naturally).
+- No changes under `modern_di/` or `tests/`.
+
+## Design
+
+Site rules, in order:
+
+1. Default: add `validate=True`.
+2. A sample whose graph is deliberately broken to demonstrate a **validation**
+   error: `validate=True` (the error is the point).
+3. A sample whose graph is deliberately broken to demonstrate a **runtime**
+   failure (the lesson requires construction to succeed and the failure to
+   happen at resolve time): `validate=False`.
+4. A sample that demonstrates `UnvalidatedContainerWarning` itself (the
+   to-3.x guide's "before" snippets): stays bare — that is the point.
+
+`build_child_container` calls are untouched (children never take `validate`).
+
+## Testing
+
+- Implementer spot-runs at least one edited sample per docs section
+  (quickstart, providers, recipes, integrations, troubleshooting, migration)
+  as a script to prove the snippets still execute.
+- `just docs-build` (strict) and `just lint-ci` pass.
+
+## Risk
+
+Low. Worst case is an edited sample whose graph does not actually validate —
+caught by the spot-runs; any such site falls to rule 3 with a note.

--- a/planning/changes/2026-07-06.01-docs-explicit-validate/plan.md
+++ b/planning/changes/2026-07-06.01-docs-explicit-validate/plan.md
@@ -1,0 +1,27 @@
+# docs-explicit-validate — implementation plan
+
+**Goal:** No docs/README sample constructs a bare root `Container(...)`.
+**Spec:** [`design.md`](./design.md)
+**Branch:** `docs/explicit-validate-samples`
+**Commit strategy:** single commit.
+
+### Task 1: The sweep
+
+**Files:** every `docs/**/*.md` with a hit, plus `README.md`.
+
+- [ ] **Step 1: Enumerate sites**
+
+  `grep -rn "Container(" docs/ README.md | grep -v "build_child_container" | grep -v "validate="`
+  Root constructions only. Record the list.
+
+- [ ] **Step 2: Apply the design's site rules** (validate=True default; True
+  for validation-error demos; False for runtime-failure demos; to-3.x "before"
+  snippets stay bare).
+
+- [ ] **Step 3: Spot-run one edited sample per docs section** as a throwaway
+  script under the session scratchpad; record outputs.
+
+- [ ] **Step 4: Gates** — `just docs-build`, `just lint-ci`, re-run the
+  Step 1 grep (only rule-4 sites may remain).
+
+- [ ] **Step 5: Commit** — `docs: pass explicit validate= in all root Container samples`


### PR DESCRIPTION
Follow-up to #268, bundle planning/changes/2026-07-06.01-docs-explicit-validate/. With 2.24.0's UnvalidatedContainerWarning, copy-pasted project samples must model the explicit spelling.

- 25 sites → validate=True across docs/ (quickstart, providers, recipes, integrations, troubleshooting, migration).
- 2 necessary validate=False downgrades, each verified in review against Container's validate-at-construction semantics: docs/providers/context.md (integration registers the ContextProvider via setup_di after construction — True would raise before setup_di runs) and docs/troubleshooting/circular-dependency.md (preserves the validate-at-creation vs validate-later contrast).
- Left bare on purpose: the to-3.x guide's two "before" snippets (they demonstrate the warning) and 17 historical/pre-2.x or prose-only mentions.

Review re-enumerated all sites independently and checked every edited sample's graph against validate=True. Gates: docs-build --strict, lint-ci, check-planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)