### PR TITLE
feat: breadcrumb dependency chains on runtime scope errors (ERR-3)

### DIFF
--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -42,6 +42,15 @@ the container at that level. If the scope is deeper than the current container (
 `ScopeNotInitializedError` is raised; if it was skipped when building the child chain, a `ScopeSkippedError` is raised.
 From this point all cache and context operations use the scope-correct container.
 
+Both scope errors carry the same breadcrumb `dependency_path` as `ResolutionError` (they share
+`DependencyPathMixin`, see below), so a runtime **captive dependency** — a shallower-scoped provider
+depending, directly or transitively, on a deeper-scoped one — names both ends: the provider that
+captured the dependency and the one that actually failed to resolve, not just the two scope names.
+`Factory.resolve` wraps its own `find_container` call and prepends its own step on a scope error before
+re-raising, so the failing provider's name makes it into the chain even though this call sits outside
+the try block that wraps the rest of `resolve` (see Step 5's `prepend_step` note for the general
+mechanism). `Alias.resolve`'s except is widened the same way.
+
 ## Step 3 — Cache hit
 
 With the correct container in hand, `Factory.resolve` fetches (or creates) a `CacheItem` for this provider:
@@ -101,8 +110,9 @@ reads `dependencies`, `iter_validation_issues` builds a fresh error per `unwirea
 
 With the wiring plan in hand, `Factory` first surfaces any unwireable parameter: if `plan.unwireable` is non-empty it
 raises a **freshly built** `ArgumentResolutionError` from the first record before calling the creator. The error is
-built fresh on every raise (never memoized) because `ResolutionError.prepend_step` *mutates* the exception as it
-propagates up the chain — a stored instance would accumulate and leak breadcrumbs across repeated or nested resolves.
+built fresh on every raise (never memoized) because `prepend_step` (owned by the shared `DependencyPathMixin`, mixed
+into both `ResolutionError` and the two scope errors) *mutates* the exception as it propagates up the chain — a
+stored instance would accumulate and leak breadcrumbs across repeated or nested resolves.
 
 ```python
 resolved_kwargs = dict(plan.static_kwargs)

--- a/architecture/scopes.md
+++ b/architecture/scopes.md
@@ -37,6 +37,13 @@ two exceptions, depending on what went wrong:
 
 Both exceptions inherit from `ContainerError → ModernDIError → RuntimeError`.
 
+Both also carry a breadcrumb `dependency_path` (via the shared `DependencyPathMixin` — see the scope
+walk in [resolution.md](resolution.md)), so a **captive dependency** (a shallower-scoped provider that,
+directly or transitively, depends on a deeper-scoped one) reports both the capturing provider's name
+and the one that actually failed to resolve, in addition to the two scope names. Raised with an empty
+path (e.g. a bare `find_container` call with no provider frame involved) the message is unchanged from
+the shape shown above.
+
 ## How the container locates the right-scope container
 
 Each `Container` maintains a `scope_map: dict[IntEnum, Container]`. When a root container is created, the map is

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -55,10 +55,14 @@ Catch `ContainerError` for any container/scope failure.
   parent is already at the deepest scope (`STEP`), so there is no next level to advance to.
 - **`ScopeNotInitializedError`** — raised during resolution when a provider needs a scope *deeper*
   than the current container's, and no container at that scope exists in the chain (e.g. resolving a
-  `REQUEST`-scoped provider from the `APP` container). See [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md).
+  `REQUEST`-scoped provider from the `APP` container). Like `ResolutionError`, it carries a breadcrumb
+  `dependency_path`: a runtime *captive dependency* (a shallower-scoped provider depending, directly or
+  transitively, on this deeper-scoped one) names both the capturing provider and the one that actually
+  failed, not just the two scope names. See [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md).
 - **`ScopeSkippedError`** — raised during resolution when the target scope is *shallower* than the
   current container but is missing from the scope chain (a level was skipped when building children).
-  See [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md).
+  Carries the same breadcrumb `dependency_path` as `ScopeNotInitializedError`. See
+  [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md).
 - **`InvalidScopeTypeError`** — raised by the `Container` constructor when `scope` is not an
   `enum.IntEnum`.
 - **`ContainerClosedError`** — raised in modern-di **3.0** when you resolve from, or build a child
@@ -82,7 +86,8 @@ Catch `ResolutionError` for any resolution failure. These carry a `dependency_pa
 accumulated as the error propagates, so the message shows the full chain from the requested type
 down to the failing dependency. `dependency_path` is a `list[ResolutionStep]`, where each
 `ResolutionStep` (importable from `modern_di.exceptions`) has a `.scope` and a `.name` — inspect it
-to render the chain programmatically.
+to render the chain programmatically. `ScopeNotInitializedError` and `ScopeSkippedError` (below) carry
+the same `dependency_path` — the breadcrumb machinery is shared, not duplicated.
 
 - **`ProviderNotRegisteredError`** — raised by `resolve(SomeType)` when no provider is registered for
   the type. The message includes "did you mean…" suggestions when a close match exists. See

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -30,6 +30,47 @@ class ModernDIError(RuntimeError):
     __slots__ = ()
 
 
+class DependencyPathMixin(ModernDIError):  # noqa: N818 -- mixin, not a raisable error in its own right
+    """Breadcrumb machinery shared by :class:`ResolutionError` and the runtime scope errors.
+
+    Owns the two extra slots (`_base_message`, `dependency_path`) plus `prepend_step` and the
+    chain-rendering `__str__`, so any error raised inside a resolution frame can accumulate the
+    chain of provider names as it propagates back up to the caller. With an empty
+    `dependency_path` (the error never passed through a resolution frame) `__str__` returns the
+    base message unchanged.
+
+    Inherits from `ModernDIError` (rather than being a bare mixin) so it shares one instance
+    layout with `ContainerError`'s branch: combining a plain-object mixin's `__slots__` with an
+    `Exception` subclass's C-level layout raises `TypeError: multiple bases have instance
+    lay-out conflict`; sharing the solid base resolves it without changing any public surface
+    (not exported; `ResolutionError`/`ScopeNotInitializedError`/`ScopeSkippedError` keep their
+    documented bases and `isinstance` behavior).
+    """
+
+    __slots__ = ("_base_message", "dependency_path")
+
+    def __init__(self, message: str) -> None:
+        self._base_message = message
+        self.dependency_path: list[ResolutionStep] = []
+        super().__init__(message)
+
+    def prepend_step(self, step: ResolutionStep) -> None:
+        self.dependency_path.insert(0, step)
+        self.args = (str(self),)
+
+    def __str__(self) -> str:
+        if not self.dependency_path:
+            return self._base_message
+
+        scope_width = max(len(step.scope.name) for step in self.dependency_path)
+        lines = ["Cannot resolve dependency chain:"]
+        for i, step in enumerate(self.dependency_path):
+            prefix = "" if i == 0 else "    " * (i - 1) + "└─> "
+            lines.append(f"  {step.scope.name:<{scope_width}}  {prefix}{step.name}")
+        lines.append(f"  caused by: {self._base_message}")
+        return "\n".join(lines)
+
+
 class ContainerError(ModernDIError):
     """Base class for container and scope errors."""
 
@@ -65,8 +106,12 @@ class MaxScopeReachedError(ContainerError):
         )
 
 
-class ScopeNotInitializedError(ContainerError):
-    """Provider's scope is deeper than any active container. Inspect ``.provider_scope``, ``.container_scope``."""
+class ScopeNotInitializedError(DependencyPathMixin, ContainerError):
+    """Provider's scope is deeper than any active container. Inspect ``.provider_scope``, ``.container_scope``.
+
+    Carries a breadcrumb ``.dependency_path`` (see :class:`DependencyPathMixin`) so a captive
+    runtime dependency names both the failing provider and the one that captured it.
+    """
 
     __slots__ = ("container_scope", "provider_scope")
 
@@ -78,8 +123,12 @@ class ScopeNotInitializedError(ContainerError):
         )
 
 
-class ScopeSkippedError(ContainerError):
-    """Provider's scope was skipped in the container chain. Attrs: ``provider_scope``, ``container_scope``."""
+class ScopeSkippedError(DependencyPathMixin, ContainerError):
+    """Provider's scope was skipped in the container chain. Attrs: ``provider_scope``, ``container_scope``.
+
+    Carries a breadcrumb ``.dependency_path`` (see :class:`DependencyPathMixin`) so a captive
+    runtime dependency names both the failing provider and the one that captured it.
+    """
 
     __slots__ = ("container_scope", "provider_scope")
 
@@ -145,36 +194,16 @@ class UnvalidatedContainerWarning(FutureWarning):
     """
 
 
-class ResolutionError(ModernDIError):
+class ResolutionError(DependencyPathMixin, ModernDIError):
     """Base class for errors raised while resolving a provider.
 
     Carries an optional `dependency_path` accumulated as the error propagates up
     the resolution chain, so the rendered message shows the full path from the
-    initially requested type down to the failing dependency.
+    initially requested type down to the failing dependency. See
+    :class:`DependencyPathMixin` for the shared machinery.
     """
 
-    __slots__ = ("_base_message", "dependency_path")
-
-    def __init__(self, message: str) -> None:
-        self._base_message = message
-        self.dependency_path: list[ResolutionStep] = []
-        super().__init__(message)
-
-    def prepend_step(self, step: ResolutionStep) -> None:
-        self.dependency_path.insert(0, step)
-        self.args = (str(self),)
-
-    def __str__(self) -> str:
-        if not self.dependency_path:
-            return self._base_message
-
-        scope_width = max(len(step.scope.name) for step in self.dependency_path)
-        lines = ["Cannot resolve dependency chain:"]
-        for i, step in enumerate(self.dependency_path):
-            prefix = "" if i == 0 else "    " * (i - 1) + "└─> "
-            lines.append(f"  {step.scope.name:<{scope_width}}  {prefix}{step.name}")
-        lines.append(f"  caused by: {self._base_message}")
-        return "\n".join(lines)
+    __slots__ = ()
 
 
 class ProviderNotRegisteredError(ResolutionError):

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -30,29 +30,30 @@ class ModernDIError(RuntimeError):
     __slots__ = ()
 
 
-class DependencyPathMixin(ModernDIError):  # noqa: N818 -- mixin, not a raisable error in its own right
+class DependencyPathMixin:
     """Breadcrumb machinery shared by :class:`ResolutionError` and the runtime scope errors.
 
-    Owns the two extra slots (`_base_message`, `dependency_path`) plus `prepend_step` and the
-    chain-rendering `__str__`, so any error raised inside a resolution frame can accumulate the
-    chain of provider names as it propagates back up to the caller. With an empty
-    `dependency_path` (the error never passed through a resolution frame) `__str__` returns the
-    base message unchanged.
+    Owns `prepend_step` and the chain-rendering `__str__`, so any error raised inside a
+    resolution frame can accumulate the chain of provider names as it propagates back up to the
+    caller. With an empty `dependency_path` (the error never passed through a resolution frame)
+    `__str__` returns the base message unchanged.
 
-    Inherits from `ModernDIError` (rather than being a bare mixin) so it shares one instance
-    layout with `ContainerError`'s branch: combining a plain-object mixin's `__slots__` with an
-    `Exception` subclass's C-level layout raises `TypeError: multiple bases have instance
-    lay-out conflict`; sharing the solid base resolves it without changing any public surface
-    (not exported; `ResolutionError`/`ScopeNotInitializedError`/`ScopeSkippedError` keep their
-    documented bases and `isinstance` behavior).
+    Not itself an exception: it is not catchable via `except DependencyPathMixin` and is not
+    exported. Plain-`object` with empty `__slots__` so it never contributes instance layout of
+    its own — each concrete error (`ResolutionError`, `ScopeNotInitializedError`,
+    `ScopeSkippedError`) declares the `_base_message`/`dependency_path` slots itself alongside
+    its own attrs, avoiding the `TypeError: multiple bases have instance lay-out conflict` that
+    combining a slotted mixin with an `Exception` subclass would otherwise raise.
     """
 
-    __slots__ = ("_base_message", "dependency_path")
+    __slots__ = ()
 
     def __init__(self, message: str) -> None:
         self._base_message = message
         self.dependency_path: list[ResolutionStep] = []
-        super().__init__(message)
+        # Mixin's own base is `object`; the real MRO (via ResolutionError/ContainerError ->
+        # ModernDIError -> RuntimeError) accepts the arg at runtime.
+        super().__init__(message)  # ty: ignore[too-many-positional-arguments]
 
     def prepend_step(self, step: ResolutionStep) -> None:
         self.dependency_path.insert(0, step)
@@ -113,7 +114,7 @@ class ScopeNotInitializedError(DependencyPathMixin, ContainerError):
     runtime dependency names both the failing provider and the one that captured it.
     """
 
-    __slots__ = ("container_scope", "provider_scope")
+    __slots__ = ("_base_message", "container_scope", "dependency_path", "provider_scope")
 
     def __init__(self, *, provider_scope: enum.IntEnum, container_scope: enum.IntEnum) -> None:
         self.provider_scope = provider_scope
@@ -130,7 +131,7 @@ class ScopeSkippedError(DependencyPathMixin, ContainerError):
     runtime dependency names both the failing provider and the one that captured it.
     """
 
-    __slots__ = ("container_scope", "provider_scope")
+    __slots__ = ("_base_message", "container_scope", "dependency_path", "provider_scope")
 
     def __init__(self, *, provider_scope: enum.IntEnum, container_scope: enum.IntEnum) -> None:
         self.provider_scope = provider_scope
@@ -203,7 +204,7 @@ class ResolutionError(DependencyPathMixin, ModernDIError):
     :class:`DependencyPathMixin` for the shared machinery.
     """
 
-    __slots__ = ()
+    __slots__ = ("_base_message", "dependency_path")
 
 
 class ProviderNotRegisteredError(ResolutionError):

--- a/modern_di/providers/alias.py
+++ b/modern_di/providers/alias.py
@@ -68,6 +68,6 @@ class Alias(AbstractProvider[types.T_co]):
     def resolve(self, container: "Container") -> types.T_co:
         try:
             return container.resolve_provider(self._find_source(container))
-        except exceptions.ResolutionError as exc:
+        except (exceptions.ResolutionError, exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
             exc.prepend_step(self._resolution_step())
             raise

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -241,7 +241,14 @@ class Factory(AbstractProvider[types.T_co]):
         return resolved_kwargs
 
     def resolve(self, container: "Container") -> types.T_co:
-        container = container.find_container(self.scope)
+        try:
+            container = container.find_container(self.scope)
+        except (exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
+            # Name the failing end too: without this, a captive dependency's own step never
+            # makes it into the chain, and consumer frames alone would name every provider
+            # except the one that actually failed to resolve.
+            exc.prepend_step(self._resolution_step())
+            raise
         container._warn_and_reopen_if_closed()  # noqa: SLF001
         cache_item = container.cache_registry.fetch_cache_item(self)
 
@@ -250,7 +257,7 @@ class Factory(AbstractProvider[types.T_co]):
 
         try:
             resolved_kwargs = self._resolve_kwargs(container, cache_item)
-        except exceptions.ResolutionError as exc:
+        except (exceptions.ResolutionError, exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
             exc.prepend_step(self._resolution_step())
             raise
 

--- a/planning/changes/2026-07-06.02-scope-error-breadcrumbs/design.md
+++ b/planning/changes/2026-07-06.02-scope-error-breadcrumbs/design.md
@@ -1,5 +1,5 @@
 ---
-summary: Runtime scope errors carry breadcrumb dependency chains (ERR-3): a captive dependency now names both ends of the bad edge.
+summary: Shipped ERR-3 — runtime scope errors carry breadcrumb chains naming both ends of a captive dependency, via an uncatchable empty-slots DependencyPathMixin (maintainer-ruled shape).
 ---
 
 # Design: Breadcrumb dependency paths on runtime scope errors

--- a/planning/changes/2026-07-06.02-scope-error-breadcrumbs/design.md
+++ b/planning/changes/2026-07-06.02-scope-error-breadcrumbs/design.md
@@ -1,0 +1,66 @@
+---
+summary: Runtime scope errors carry breadcrumb dependency chains (ERR-3): a captive dependency now names both ends of the bad edge.
+---
+
+# Design: Breadcrumb dependency paths on runtime scope errors
+
+## Summary
+
+Implements shortlist ruling ERR-3 (2026-07-05 UX research). `Factory.resolve`
+only prepends breadcrumb steps to `ResolutionError`; scope errors
+(`ScopeNotInitializedError`, `ScopeSkippedError`) are `ContainerError`
+subclasses raised inside `find_container`, so a runtime captive dependency
+(APP factory pulling a REQUEST-scoped dep) reports only two scope names — no
+provider names, no chain. The wrong-blame failure users file bugs about
+elsewhere (Dagger #1023, Angular #58391); .NET MEDI names both ends.
+
+## Approach (maintainer-ruled: mixin)
+
+- Extract the breadcrumb machinery (`_base_message`, `dependency_path`,
+  `prepend_step`, chain-rendering `__str__`) from `ResolutionError`
+  (exceptions.py:148) into `DependencyPathMixin` in the same module. The
+  mixin owns the two slots; `ResolutionError(DependencyPathMixin,
+  ModernDIError)` keeps identical behavior; `__init__` stays cooperative
+  (`super().__init__(message)` through the MRO).
+- `ScopeNotInitializedError(DependencyPathMixin, ContainerError)` and
+  `ScopeSkippedError(DependencyPathMixin, ContainerError)` — public base
+  `ContainerError` preserved, so downstream `except ContainerError` handlers
+  are unaffected. Base messages (exceptions.py:76-78, 89-93) unchanged; with
+  an empty `dependency_path` the rendered message is byte-identical to today.
+- Widen the two existing prepend sites from `except exceptions.ResolutionError`
+  to the tuple `(ResolutionError, ScopeNotInitializedError, ScopeSkippedError)`
+  (a mixin cannot be an `except` target): `factory.py:253` and the
+  `Alias.resolve` except (alias.py:69-74).
+- Name the failing end too (verification nuance from the report): the failing
+  provider's own `find_container` call at `factory.py:244` sits outside its
+  try block, so consumer frames alone would chain everything except the
+  provider that actually failed. Wrap that call; on a scope error prepend
+  this factory's own step, then re-raise (outer frames prepend theirs).
+
+## Non-goals
+
+- No change to base messages, exception bases, or attributes — only added
+  chain rendering when the error propagates through resolution frames.
+- No change to `validate()`'s static captive-dependency check
+  (`InvalidScopeDependencyError`) — this covers the runtime path only.
+
+## Testing
+
+TDD in `tests/test_dependency_path.py`:
+- Captive repro (the report's live-verified scenario): APP-scoped factory
+  depending on a REQUEST-scoped provider, resolved from a REQUEST container —
+  assert the rendered message contains both provider names, the chain arrows,
+  and the scope-error base message as the `caused by:` line.
+- Top-level direct resolve of a too-deep provider: message byte-identical to
+  today (empty path ⇒ no chain header).
+- `except ContainerError` still catches both classes.
+- Alias in the chain prepends its step on a scope error.
+- Full gates: `just test-ci` (100%), `just lint-ci`.
+
+## Risk
+
+- **Slots/MRO subtleties** (low/medium): mixin carries the slots; exception
+  bases keep `__slots__ = ()`. Guarded by the byte-identical-message tests and
+  the existing dependency-path suite.
+- **Over-catching in the widened excepts** (low/low): the tuple is explicit;
+  no other `ContainerError` subclass flows through those frames.

--- a/planning/changes/2026-07-06.02-scope-error-breadcrumbs/plan.md
+++ b/planning/changes/2026-07-06.02-scope-error-breadcrumbs/plan.md
@@ -1,0 +1,33 @@
+# scope-error-breadcrumbs — implementation plan
+
+**Goal:** Runtime scope errors render the full dependency chain naming both ends.
+**Spec:** [`design.md`](./design.md)
+**Branch:** `feat/scope-error-breadcrumbs`
+**Commit strategy:** per-task commits.
+
+### Task 1: Mixin + widened prepend sites (TDD)
+
+**Files:** `modern_di/exceptions.py`, `modern_di/providers/factory.py`,
+`modern_di/providers/alias.py`; tests in `tests/test_dependency_path.py`.
+
+- [ ] Failing tests first (design's Testing list: captive repro asserting both
+      names + `caused by:` scope message; byte-identical top-level message;
+      `except ContainerError` compatibility; alias step).
+- [ ] RED run, then implement: extract `DependencyPathMixin` (slots
+      `_base_message`, `dependency_path`; `prepend_step`; chain `__str__`;
+      cooperative `__init__`); rebase `ResolutionError` and the two scope
+      errors onto it; widen `factory.py:253` and `alias.py:69-74` excepts to
+      the explicit 3-tuple; wrap `factory.py:244`'s `find_container` to
+      prepend the failing factory's own step.
+- [ ] GREEN: targeted file, then full suite; `just test-ci` at 100% (mixin
+      lines all covered), `just lint-ci`.
+- [ ] Commit: `feat: breadcrumb dependency chains on runtime scope errors (ERR-3)`
+
+### Task 2: Docs promotion
+
+**Files:** `architecture/resolution.md` (breadcrumb section: now also scope
+errors), `architecture/scopes.md` (error-shape note), 
+`docs/providers/errors-and-exceptions.md` (scope-error entries mention the
+chain); verify `just docs-build`.
+
+- [ ] Commit: `docs: promote scope-error breadcrumbs into architecture/`

--- a/tests/test_dependency_path.py
+++ b/tests/test_dependency_path.py
@@ -2,7 +2,7 @@ import dataclasses
 
 import pytest
 
-from modern_di import Container, Group, Scope, providers
+from modern_di import Container, Group, Scope, exceptions, providers
 from modern_di.exceptions import (
     ArgumentResolutionError,
     ContainerError,
@@ -147,3 +147,8 @@ def test_scope_error_still_caught_as_container_error() -> None:
     with pytest.raises(ContainerError) as exc_info:
         container.find_container(Scope.REQUEST)
     assert isinstance(exc_info.value, ScopeNotInitializedError)
+
+
+def test_dependency_path_mixin_is_not_an_exception() -> None:
+    # Guards the ruling: DependencyPathMixin must never become except-catchable on its own.
+    assert not issubclass(exceptions.DependencyPathMixin, BaseException)

--- a/tests/test_dependency_path.py
+++ b/tests/test_dependency_path.py
@@ -3,7 +3,13 @@ import dataclasses
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import ArgumentResolutionError, ProviderNotRegisteredError, ResolutionStep
+from modern_di.exceptions import (
+    ArgumentResolutionError,
+    ContainerError,
+    ProviderNotRegisteredError,
+    ResolutionStep,
+    ScopeNotInitializedError,
+)
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -70,3 +76,74 @@ def test_chain_includes_scope_name() -> None:
     rendered = str(exc_info.value)
     assert "REQUEST" in rendered
     assert exc_info.value.dependency_path[0].scope == Scope.REQUEST
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class ScopedResource:
+    pass
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class CaptiveConsumer:
+    resource: ScopedResource
+
+
+class AbstractResource: ...
+
+
+def test_scope_error_at_direct_container_call_has_empty_path() -> None:
+    # No provider frame is ever entered (find_container is called directly, not via
+    # resolve()), so the dependency_path stays empty and the message is exactly today's.
+    container = Container()
+    with pytest.raises(ScopeNotInitializedError) as exc_info:
+        container.find_container(Scope.REQUEST)
+
+    exc = exc_info.value
+    assert exc.dependency_path == []
+    assert str(exc) == "Provider of scope REQUEST cannot be resolved in container of scope APP."
+
+
+def test_captive_dependency_names_both_ends() -> None:
+    # The report's live-verified scenario: an APP-scoped factory captively depends on a
+    # REQUEST-scoped provider. Resolving it from a REQUEST container still fails (the
+    # captured object would outlive its scope), but the message must now name both the
+    # captor and the captive, not just the two scope names.
+    class CaptiveGroup(Group):
+        resource = providers.Factory(scope=Scope.REQUEST, creator=ScopedResource)
+        consumer = providers.Factory(scope=Scope.APP, creator=CaptiveConsumer)
+
+    app_container = Container(groups=[CaptiveGroup])
+    request_container = app_container.build_child_container(scope=Scope.REQUEST)
+
+    with pytest.raises(ScopeNotInitializedError) as exc_info:
+        request_container.resolve(CaptiveConsumer)
+
+    exc = exc_info.value
+    assert [step.name for step in exc.dependency_path] == ["CaptiveConsumer", "ScopedResource"]
+    rendered = str(exc)
+    assert rendered.startswith("Cannot resolve dependency chain:")
+    assert "CaptiveConsumer" in rendered
+    assert "└─> ScopedResource" in rendered
+    assert "caused by: Provider of scope REQUEST cannot be resolved in container of scope APP." in rendered
+
+
+def test_alias_prepends_step_on_scope_error() -> None:
+    class AliasCaptiveGroup(Group):
+        resource = providers.Factory(scope=Scope.REQUEST, creator=ScopedResource)
+        alias = providers.Alias(source_type=ScopedResource, bound_type=AbstractResource)
+
+    app_container = Container(groups=[AliasCaptiveGroup])
+    with pytest.raises(ScopeNotInitializedError) as exc_info:
+        app_container.resolve(AbstractResource)
+
+    exc = exc_info.value
+    assert [step.name for step in exc.dependency_path] == ["AbstractResource", "ScopedResource"]
+    rendered = str(exc)
+    assert "caused by: Provider of scope REQUEST cannot be resolved in container of scope APP." in rendered
+
+
+def test_scope_error_still_caught_as_container_error() -> None:
+    container = Container()
+    with pytest.raises(ContainerError) as exc_info:
+        container.find_container(Scope.REQUEST)
+    assert isinstance(exc_info.value, ScopeNotInitializedError)


### PR DESCRIPTION
Shortlist ruling ERR-3 from the 3.0 UX research; bundle planning/changes/2026-07-06.02-scope-error-breadcrumbs/.

A runtime captive dependency (APP factory pulling a REQUEST-scoped dep) previously reported only two scope names. Now ScopeNotInitializedError/ScopeSkippedError carry the same breadcrumb chain as ResolutionError, naming every hop including the failing provider itself (its own find_container call is wrapped so both ends of the bad edge appear).

Design points:
- DependencyPathMixin holds the shared machinery; per maintainer ruling it is plain-object with empty slots (data slots live on the three concrete classes), so it is NOT except-catchable — pinned by a test. Public bases unchanged: both scope errors remain ContainerError subclasses, and empty-path messages are byte-identical to before (both pinned by tests).
- Prepend sites widened to the explicit 3-tuple in Factory.resolve and Alias.resolve.

Review loop: initial implementation made the mixin a catchable exception to dodge a slots layout conflict; the reviewer surfaced the empty-slots alternative, Artur ruled for it, re-review approved. Gates: just test-ci 274 passed / 100% coverage, lint-ci, docs-build --strict; architecture/ promoted in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)