### PR TITLE
docs: publish llms.txt + per-page markdown endpoints (DOC-8)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs>=1.6,<2
 mkdocs-material>=9,<10
+mkdocs-llmstxt>=0.5,<0.6

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,62 @@ extra_css:
   - css/code.css
   - css/brand.css
 
+plugins:
+  - llmstxt:
+      full_output: llms-full.txt
+      markdown_description: "Powerful dependency-injection framework with IoC container and scopes."
+      sections:
+        Quickstart:
+          - index.md: How to install and a minimal container example
+        Introduction:
+          - introduction/about-di.md: What dependency injection is and the problem it solves
+          - introduction/resolving.md: Resolving dependencies by type or by provider reference
+          - introduction/design-decisions.md: The deliberate API choices behind modern-di
+          - introduction/comparison.md: How modern-di compares to other DI approaches
+          - introduction/for-fastapi-users.md: Translating FastAPI's Depends idioms to modern-di
+          - introduction/that-depends-or-modern-di.md: Choosing between that-depends and modern-di
+        Providers:
+          - providers/scopes.md: The five built-in scopes and the resolution rule
+          - providers/lifecycle.md: How instances are created, cached, and cleaned up
+          - providers/factories.md: Regular vs cached Factory providers
+          - providers/context.md: Injecting runtime context values with ContextProvider
+          - providers/container.md: The auto-registered provider that resolves to the Container itself
+          - providers/alias.md: Binding one type to an already-registered provider
+          - providers/errors-and-exceptions.md: The ModernDIError exception hierarchy
+          - providers/advanced-api.md: Low-level extension points for library authors
+        Integrations:
+          - integrations/aiohttp.md: Usage with aiohttp
+          - integrations/fastapi.md: Usage with FastAPI
+          - integrations/faststream.md: Usage with FastStream
+          - integrations/litestar.md: Usage with Litestar
+          - integrations/starlette.md: Usage with Starlette
+          - integrations/typer.md: Usage with Typer
+          - integrations/pytest.md: Usage with pytest via modern-di-pytest
+          - integrations/writing-integrations.md: Specification for building a new framework integration
+        Recipes:
+          - recipes/sqlalchemy.md: Wiring an async SQLAlchemy engine, session, and repositories
+          - recipes/async-lifespan.md: Constructing async resources via the framework lifespan
+          - recipes/multi-group.md: Organizing a large container with multiple Groups
+          - recipes/testing-overrides.md: Swapping dependencies in tests with overrides
+          - recipes/request-scoped-engine.md: Routing requests to different engines by scope
+          - recipes/good-and-bad-practices.md: Common DI footguns and how modern-di catches them
+        Testing:
+          - testing/fixtures.md: Wiring modern-di into pytest, with and without modern-di-pytest
+        Troubleshooting:
+          - troubleshooting/circular-dependency.md: Diagnosing circular dependency errors
+          - troubleshooting/duplicate-type-error.md: Diagnosing duplicate bound_type registration errors
+          - troubleshooting/scope-chain.md: Diagnosing scope chain violation errors
+          - troubleshooting/missing-provider.md: Diagnosing missing provider registration errors
+          - troubleshooting/context-not-set.md: Diagnosing ContextProvider-has-no-value errors
+        Migration:
+          - migration/to-1.x.md: Migrating from modern-di 0.x to 1.x
+          - migration/to-2.x.md: Migrating from modern-di 1.x to 2.x
+          - migration/to-3.x.md: Migrating from modern-di 2.x to 3.x
+          - migration/from-that-depends.md: Migrating an existing that-depends codebase to modern-di
+          - migration/from-dependency-injector.md: Migrating an existing dependency-injector codebase to modern-di
+        Development:
+          - dev/contributing.md: Contributing guide for local setup and workflow
+
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/planning/changes/2026-07-06.07-llms-txt/design.md
+++ b/planning/changes/2026-07-06.07-llms-txt/design.md
@@ -1,5 +1,5 @@
 ---
-summary: Publish llms.txt (and per-page markdown endpoints) for the docs site (DOC-8), mirroring the that-depends setup.
+summary: Published llms.txt + per-page markdown endpoints via mkdocs-llmstxt (DOC-8), mirroring that-depends' plugin/config with sections adapted to this repo's nav.
 ---
 
 # Design: llms.txt for the docs site

--- a/planning/changes/2026-07-06.07-llms-txt/design.md
+++ b/planning/changes/2026-07-06.07-llms-txt/design.md
@@ -1,0 +1,47 @@
+---
+summary: Publish llms.txt (and per-page markdown endpoints) for the docs site (DOC-8), mirroring the that-depends setup.
+---
+
+# Design: llms.txt for the docs site
+
+## Summary
+
+Implements shortlist ruling DOC-8 (2026-07-05 UX research). AI assistants are
+a primary onboarding channel; the site ships `docs/context7.json` but
+`https://modern-di.modern-python.org/llms.txt` 404s, so agents scrape mkdocs
+HTML. Sibling project that-depends (same org) already serves
+`https://that-depends.modern-python.org/llms.txt` plus per-page markdown
+endpoints — mirror its setup rather than inventing one.
+
+## Design
+
+- **Follow that-depends exactly**: fetch its live `mkdocs.yml` and docs
+  requirements from GitHub (`modern-python/that-depends`) and adopt the same
+  plugin and configuration (expected: an mkdocs llms.txt plugin emitting the
+  nav tree with page summaries and raw-markdown endpoints). Deviate only
+  where this repo's nav demands it, and record any deviation.
+- Docs tooling only: the plugin goes in `docs/requirements.txt` (the docs
+  build runs via `uvx --with-requirements docs/requirements.txt`, so the
+  published library keeps zero dependencies); config in `mkdocs.yml`.
+- No Justfile/CI changes expected: `just docs-build` and the Deploy Docs
+  workflow already build via the same requirements file. Verify the built
+  `site/` contains `llms.txt` (and the per-page endpoints) under
+  `mkdocs build --strict`.
+- Pin the plugin version in `docs/requirements.txt` (the file's existing
+  style governs).
+
+## Non-goals
+
+- No changes to `docs/context7.json`; no content edits; no README section
+  about llms.txt (can ride a later docs pass if wanted).
+
+## Testing
+
+`just docs-build` (strict) then assert `site/llms.txt` exists and sanity-read
+it (nav coverage, no broken relative links inside); spot-check one per-page
+markdown endpoint file in `site/`; `just lint-ci`.
+
+## Risk
+
+Plugin/theme incompatibility (low/low): the same org runs the identical stack
+(mkdocs Material) with this plugin in production.

--- a/planning/changes/2026-07-06.07-llms-txt/plan.md
+++ b/planning/changes/2026-07-06.07-llms-txt/plan.md
@@ -6,10 +6,10 @@
 **Commit strategy:** single commit.
 
 ### Task 1: Mirror the that-depends setup
-- [ ] Fetch that-depends' live mkdocs.yml + docs requirements (GitHub raw);
+- [x] Fetch that-depends' live mkdocs.yml + docs requirements (GitHub raw);
       identify the plugin + config it uses for llms.txt.
-- [ ] Add the pinned plugin to docs/requirements.txt; add the mkdocs.yml
+- [x] Add the pinned plugin to docs/requirements.txt; add the mkdocs.yml
       plugin config adapted to this repo's nav.
-- [ ] `just docs-build` (strict); assert site/llms.txt exists and covers the
+- [x] `just docs-build` (strict); assert site/llms.txt exists and covers the
       nav; spot-check a per-page markdown endpoint; `just lint-ci`.
-- [ ] Commit: `docs: publish llms.txt + per-page markdown endpoints (DOC-8)`
+- [x] Commit: `docs: publish llms.txt + per-page markdown endpoints (DOC-8)`

--- a/planning/changes/2026-07-06.07-llms-txt/plan.md
+++ b/planning/changes/2026-07-06.07-llms-txt/plan.md
@@ -1,0 +1,15 @@
+# llms-txt — implementation plan
+
+**Goal:** The built docs site serves llms.txt and per-page markdown endpoints.
+**Spec:** [`design.md`](./design.md)
+**Branch:** `docs/llms-txt`
+**Commit strategy:** single commit.
+
+### Task 1: Mirror the that-depends setup
+- [ ] Fetch that-depends' live mkdocs.yml + docs requirements (GitHub raw);
+      identify the plugin + config it uses for llms.txt.
+- [ ] Add the pinned plugin to docs/requirements.txt; add the mkdocs.yml
+      plugin config adapted to this repo's nav.
+- [ ] `just docs-build` (strict); assert site/llms.txt exists and covers the
+      nav; spot-check a per-page markdown endpoint; `just lint-ci`.
+- [ ] Commit: `docs: publish llms.txt + per-page markdown endpoints (DOC-8)`


### PR DESCRIPTION
Shortlist ruling DOC-8; bundle planning/changes/2026-07-06.07-llms-txt/.

Adds mkdocs-llmstxt (docs/requirements.txt only — the library stays zero-dependency) with configuration mirroring that-depends' production setup: /llms.txt index (all 41 nav pages, verified one-to-one including this week's four new pages), /llms-full.txt, and genuine per-page markdown endpoints (review verified against the plugin's docs that these are plugin-generated, not a mkdocs directory-URL artifact). No Justfile/CI changes — the existing docs build and Deploy Docs workflow pick it up automatically.

One judgment call for explicit ratification: the plugin is pinned `>=0.5,<0.6` (next-minor ceiling, since it's pre-1.0 where minors may break) while the file's two existing pins ceiling at the next major. Say the word if you'd rather have `<1`.

Gates: docs-build --strict, lint-ci, check-planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)