### PR TITLE
docs(release): extend 2.24.0 notes with the diagnostics additions

### DIFF
--- a/planning/releases/2.24.0.md
+++ b/planning/releases/2.24.0.md
@@ -1,11 +1,20 @@
-# modern-di 2.24.0 — grouped validation reports, two transitional warnings, to-3.x migration guide
+# modern-di 2.24.0 — richer error diagnostics, two transitional warnings, to-3.x migration guide
 
-Back-compatible: no behavior flips. Validation errors render more readably, two transitional warnings
-land ahead of planned 3.0 changes, and the docs gain a migration guide with a warnings-as-errors
-readiness recipe.
+Back-compatible: no behavior flips. Errors got a diagnostics upgrade — grouped validation reports, a
+runtime cycle guard, dependency chains on scope errors — two transitional warnings land ahead of
+planned 3.0 changes, and the docs gain a migration guide with a warnings-as-errors readiness recipe.
 
 ## Feature
 
+- **Runtime cycle guard.** An unvalidated circular graph no longer dies with a raw `RecursionError`
+  on first resolve: `resolve()` now raises `CircularDependencyError` with the full cycle path (the
+  original `RecursionError` is kept as `__cause__`). A creator that merely recurses on its own — with
+  no cycle in the provider graph — still raises the original `RecursionError` unchanged. Zero cost on
+  the happy path; `validate()` remains the way to see all graph errors before first resolve.
+- **Scope errors carry dependency chains.** `ScopeNotInitializedError` and `ScopeSkippedError` now
+  render the same breadcrumb chain as resolution errors when they propagate through factories, naming
+  both ends of a captive dependency (previously: two scope names, no provider names). Raised directly,
+  their messages are byte-identical to before; both remain `ContainerError` subclasses.
 - **Grouped validation reports.** `ValidationFailedError` now groups its errors by kind with per-group
   counts and indents multi-line sub-errors (so "Did you mean" suggestion blocks render intact), and
   `CircularDependencyError` draws the cycle as a multi-line arrow chain instead of an inline
@@ -48,5 +57,7 @@ always points at a line you own). The integrations' own test suites and READMEs 
 
 ## Internals
 
+- Every docs sample now constructs root containers with explicit `validate=` — copy-pasted samples
+  never trigger the new warning.
 - 100% line coverage maintained across Python 3.10–3.14; `ruff` and `ty` clean.
 - Docs links and anchors now validated under `mkdocs --strict` in CI.


### PR DESCRIPTION
Extends planning/releases/2.24.0.md for the three additions merged since #269: runtime cycle guard (#272), scope-error dependency chains (#271), and the docs explicit-validate sweep (#270). Headline updated to "richer error diagnostics".

Checked in the same pass: docs/migration/to-3.x.md needs no update — ERR-1/ERR-3 are non-breaking (not 3.0 switches) and the guide never described the old RecursionError behavior; the two pages that did were already updated in #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)