### PR TITLE
docs: progressive-disclosure quickstart — first success in two concepts (DOC-2)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,12 +49,16 @@ For end-to-end patterns drawn from real services, see the [Recipes](recipes/sqla
 
 If you want a framework integration, install the matching adapter — e.g. `modern-di-aiohttp`, `modern-di-fastapi`, `modern-di-litestar`, `modern-di-faststream`, `modern-di-starlette`, `modern-di-typer`. For pytest support, install `modern-di-pytest`.
 
-## 2. Describe your dependencies
+## 2. First success
 
-Two providers, two scopes: a `Settings` shared by the whole process, and a `UserRepository` rebuilt per request.
+One provider, no scopes, no caching — the smallest honest example. A `Group` is a namespace that
+lists your providers; `Factory` defaults to `scope=Scope.APP`; `Container.resolve` looks a value up
+by its type.
 
 ```python
 import dataclasses
+
+from modern_di import Container, Group, providers
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
@@ -62,78 +66,119 @@ class Settings:
     database_url: str = "postgresql+asyncpg://localhost/app"
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
-class UserRepository:
-    settings: Settings    # auto-injected by type
+class Dependencies(Group):
+    settings = providers.Factory(creator=Settings)
 
-    def find(self, user_id: int) -> dict[str, int]:
-        return {"id": user_id}
+
+# Pass validate=True to detect cycles and scope-chain errors at startup
+container = Container(groups=[Dependencies], validate=True)
+settings = container.resolve(Settings)
+print(settings.database_url)
 ```
 
-## 3. Declare a Group
+Without `cache=`, `Factory` calls the creator on every resolve — fine for cheap, stateless objects,
+but not what you want for a database engine you only want to build once.
 
-A `Group` is a namespace that lists your providers. You instantiate a `Container` from it; the `Group` itself is schema only.
+## 3. Create once, reuse
+
+Add `cache=True` (via `CacheSettings`, which also lets you attach a finalizer) to turn `settings`
+into a singleton, and switch to the `with` form so the finalizer runs when the container closes.
 
 ```python
-from modern_di import Group, Scope, providers
+import dataclasses
+
+from modern_di import Container, Group, providers
+
+
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class Settings:
+    database_url: str = "postgresql+asyncpg://localhost/app"
+
+
+def close_settings(settings: Settings) -> None:
+    print(f"closing settings ({id(settings)})")
 
 
 class Dependencies(Group):
     settings = providers.Factory(
-        scope=Scope.APP,                          # APP is the default
         creator=Settings,
-        cache=True,  # cache the singleton for the whole app
+        cache=providers.CacheSettings(finalizer=close_settings),
     )
 
-    user_repository = providers.Factory(
-        scope=Scope.REQUEST,                       # rebuilt for each request
-        creator=UserRepository,
-    )
+
+with Container(groups=[Dependencies], validate=True) as container:
+    first = container.resolve(Settings)
+    second = container.resolve(Settings)
+    assert first is second  # same instance, cached on first resolve
+# `close_settings` ran here, on `with` exit
 ```
 
-## 4. Wire it up
+## 4. Request scope
 
-Pick **one** of the two mutually-exclusive options below.
-
-### Option A — integrate with your framework
-
-Pick the integration you need:
-
-- [aiohttp](integrations/aiohttp.md)
-- [FastAPI](integrations/fastapi.md)
-- [FastStream](integrations/faststream.md)
-- [Litestar](integrations/litestar.md)
-- [Starlette](integrations/starlette.md)
-- [Typer](integrations/typer.md)
-- [Pytest](integrations/pytest.md)
-
-The integration package builds the per-request child container automatically and closes the APP container at shutdown.
-
-### Option B — use modern-di directly
+Real apps also need state that lives for one request: a `UserRepository` rebuilt per request, fed
+by a `RequestId` supplied at request time via `ContextProvider`. Build a `Scope.REQUEST` child
+container with `build_child_container(scope=..., context={...})`; it can still resolve the
+APP-scoped `Settings` through the parent.
 
 ```python
-from modern_di import Container, Scope
+import dataclasses
+
+from modern_di import Container, Group, Scope, providers
 
 
-# Pass validate=True to detect cycles and scope-chain errors at startup
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class Settings:
+    database_url: str = "postgresql+asyncpg://localhost/app"
+
+
+def close_settings(settings: Settings) -> None:
+    print(f"closing settings ({id(settings)})")
+
+
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class RequestId:
+    value: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class UserRepository:
+    settings: Settings       # auto-injected by type, resolved through the request container
+    request_id: RequestId    # supplied via context, one value per request
+
+    def find(self, user_id: int) -> dict[str, object]:
+        return {"id": user_id, "request_id": self.request_id.value}
+
+
+class Dependencies(Group):
+    settings = providers.Factory(
+        creator=Settings,
+        cache=providers.CacheSettings(finalizer=close_settings),
+    )
+    request_id = providers.ContextProvider(scope=Scope.REQUEST, context_type=RequestId)
+    user_repository = providers.Factory(scope=Scope.REQUEST, creator=UserRepository)
+
+
 with Container(groups=[Dependencies], validate=True) as container:
-    # APP-scoped providers resolve straight from the container
-    settings = container.resolve(Settings)
-
-    # REQUEST-scoped providers need a REQUEST child container
-    with container.build_child_container(scope=Scope.REQUEST) as request:
+    request_context = {RequestId: RequestId(value="req-1")}
+    with container.build_child_container(scope=Scope.REQUEST, context=request_context) as request:
         repo = request.resolve(UserRepository)
         user = repo.find(42)
-
-    # Request-scope finalizers (teardown hooks such as closing a DB connection) ran on `with` exit
-# App-scope finalizers ran on the outer `with` exit
+    # REQUEST-scope finalizers ran here (none declared in this example)
+# APP-scope finalizers ran here (closes settings)
 ```
 
-Resolution is always synchronous. Use `async with` (on both the container and the child) only when a
-provider registers an **async** finalizer — see [Lifecycle](providers/lifecycle.md).
+A framework integration (linked under "Where to next" below) builds and tears down this REQUEST
+child container for you automatically. Resolution itself is always synchronous; use `async with`
+instead of `with` only when a provider registers an **async** finalizer — see
+[Lifecycle](providers/lifecycle.md).
 
 ## Where to next
 
+- Framework integrations — [aiohttp](integrations/aiohttp.md), [FastAPI](integrations/fastapi.md),
+  [FastStream](integrations/faststream.md), [Litestar](integrations/litestar.md),
+  [Starlette](integrations/starlette.md), [Typer](integrations/typer.md),
+  [Pytest](integrations/pytest.md) — each builds the per-request child container automatically and
+  closes the APP container at shutdown.
 - [Resolving](introduction/resolving.md) — how type-based auto-injection works.
 - [Factories](providers/factories.md) — the provider you just used.
 - [Scopes](providers/scopes.md) — the APP → REQUEST lifetime model in one page.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,8 +52,7 @@ If you want a framework integration, install the matching adapter — e.g. `mode
 ## 2. First success
 
 One provider, no scopes, no caching — the smallest honest example. A `Group` is a namespace that
-lists your providers; `Factory` defaults to `scope=Scope.APP`; `Container.resolve` looks a value up
-by its type.
+lists your providers; `Container.resolve` looks a value up by its type.
 
 ```python
 import dataclasses
@@ -109,7 +108,7 @@ class Dependencies(Group):
 with Container(groups=[Dependencies], validate=True) as container:
     first = container.resolve(Settings)
     second = container.resolve(Settings)
-    assert first is second  # same instance, cached on first resolve
+    print(id(first), id(second), first is second)  # same instance, cached on first resolve
 # `close_settings` ran here, on `with` exit
 ```
 
@@ -163,14 +162,15 @@ with Container(groups=[Dependencies], validate=True) as container:
     with container.build_child_container(scope=Scope.REQUEST, context=request_context) as request:
         repo = request.resolve(UserRepository)
         user = repo.find(42)
+        print(user)
     # REQUEST-scope finalizers ran here (none declared in this example)
 # APP-scope finalizers ran here (closes settings)
 ```
 
 A framework integration (linked under "Where to next" below) builds and tears down this REQUEST
 child container for you automatically. Resolution itself is always synchronous; use `async with`
-instead of `with` only when a provider registers an **async** finalizer — see
-[Lifecycle](providers/lifecycle.md).
+(on both the container and the child) instead of `with` only when a provider registers an
+**async** finalizer — see [Lifecycle](providers/lifecycle.md).
 
 ## Where to next
 

--- a/planning/changes/2026-07-06.05-quickstart-ramp/design.md
+++ b/planning/changes/2026-07-06.05-quickstart-ramp/design.md
@@ -1,0 +1,57 @@
+---
+summary: Progressive-disclosure quickstart (DOC-2) — first success with Group + Factory + resolve, cache/finalizer as lesson two, scopes as lesson three.
+---
+
+# Design: Progressive-disclosure quickstart
+
+## Summary
+
+Implements shortlist ruling DOC-2 (2026-07-05 UX research). `docs/index.md`
+front-loads two scopes, `cache=True`, and `build_child_container` in the very
+first example — 5-6 concepts before first resolve, versus 2 for svcs/FastAPI
+and 4 for wireup (verified in the research). Nothing beyond Group + Factory +
+`resolve` is needed for an honest first success (Factory defaults to
+`scope=Scope.APP`). Restructure the ramp; no API changes; precedent: FastAPI's
+dependencies tutorial escalation, Angular's essentials/deep-guide split.
+
+## Design
+
+Target shape for `docs/index.md` (keep the existing hero/badges/install and
+the "Where to next" links, which now include the anti-patterns page):
+
+1. **Step A — first success (~10 lines):** one `Group`, one plain `Factory`,
+   `Container(groups=[...], validate=True)` (explicit `validate=` is the
+   house spelling since the 2.24.0 sweep), `container.resolve(T)`. No scopes,
+   no caching, no child containers mentioned yet.
+2. **Step B — create once, reuse (singleton):** add `cache=True` and a
+   finalizer; make identity observable (MEDI GUID-style: print/compare
+   `id(...)` across two resolves, then show the finalizer running on close
+   via the `with` form).
+3. **Step C — request scope:** introduce `Scope.REQUEST`,
+   `build_child_container(scope=..., context={...})`, and one context-typed
+   dependency — the smallest honest request-boundary example.
+4. Close with "Where to next" (Providers pages own the deep material).
+
+Rules:
+- Each step builds on the previous snippet with minimal diff noise; a
+  first-time reader must never meet a concept before the step that teaches it.
+- Content currently on index.md that exists nowhere else must be relocated
+  (to the owning Providers/Recipes page), not deleted; content duplicated
+  elsewhere may be dropped from index.md.
+- Every snippet runnable as written (spot-run each step).
+
+## Non-goals
+
+- No changes to other pages beyond relocation targets; no nav changes; no
+  API or code changes.
+
+## Testing
+
+Spot-run all three step snippets as scripts; `just docs-build` (strict);
+`just lint-ci`. Review reads the page as a first-time user (the docs-ux
+audit's onboarding lens) and checks the concept-before-use rule.
+
+## Risk
+
+Losing content in the restructure (medium/low): mitigated by the
+relocate-don't-delete rule and a reviewer diff pass over removed blocks.

--- a/planning/changes/2026-07-06.05-quickstart-ramp/design.md
+++ b/planning/changes/2026-07-06.05-quickstart-ramp/design.md
@@ -1,5 +1,5 @@
 ---
-summary: Progressive-disclosure quickstart (DOC-2) — first success with Group + Factory + resolve, cache/finalizer as lesson two, scopes as lesson three.
+summary: Shipped DOC-2 — quickstart teaches Group + Factory + resolve first (2 concepts, was ~5), caching then scopes as lessons two and three.
 ---
 
 # Design: Progressive-disclosure quickstart

--- a/planning/changes/2026-07-06.05-quickstart-ramp/plan.md
+++ b/planning/changes/2026-07-06.05-quickstart-ramp/plan.md
@@ -1,0 +1,15 @@
+# quickstart-ramp — implementation plan
+
+**Goal:** docs/index.md teaches Group + Factory + resolve first; caching and scopes are lessons two and three.
+**Spec:** [`design.md`](./design.md)
+**Branch:** `docs/quickstart-ramp`
+**Commit strategy:** single commit (plus relocations if any, same commit).
+
+### Task 1: Restructure the ramp
+- [ ] Inventory docs/index.md: mark each block keep / restructure / relocate
+      (unique content) / drop (duplicated elsewhere — name where).
+- [ ] Write steps A/B/C per the design's target shape; spot-run each snippet
+      as a throwaway scratchpad script.
+- [ ] Apply relocations; keep "Where to next" current.
+- [ ] Gates: `just docs-build`, `just lint-ci`.
+- [ ] Commit: `docs: progressive-disclosure quickstart — first success in three concepts (DOC-2)`


### PR DESCRIPTION
Shortlist ruling DOC-2; bundle planning/changes/2026-07-06.05-quickstart-ramp/.

docs/index.md previously front-loaded ~5 concepts (Group, Factory, two scopes, cache=True) before the first resolve. The new ramp: Step 2 "First success" = Group + Factory + resolve (2 concepts, ~10 lines, validate=True house spelling); Step 3 = create-once/reuse with an observable id() identity demo and finalizer-on-close; Step 4 = request scope with build_child_container + ContextProvider. Deep material stays on the Providers pages; framework-integration links moved into "Where to next" (now also linking the new anti-patterns page). No content lost — reviewer verified every dropped block against the old page.

Review loop: the first pass caught stale spot-run evidence (outputs from an earlier draft) plus a silent assert where the design demanded an observable demo, and Scope.APP named in prose before being taught — all fixed; the re-reviewer re-extracted the shipped snippets byte-for-byte and ran them to confirm.

Gates: docs-build --strict, lint-ci, check-planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)