### PR TITLE
docs: pages batch — FastAPI-users guide, vocabulary table, anti-patterns, non-goals (DOC-4/5/7/9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ with Container(groups=[Dependencies], validate=True) as container:
         print(repo.settings.database_url)
 ```
 
-See the [documentation](https://modern-di.modern-python.org) for scopes, lifecycles, finalizers, and framework integrations.
+See the [documentation](https://modern-di.modern-python.org) for scopes, lifecycles, finalizers, and framework integrations. `modern-di` is deliberately conservative — see [Design decisions](https://modern-di.modern-python.org/introduction/design-decisions/) for what it leaves out on purpose, including auto-binding, in-package integrations, and graph rendering.
 
 Usage examples:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,3 +139,4 @@ provider registers an **async** finalizer — see [Lifecycle](providers/lifecycl
 - [Scopes](providers/scopes.md) — the APP → REQUEST lifetime model in one page.
 - [Lifecycle](providers/lifecycle.md) — finalizers, `close_async()`, validation.
 - [Recipes](recipes/sqlalchemy.md) — async SQLAlchemy, lifespan-managed resources, testing with overrides.
+- [Good and bad practices](recipes/good-and-bad-practices.md) — named footguns and the mechanism that catches each one.

--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -106,6 +106,7 @@ lifetime dialect, so here is how the same six concepts translate:
 ## See also
 
 - [Design decisions](design-decisions.md) — the reasoning behind sync-only
-  resolution, no global state, and a conservative core.
+  resolution, no global state, a conservative core, and the deliberate
+  [non-goals](design-decisions.md#non-goals) that keep it that way.
 - [that-depends or modern-di?](that-depends-or-modern-di.md) — choosing within
   the modern-python family.

--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -88,6 +88,21 @@ modern-di earns its place once you have a second entrypoint, or need typed,
 scoped, app-wide singletons with overrides that work everywhere, not just on the
 HTTP path.
 
+## Where is Singleton? — cross-framework vocabulary
+
+modern-di deliberately has no `Singleton` class — "create once and reuse" is spelled via a scope
+plus `cache=True` on an ordinary `Factory`. Every arriving user speaks a different framework's
+lifetime dialect, so here is how the same six concepts translate:
+
+| Concept | dependency-injector | dishka | wireup | svcs | FastAPI `Depends` | modern-di |
+|---|---|---|---|---|---|---|
+| Singleton (create once, share) | `providers.Singleton(...)` | `provide(Impl, scope=Scope.APP)` — cached by default within its scope | `@injectable` — default `lifetime="singleton"` | `registry.register_value(Type, value)` at startup | a dependency wrapped in `@lru_cache` | [`Factory(scope=Scope.APP, cache=True)`](../providers/factories.md#cached-factories) |
+| Transient (fresh instance every time) | `providers.Factory(...)` | `provide(Impl, cache=False)` | `@injectable(lifetime="transient")` | no dedicated provider — call the plain factory directly | `Depends(fn, use_cache=False)` | a plain [`Factory(...)`](../providers/factories.md) with no `cache` |
+| Request-scoped | `providers.Resource` + the `Closing` wiring marker | `provide(Impl, scope=Scope.REQUEST)` | `@injectable(lifetime="scoped")` | one instance per `svcs.Container` (built per request) | bare `Depends(fn)` — computed once per request by default | [`Factory(scope=Scope.REQUEST, cache=True)`](../providers/scopes.md) |
+| Runtime value (request object, etc.) | `providers.Configuration` / `.from_value()` | `from_context(provides=Type, scope=...)` declared, then `context={Type: value}` at scope entry | a typed constructor parameter resolved from the active scope's context | `registry.register_value(Type, value)`, or a per-container local factory | the framework injects `Request`/`WebSocket` directly by type | [`ContextProvider(context_type=...)`](../providers/context.md) + `context={...}` |
+| Interface binding (concrete → abstract type) | `providers.AbstractFactory` — must be overridden with a concrete `Factory` before use | `alias(source=Impl, provides=Interface)` | `@injectable(as_type=Interface)` | `register_factory(Interface, factory)` — svcs keys by whatever type you register under | n/a — `Depends` is callable-keyed, not type-keyed | [`Alias(source_type=Impl, bound_type=Interface)`](../providers/alias.md) |
+| Test override | `provider.override(...)`, or `with provider.override(...):` | no dedicated API — build a separate container from mock providers | `with container.override.injectable(Target, new=fake):` | re-call `register_value()`/`register_factory()`; `container.close()` first if already cached | `app.dependency_overrides[dep] = fake` | [`container.override(provider, mock)`](../recipes/testing-overrides.md) |
+
 ## See also
 
 - [Design decisions](design-decisions.md) — the reasoning behind sync-only

--- a/docs/introduction/design-decisions.md
+++ b/docs/introduction/design-decisions.md
@@ -38,6 +38,34 @@ The codebase is type-checked with `ty` and linted with ruff's full rule set (`se
 
 New features get added only when existing primitives genuinely cannot solve the task. The core has three concrete provider types (`Factory`, `Alias`, `ContextProvider`), plus the `AbstractProvider` base and the pre-built `container_provider` singleton — most other DI frameworks have two to three times that. This is deliberate: a small, composable core is easier to learn, easier to test, and easier to keep correct.
 
+## Non-goals
+
+Beyond the choices above, three more things are deliberately out of scope. Naming them here is meant to save you from filing (or us from re-litigating) the same feature request.
+
+### Auto-binding / auto-registration
+
+**What:** modern-di never registers a provider for a type you didn't declare, and never infers wiring by scanning your codebase (import scanning, decorator scanning, `auto_bind`-style fallbacks some frameworks offer).
+
+**Why:** Auto-binding defers a missing-provider error from declaration time — where modern-di already raises `UnsupportedCreatorParameterError` — to whichever request first exercises the untested path. That's the opposite of the framework's declaration-time-failure bet, and it invites automagic wiring nobody can trace back to a source.
+
+**Alternative:** Register the provider explicitly in a `Group`. If the boilerplate is real, write a small helper that builds several `Factory` instances from a list of classes — that's application code, not a framework feature.
+
+### In-package framework integrations
+
+**What:** The core `modern-di` package ships no aiohttp/FastAPI/FastStream/Litestar/Starlette/Typer/pytest code. Each integration is a separate `modern-di-*` package with its own release cadence.
+
+**Why:** Bundling integrations into core would couple the library's release cadence to every framework's own churn, and would erode the zero-dependency guarantee that lets `modern-di` itself stay dependency-free. The separate-repo model is a standing architectural decision (see [`writing-integrations.md`](../integrations/writing-integrations.md)), not an oversight.
+
+**Alternative:** Install the matching adapter package — see the [Quickstart](../index.md) for the current list — or write your own following [Writing an integration](../integrations/writing-integrations.md).
+
+### Graph rendering / visualization tooling
+
+**What:** modern-di has no built-in way to render the dependency graph as a picture — no ASCII art, no Graphviz/Mermaid export, no `plot()`/`render()` call.
+
+**Why:** The graph already exists internally — `validate()` walks the full provider graph and reports every wiring problem it finds — but a renderer is a standalone subsystem (choosing and maintaining a diagram format) rather than an extension of an existing primitive, so it sits outside the conservative feature set. `validate()`'s aggregated, all-errors-at-once text report already surfaces the graph's problems without a new dependency or output format.
+
+**Alternative:** None shipped today. If you need a picture of the graph, walk `Group.get_providers()` yourself.
+
 ## See also
 
 - [About DI](about-di.md) — the framework-agnostic introduction.

--- a/docs/introduction/design-decisions.md
+++ b/docs/introduction/design-decisions.md
@@ -60,11 +60,11 @@ Beyond the choices above, three more things are deliberately out of scope. Namin
 
 ### Graph rendering / visualization tooling
 
-**What:** modern-di has no built-in way to render the dependency graph as a picture — no ASCII art, no Graphviz/Mermaid export, no `plot()`/`render()` call.
+**What:** modern-di has no built-in way to render the dependency graph as a picture — no ASCII art, no bundled renderer, no `plot()`/`render()` call, no image output.
 
-**Why:** The graph already exists internally — `validate()` walks the full provider graph and reports every wiring problem it finds — but a renderer is a standalone subsystem (choosing and maintaining a diagram format) rather than an extension of an existing primitive, so it sits outside the conservative feature set. `validate()`'s aggregated, all-errors-at-once text report already surfaces the graph's problems without a new dependency or output format.
+**Why:** Rendering is a standalone subsystem (choosing, drawing, and maintaining a diagram toolchain) rather than an extension of an existing primitive, so it sits outside the conservative feature set and the zero-dependency guarantee. `validate()`'s aggregated, all-errors-at-once text report already surfaces the graph's problems without a new dependency or output format.
 
-**Alternative:** None shipped today. If you need a picture of the graph, walk `Group.get_providers()` yourself.
+**Alternative:** None shipped today. If you need a picture of the graph, walk `Group.get_providers()` yourself and feed the edges to the diagram tool of your choice.
 
 ## See also
 

--- a/docs/introduction/for-fastapi-users.md
+++ b/docs/introduction/for-fastapi-users.md
@@ -1,0 +1,70 @@
+# modern-di for FastAPI users
+
+FastAPI's own `Depends` system covers a single request-scoped web service well. You reach for
+modern-di once you need a second entrypoint (a worker, a CLI), typed app-wide singletons with real
+teardown, or overrides that work outside the HTTP path — see
+[Do you even need a DI container?](comparison.md#do-you-even-need-a-di-container). This page
+translates the `Depends` idioms you already know into their modern-di equivalents.
+
+## Translation table
+
+| FastAPI `Depends` | modern-di | Notes |
+|---|---|---|
+| `Depends(fn)` | `Factory(creator=fn)` | Both auto-wire the callable's parameters; modern-di matches by type annotation instead of by the callable's own parameter defaults. |
+| bare `Depends(fn)` (`use_cache=True`, the default) | `Factory(scope=Scope.REQUEST, creator=fn, cache=True)` | FastAPI memoizes a dependency for the rest of the *same request* once it's been called; the REQUEST-scoped cached `Factory` is the equivalent — one shared instance per request container. |
+| `Depends(fn, use_cache=False)` | a bare `Factory(creator=fn)` — no `cache` | Without `cache`, a `Factory` builds a fresh instance on every resolve, matching `use_cache=False`. |
+| `yield`-based teardown (`def fn(): ...; yield x; ...cleanup...`) | `cache=CacheSettings(finalizer=cleanup_fn)` | modern-di has no generator-creator form (see [Design decisions](design-decisions.md)); teardown is a second, explicit object instead of code after `yield`. `finalizer` may be sync or async — see [Lifecycle](../providers/lifecycle.md). |
+| `@lru_cache`-wrapped dependency (process-wide singleton) | `Factory(scope=Scope.APP, creator=fn, cache=True)`, optionally with a `finalizer` | `lru_cache` has no cleanup hook; the APP-scoped cached `Factory` adds one via `CacheSettings(finalizer=...)` if the singleton needs to release anything on shutdown. |
+| `app.dependency_overrides[fn] = fake` | `container.override(provider, fake)` | modern-di overrides are keyed by **provider reference**, not by callable, and apply across the whole container tree — see [Testing with overrides](../recipes/testing-overrides.md). Reset with `container.reset_override(provider)`. |
+
+## Two meanings of "scope"
+
+Since FastAPI 0.121.0, `Depends(scope="function" | "request")` controls **when the code after
+`yield` runs** relative to the response: `scope="function"` tears down right after your path
+operation function returns (before the response is sent), and `scope="request"` — the default for
+a `yield` dependency — tears down after the response has been sent back to the client. It says
+nothing about how many times the dependency is *constructed*; that's `use_cache`'s job.
+
+modern-di's `Scope` (`APP → SESSION → REQUEST → ACTION → STEP`) answers a different question
+entirely: **how long a provider's cached instance lives**, not when its finalizer fires relative to
+a response. The two `scope`s share a word but not an axis — FastAPI's is teardown timing, modern-di's
+is lifetime. See [Scopes](../providers/scopes.md) for the full model.
+
+## Example: request-scoped session with teardown
+
+```python
+import dataclasses
+
+from modern_di import Group, Scope, providers
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class Session:
+    connection_string: str
+
+
+def create_session() -> Session:
+    return Session(connection_string="postgresql+asyncpg://localhost/app")
+
+
+def close_session(session: Session) -> None:
+    ...  # release the connection
+
+
+class Dependencies(Group):
+    session = providers.Factory(
+        scope=Scope.REQUEST,
+        creator=create_session,
+        cache=providers.CacheSettings(finalizer=close_session),
+    )
+```
+
+This is the modern-di equivalent of a FastAPI `yield`-dependency that hands out one session per
+request and closes it afterward — but with the container's finalizer, not code after `yield`, and
+`Scope.REQUEST` naming the lifetime rather than the teardown moment.
+
+## See also
+
+- [modern-di vs other libraries](comparison.md) — including the cross-framework vocabulary table.
+- [FastAPI integration](../integrations/fastapi.md) — `setup_di`, `FromDI`, and websocket scopes.
+- [Design decisions](design-decisions.md) — why modern-di has no generator-based teardown.

--- a/docs/recipes/good-and-bad-practices.md
+++ b/docs/recipes/good-and-bad-practices.md
@@ -1,0 +1,154 @@
+# Good and bad practices
+
+modern-di's docs mostly show the happy path. This page collects the footguns instead — real
+mistakes the framework lets you make, each paired with the mechanism that catches or prevents it.
+
+## 1. Captive dependency: a wide-scoped provider holding a narrow-scoped one
+
+A provider is a *captive dependency* when it lives longer than something it depends on — an
+APP-scoped provider that (directly or transitively) needs a REQUEST-scoped one. The REQUEST
+instance would have to outlive its request, so it can't actually be supplied.
+
+```python
+class Dependencies(Group):
+    session = providers.Factory(scope=Scope.REQUEST, creator=Session)
+
+    # ❌ forgot scope=Scope.REQUEST — defaults to Scope.APP, which cannot hold `session`
+    user_cache = providers.Factory(creator=UserCache)
+
+    # ✅ matches the lifetime of what it consumes
+    user_cache = providers.Factory(scope=Scope.REQUEST, creator=UserCache)
+```
+
+**Caught by:** `Container(groups=[...], validate=True)` raises `InvalidScopeDependencyError` for
+this exact graph before anything is ever resolved — see
+[Scope chain violation](../troubleshooting/scope-chain.md). If the graph is never validated, the
+runtime failure is a `ScopeNotInitializedError`/`ScopeSkippedError` that (since the scope-error
+breadcrumb work) now names both the provider that captured the dependency and the one that
+actually failed — but it fires on the first request that hits it, not at startup. Prefer catching it
+statically.
+
+## 2. Shipping a never-validated graph
+
+`validate()` is the only thing that checks the *whole* graph — cycles, inverted scopes, and missing
+dependencies — before the first request. Skipping it doesn't remove the bugs, it just delays
+finding them to whichever resolve happens to hit one first.
+
+```python
+# ❌ wiring bugs surface one at a time, in production, on whatever request trips them
+container = Container(groups=[Dependencies])
+
+# ✅ every wiring bug in the graph is reported at startup, all at once
+container = Container(groups=[Dependencies], validate=True)
+```
+
+**Caught by:** `validate=True` (or an explicit `container.validate()` call). Note that an
+unvalidated circular graph is *not* a silent hang or a bare traceback anymore: the first resolve
+that overflows the stack is caught and re-raised as `CircularDependencyError` with the cycle path
+attached (see [Circular Dependency Error](../troubleshooting/circular-dependency.md)) — but that
+runtime cycle guard is a backstop for the *one* cycle a particular resolve happened to hit, not a
+substitute for `validate()` finding *every* issue up front. Leaving `validate` unset on a root
+container also emits `UnvalidatedContainerWarning`, since modern-di 3.0 turns validation on by
+default.
+
+## 3. A cached factory resolved before `set_context`
+
+Context values are read live on every resolve of a **non-cached** factory — but a **cached**
+factory is built once, and a later `set_context` does not rebuild it.
+
+```python
+class Dependencies(Group):
+    tenant_id = providers.ContextProvider(scope=Scope.REQUEST, context_type=str)
+
+    # ❌ cached: built on first resolve and frozen from then on
+    tenant_config = providers.Factory(scope=Scope.REQUEST, creator=create_tenant_config, cache=True)
+
+    # ✅ uncached: re-reads the live context on every resolve
+    tenant_config = providers.Factory(scope=Scope.REQUEST, creator=create_tenant_config)
+```
+
+If a request container resolves `tenant_config` before the real tenant ID is known (e.g. during
+setup), the cached version keeps serving that first value for the rest of the request even after
+`request.set_context(str, real_tenant_id)` runs. Either drop `cache=True` for anything whose
+correctness depends on context set later, or make sure `set_context` runs before the first resolve.
+**Caught by:** nothing automatic — this is a timing bug, not a wiring bug, so `validate()` cannot
+see it. See [Context propagation](../providers/context.md#context-propagation) for how `set_context`
+timing interacts with a provider's scope, and [Lifecycle](../providers/lifecycle.md) for caching.
+
+## 4. Service location via `container_provider` overuse
+
+`container_provider` lets a creator accept the resolving `Container` itself and pull dependencies
+out of it manually. Used for its intended purpose (a provider that genuinely needs the container,
+such as building a child container), it's fine. Used as a shortcut to avoid declaring real
+parameters, it turns type-driven DI into a service locator: the dependency is hidden from
+`validate()`, from readers, and from anyone trying to see the graph.
+
+```python
+# ❌ the real dependency (Settings) is invisible to validate() and to the signature
+def create_api_key(container: Container) -> str:
+    return container.resolve(Settings).api_key
+
+# ✅ declared as an ordinary parameter — visible, validated, and testable via override
+def create_api_key(settings: Settings) -> str:
+    return settings.api_key
+```
+
+**Caught by:** nothing enforces this — it's a style discipline, not a validation rule. Reserve
+`container_provider` for cases that are actually about the container (building a child container,
+introspecting the current scope), and declare everything else as a typed parameter so
+`validate()` and [Resolving dependencies](../introduction/resolving.md) can see it.
+
+## 5. Override leaks across tests
+
+`container.override(provider, replacement)` is keyed by provider reference and shared across the
+*whole* container tree. Forgetting to reset it doesn't just affect the test that set it — every
+later test that shares the container inherits the replacement.
+
+```python
+# ❌ no reset: the next test that resolves Clock silently gets the fake
+def test_one() -> None:
+    container.override(Dependencies.clock, fake_clock)
+    ...
+
+# ✅ always reset, even if the test fails — a fixture teardown is the reliable place for this
+@pytest.fixture
+def frozen_clock() -> Mock:
+    fake = Mock(spec=Clock)
+    container.override(Dependencies.clock, fake)
+    yield fake
+    container.reset_override(Dependencies.clock)
+```
+
+**Caught by:** nothing automatic mid-suite — `reset_override()` (or `reset_override()` with no
+arguments, to clear everything) is the fix, and closing the **root** container clears every override
+in the shared registry as a last resort. See
+[Testing with overrides](testing-overrides.md#pitfalls).
+
+## 6. `skip_creator_parsing=True` with no `bound_type`
+
+`skip_creator_parsing=True` turns off signature introspection — useful for callables that can't be
+reflected (C extensions, `functools.partial`). But skipping introspection also means modern-di has
+no idea what type the provider produces, so type-based resolution silently can't find it.
+
+```python
+# ❌ nothing else can resolve this provider by type — UserWarning at declaration time
+providers.Factory(scope=Scope.APP, creator=opaque_creator, skip_creator_parsing=True)
+
+# ✅ tell modern-di the type explicitly
+providers.Factory(
+    scope=Scope.APP,
+    creator=opaque_creator,
+    skip_creator_parsing=True,
+    bound_type=MyClass,
+)
+```
+
+**Caught by:** a `UserWarning` at declaration time. It's easy to miss in test output — treat it as a
+signal to add `bound_type=`, not to ignore.
+
+## See also
+
+- [Errors and exceptions](../providers/errors-and-exceptions.md) — the full catalog this page draws
+  its mechanisms from.
+- [Testing with overrides](testing-overrides.md) — the full override lifecycle.
+- [Lifecycle](../providers/lifecycle.md) — caching, finalizers, and `validate()`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Multi-Group organization: recipes/multi-group.md
       - Testing with overrides: recipes/testing-overrides.md
       - Request-scoped engine selection: recipes/request-scoped-engine.md
+      - Good and bad practices: recipes/good-and-bad-practices.md
   - Testing:
       - Fixtures: testing/fixtures.md
   - Troubleshooting:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
       - Resolving: introduction/resolving.md
       - Design decisions: introduction/design-decisions.md
       - Comparison: introduction/comparison.md
+      - modern-di for FastAPI users: introduction/for-fastapi-users.md
       - that-depends or modern-di?: introduction/that-depends-or-modern-di.md
   - Providers:
       - Scopes: providers/scopes.md

--- a/planning/changes/2026-07-06.04-docs-pages-batch/design.md
+++ b/planning/changes/2026-07-06.04-docs-pages-batch/design.md
@@ -1,0 +1,79 @@
+---
+summary: Docs pages batch — FastAPI-users translation page (DOC-4), cross-framework vocabulary table (DOC-5), anti-patterns catalog (DOC-7), non-goals extension (DOC-9).
+---
+
+# Design: Docs pages batch (DOC-4, DOC-5, DOC-7, DOC-9)
+
+## Summary
+
+Four self-contained page additions from the ruled 2026-07-05 UX-research
+shortlist, batched into one PR (house precedent: the audit fix batches).
+All content claims about other frameworks must be verified against live
+sources at writing time — the per-framework research notes were ephemeral;
+the report (`planning/audits/2026-07-05-v3-ux-research-report.md`) retains
+the citations to start from.
+
+## Design
+
+### DOC-4 — "modern-di for FastAPI users" (`docs/introduction/for-fastapi-users.md`)
+
+Side-by-side translation table: `Depends(fn)` ↔ `Factory(creator=fn)`;
+`use_cache` per-request memo ↔ REQUEST-scope `Factory(cache=True)` (a bare
+Factory = fresh instance per resolve, i.e. `use_cache=False`); yield
+teardown ↔ `cache=CacheSettings(finalizer=...)`; `lru_cache` singleton ↔
+APP-scope `Factory(cache=True)` with finalizer; `app.dependency_overrides` ↔
+`container.override(provider, mock)`. Callout box: since FastAPI 0.121.0,
+`Depends(scope="function"|"request")` means *teardown timing*, while
+modern-di's `Scope` is *lifetime* — same word, different axis (verify the
+0.121 semantics against FastAPI's release notes/docs before quoting). Nav:
+under Introduction, after Comparison.
+
+### DOC-5 — vocabulary table (extend `docs/introduction/comparison.md`)
+
+A "where is Singleton?" translation table appended to the existing
+comparison page (not a new page): rows = singleton · transient ·
+request-scoped · runtime value · interface binding · test override; columns
+= dependency-injector, dishka, wireup, svcs, FastAPI, modern-di. Each
+modern-di cell links to the owning docs page. Every competitor spelling
+verified against that framework's current docs (the report's precedent URLs
+are the starting set). Beware the repo's table rule: a literal `|` inside a
+code span in a Markdown table must be a raw pipe, not `\|` or `&#124;`.
+
+### DOC-7 — anti-patterns page (`docs/recipes/good-and-bad-practices.md`)
+
+5-7 named anti-patterns, each with a bad/good code pair and a link to the
+enforcing mechanism: captive dependency (validate catches); cached factory
+built before `set_context` (stale instance); shipping unvalidated graphs
+(cycle guard is the backstop, `validate=True` the answer); service location
+via `container_provider` overuse; override leaks across tests (root close
+auto-clears; `reset_override()` / the shared registry). Precedents:
+injector's practices page, Microsoft's DI guidelines anti-pattern catalog.
+Nav: Recipes; cross-link from quickstart's "Where to next".
+
+### DOC-9 — non-goals (extend `docs/introduction/design-decisions.md`)
+
+Add the three genuinely missing deliberate omissions, in the page's existing
+what/why/alternative format: auto-binding / auto-registration; in-package
+framework integrations; graph *rendering/visualization* tooling (phrase the
+graphs entry carefully: rendering is out of scope — do not promise the
+accepted-but-unshipped text export). Reference the page from `README.md`
+and `comparison.md` (the repo has no issue templates; the ruling chose
+these two link points instead). Source material: report section 4.
+
+## Non-goals
+
+- No quickstart changes (DOC-2 is its own PR), no migration guide (DOC-3),
+  no build tooling (DOC-8).
+- No new claims about competitor roadmaps; only current, verifiable API
+  spellings with citations checked at writing time.
+
+## Testing
+
+`just docs-build` (strict links/anchors), `just lint-ci`; every
+cross-framework claim carries a source the implementer actually fetched;
+modern-di-side snippets spot-run where runnable.
+
+## Risk
+
+Stale competitor claims (medium/medium) — mitigated by the live-verification
+requirement; a reviewer re-checks a sample of claims independently.

--- a/planning/changes/2026-07-06.04-docs-pages-batch/plan.md
+++ b/planning/changes/2026-07-06.04-docs-pages-batch/plan.md
@@ -1,0 +1,30 @@
+# docs-pages-batch — implementation plan
+
+**Goal:** Ship DOC-4, DOC-5, DOC-7, DOC-9 as one docs PR.
+**Spec:** [`design.md`](./design.md)
+**Branch:** `docs/pages-batch`
+**Commit strategy:** one commit per DOC item (4 commits).
+
+### Task 1: DOC-5 vocabulary table (comparison.md)
+- [ ] Verify each competitor spelling against its live docs (start from the
+      report's citations); build the 6×6 table; raw pipes in code spans.
+- [ ] Commit: `docs: add cross-framework lifetime vocabulary table (DOC-5)`
+
+### Task 2: DOC-4 for-fastapi-users page
+- [ ] Verify FastAPI Depends semantics (use_cache, yield, 0.121 scope=)
+      against live FastAPI docs; write the page + nav entry.
+- [ ] Commit: `docs: add "modern-di for FastAPI users" page (DOC-4)`
+
+### Task 3: DOC-7 anti-patterns page
+- [ ] Write 5-7 anti-patterns with bad/good pairs; verify each footgun
+      against current source behavior (post ERR-1/ERR-3 the cycle framing
+      changed); nav entry + quickstart cross-link.
+- [ ] Commit: `docs: add good-and-bad-practices anti-pattern catalog (DOC-7)`
+
+### Task 4: DOC-9 non-goals + links
+- [ ] Extend design-decisions.md (three omissions, existing format);
+      reference from README.md and comparison.md.
+- [ ] Commit: `docs: document remaining deliberate non-goals (DOC-9)`
+
+### Gates (after each task and at the end)
+- [ ] `just docs-build`, `just lint-ci`, `just check-planning`.


### PR DESCRIPTION
Four ruled shortlist items in one batch (house precedent #213); bundle planning/changes/2026-07-06.04-docs-pages-batch/.

- **DOC-5**: cross-framework lifetime vocabulary table appended to comparison.md (dependency-injector / dishka / wireup / svcs / FastAPI / modern-di; each modern-di cell links to the owning page).
- **DOC-4**: new introduction/for-fastapi-users.md — Depends-to-modern-di translation table plus the terminology callout (FastAPI 0.121's scope= is teardown timing; modern-di's Scope is lifetime).
- **DOC-7**: new recipes/good-and-bad-practices.md — anti-pattern catalog with bad/good pairs grounded in current behavior (post cycle-guard and scope-chain changes), cross-linked from the quickstart.
- **DOC-9**: design-decisions.md gains the three missing deliberate non-goals (auto-binding, in-package integrations, graph rendering), referenced from README and comparison.md.

Accuracy protocol: 17 competitor claims verified against live docs at writing time (1 unverifiable claim dropped rather than asserted); review independently re-verified 9 of them including the FastAPI semantics — all matched. One review fix applied: the graph non-goal was narrowed to rendering-only so the page doesn't contradict the accepted-but-unshipped ERR-7 text export.

Reviewer note for conscious sign-off: good-and-bad-practices.md uses numbered catalog sections rather than the Recipes section's Problem/Solution shape — deliberate for a catalog page, flag if you'd rather it match.

Gates: docs-build --strict, lint-ci, check-planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)