### PR TITLE
docs: docstring policy pass over modern_di

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,7 @@ is quick orientation; `architecture/` holds the authoritative account.
 - `ruff` with `select = ["ALL"]` and minimal ignores; `ty` for type checking
 - Coverage excludes `TYPE_CHECKING` blocks
 - Design principle: conservative feature set; **resolution** is sync-only (async resolution was removed in 2.x), though **finalizers** may still be sync or async (`close_sync`/`close_async`); no global state
+- Docstrings: public API documents the contract; internal helpers get a
+  one-line contract, plus at most 1–2 lines for a genuinely non-obvious
+  constraint. Never narrate implementation or justify code to a reviewer —
+  cross-file rationale lives in `architecture/`.

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -23,9 +23,7 @@ def _find_reachable_cycle(start: AbstractProvider[typing.Any], container: "Conta
 
     Explicit-stack DFS — no recursion, since this runs inside a ``RecursionError`` handler
     near CPython's stack limit (headroom for a recursive walk is not guaranteed there).
-    Mirrors ``Container.validate()``'s own cycle detection (`visiting`/`visited`/`path`, see
-    `validate` below): on a back-edge, renders the cycle as `display_name`s with the first
-    name repeated at the end. Returns `None` if no static cycle is reachable from `start`.
+    Returns `None` if no static cycle is reachable from `start`.
     """
     visiting: set[int] = {start.provider_id}
     visited: set[int] = set()
@@ -62,10 +60,8 @@ def _convert_recursion_error(
 ) -> typing.NoReturn:
     """Convert an escaped `RecursionError` to `CircularDependencyError`, or re-raise it unchanged.
 
-    Split out of `resolve_provider` into its own call: CPython suspends trace-function calls for
-    a few frames while unwinding a `RecursionError`, which (under coverage.py) can under-report
-    lines executed directly inside the `except` block; giving the tracer a fresh call boundary
-    to re-arm on before raising avoids that — a coverage-measurement concern, not a behavior one.
+    Split out of `resolve_provider` into its own call so the coverage tracer gets a fresh call
+    boundary to re-arm on before raising.
     """
     cycle = _find_reachable_cycle(provider, container)
     if cycle is None:
@@ -106,14 +102,12 @@ class Container:
         """Build a container at ``scope``.
 
         ``validate=True`` checks the provider graph (cycles plus scope ordering)
-        at construction time. ``validate=False`` skips the check silently.
+        at construction time; ``validate=False`` skips the check silently.
         Leaving ``validate`` unset (``None``, the default) skips the check but
         warns with :class:`~modern_di.exceptions.UnvalidatedContainerWarning` on
-        a root container — modern-di 3.0 will run ``validate()`` by default;
-        pass ``validate=True`` to adopt that now or ``validate=False`` to opt
-        out silently. Child containers (with ``parent_container`` set) never
-        warn regardless. ``context`` seeds this container's context registry.
-        A root container owns fresh registries; a child shares the parent's
+        a root container; child containers (with ``parent_container`` set) never
+        warn. ``context`` seeds this container's context registry. A root
+        container owns fresh registries; a child shares the parent's
         providers/overrides registries and inherits its scope map.
         """
         if not isinstance(scope, enum.IntEnum):
@@ -221,17 +215,7 @@ class Container:
         return self.resolve_provider(provider)
 
     def resolve_provider(self, provider: "AbstractProvider[types.T]") -> types.T:
-        """Resolve a specific provider by reference (enforces closed-state and applies overrides).
-
-        An unvalidated circular graph would otherwise die with a raw ``RecursionError`` on first
-        resolve; when one escapes ``provider.resolve``, this re-walks the static graph from
-        `provider` (iteratively — see `_find_reachable_cycle`) and, if a cycle is reachable,
-        raises `exceptions.CircularDependencyError` from it instead. A `RecursionError` from a
-        creator recursing on its own (no static cycle) is re-raised untouched. `resolve_provider`
-        is re-entrant (`Factory`/`Alias` call it per dependency edge), so it is the innermost frame
-        that converts; outer frames see a `ResolutionError` and the existing breadcrumb machinery
-        prepends steps as it propagates back up.
-        """
+        """Resolve a specific provider by reference (enforces closed-state and applies overrides)."""
         self._warn_and_reopen_if_closed()
 
         if (
@@ -320,18 +304,10 @@ class Container:
     def set_context(self, context_type: type[types.T], obj: types.T) -> None:
         """Register a runtime context value on *this* container.
 
-        A ``ContextProvider`` reads the context registry of the container at the
-        provider's own scope — context never propagates between parent and child
-        containers. Set the value on the container whose scope matches the
-        ``ContextProvider`` (for request-scoped context, pass ``context={...}``
-        to :meth:`build_child_container` or call ``set_context`` on the request
-        container).
-
-        Context values are resolved live, so a value set here is picked up by
-        subsequent resolves of **non-cached** providers — including factories in
-        deeper-scoped child containers that read this container's context. A
-        **cached** provider (``Factory(cache=...)``) is built once and
-        its instance is *not* rebuilt by a later ``set_context``; set the context
+        Context never propagates between parent and child containers — set it
+        on the container whose scope matches the ``ContextProvider``. A
+        **cached** provider (``Factory(cache=...)``) is built once and its
+        instance is *not* rebuilt by a later ``set_context``; set the context
         before its first resolve.
         """
         self.context_registry.set_context(context_type, obj)
@@ -355,13 +331,9 @@ class Container:
     def _warn_and_reopen_if_closed(self) -> None:
         """Transitional shim for reuse of a closed container.
 
-        Emits :class:`~modern_di.exceptions.ContainerClosedWarning` and reopens
-        (so pre-2.16 "close then resolve" code keeps working); modern-di 3.0
-        will raise :class:`~modern_di.exceptions.ContainerClosedError` here
-        instead. The warning fires once per container transitioning from closed
-        to reopened — a single resolve that crosses several distinct closed
-        containers (e.g. a closed ancestor scope) emits one warning per closed
-        container it reopens; an already-open container emits none.
+        Emits :class:`~modern_di.exceptions.ContainerClosedWarning` and reopens.
+        Fires once per container transitioning from closed to reopened; an
+        already-open container emits none.
         """
         if not self.closed:
             return

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -38,12 +38,9 @@ class DependencyPathMixin:
     caller. With an empty `dependency_path` (the error never passed through a resolution frame)
     `__str__` returns the base message unchanged.
 
-    Not itself an exception: it is not catchable via `except DependencyPathMixin` and is not
-    exported. Plain-`object` with empty `__slots__` so it never contributes instance layout of
-    its own — each concrete error (`ResolutionError`, `ScopeNotInitializedError`,
-    `ScopeSkippedError`) declares the `_base_message`/`dependency_path` slots itself alongside
-    its own attrs, avoiding the `TypeError: multiple bases have instance lay-out conflict` that
-    combining a slotted mixin with an `Exception` subclass would otherwise raise.
+    Empty `__slots__`: each concrete error declares the `_base_message`/`dependency_path` slots
+    itself, avoiding the `TypeError: multiple bases have instance lay-out conflict` that a slotted
+    mixin combined with an `Exception` subclass would otherwise raise.
     """
 
     __slots__ = ()
@@ -384,7 +381,6 @@ class UnknownFactoryKwargError(RegistrationError):
                 line += f" (did you mean {sug!r}?)"
             parts.append(line)
         parts.append(f"Known parameters: {known_keys}")
-        # message built dynamically; not templated
         super().__init__("\n".join(parts))
 
 
@@ -434,7 +430,6 @@ class ValidationFailedError(ContainerError):
     def __init__(self, *, errors: list[Exception]) -> None:
         self.errors = errors
         kinds = ", ".join(sorted({type(e).__name__ for e in errors}))
-        # message built dynamically; not templated
         super().__init__(f"Container.validate() found {len(errors)} issue(s): {kinds}")
 
     def __str__(self) -> str:
@@ -461,7 +456,6 @@ class FinalizerError(ModernDIError):
         self.finalizer_errors = finalizer_errors
         self.is_async = is_async
         kind = "async" if is_async else "sync"
-        # message built dynamically; not templated
         super().__init__(f"Errors during {kind} cleanup: {finalizer_errors}")
 
 

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -17,9 +17,8 @@ class ContextProvider(AbstractProvider[types.T_co]):
     The value is passed via ``build_child_container(context={SomeType: value})``
     and looked up from the context registry at this provider's bound scope.
     Resolving it directly when no value is set emits :class:`~modern_di.exceptions.ContextValueNoneWarning`
-    and returns ``None`` (modern-di 3.0 raises :class:`~modern_di.exceptions.ContextValueNotSetError` instead);
-    injecting it into a non-nullable, no-default ``Factory`` parameter instead raises
-    ``ArgumentResolutionError``.
+    and returns ``None``; injecting it into a non-nullable, no-default ``Factory``
+    parameter instead raises ``ArgumentResolutionError``.
     """
 
     __slots__ = ("context_type",)
@@ -34,8 +33,6 @@ class ContextProvider(AbstractProvider[types.T_co]):
         super().__init__(
             scope=scope, bound_type=context_type if isinstance(bound_type, types.UnsetType) else bound_type
         )
-        # Public, like its sibling ``bound_type`` — the type this provider supplies and
-        # the key its value is set under in ``context``.
         self.context_type = context_type
 
     def __repr__(self) -> str:

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -137,9 +137,7 @@ class Factory(AbstractProvider[types.T_co]):
     def _argument_resolution_error(
         self, *, arg_name: str, item: SignatureItem, registry: "ProvidersRegistry | None" = None
     ) -> exceptions.ArgumentResolutionError:
-        # The single error-construction site: build the message and (when a registry is given and the
-        # argument has a resolvable type) the closest-match suggestions. The context path passes no
-        # registry, so absent-context errors carry no suggestions — as before.
+        # The context path passes no registry, so absent-context errors carry no suggestions.
         suggestions = (
             registry.build_suggestions(item.arg_type) if registry is not None and item.arg_type is not None else []
         )
@@ -152,10 +150,8 @@ class Factory(AbstractProvider[types.T_co]):
         )
 
     def _ensure_plan(self, container: "Container", cache_item: "CacheItem") -> WiringPlan:
-        # Plan runs outside the container lock (the lock guards only singleton creation).
-        # Under the GIL this is safe: the plan is a deterministic function of the fixed providers
-        # registry, so concurrent builds produce identical results and at worst recompute once.
-        # (Free-threaded/nogil caveat tracked in planning/deferred.md.)
+        # Plan runs outside the container lock — safe under the GIL since it's a deterministic
+        # function of the fixed providers registry (free-threaded/nogil caveat: planning/deferred.md).
         if cache_item.wiring_plan is None:
             cache_item.wiring_plan = WiringPlan.build(
                 parsed_kwargs=self._parsed_kwargs,
@@ -170,9 +166,8 @@ class Factory(AbstractProvider[types.T_co]):
     ) -> typing.Any:  # noqa: ANN401
         """Resolve a context-backed parameter live. Returns ``types.UNSET`` to omit the kwarg.
 
-        Mirrors ``Container.resolve_provider``'s override handling, then reads the live context
-        value; an absent value falls back to the creator default (omit), ``None`` (nullable),
-        or raises ``ArgumentResolutionError`` (required).
+        Absent value falls back to the creator default (omit), ``None`` (nullable), or raises
+        ``ArgumentResolutionError`` (required).
         """
         if container.overrides_registry.overrides:
             override = container.overrides_registry.fetch_override(provider.provider_id)
@@ -216,10 +211,8 @@ class Factory(AbstractProvider[types.T_co]):
         try:
             return self._creator(**resolved_kwargs)
         except TypeError as exc:
-            # Only argument-binding failures are a DI wiring problem (bad/missing kwargs); those
-            # raise at the call site, before entering the creator, so the traceback has no inner
-            # frame. A TypeError raised inside the creator body is the creator's own error and
-            # must propagate unchanged (consistent with ValueError/RuntimeError creator-failure).
+            # Argument-binding failures raise here with no inner traceback frame; a TypeError
+            # raised inside the creator body must propagate unchanged, like ValueError/RuntimeError.
             if exc.__traceback__ is not None and exc.__traceback__.tb_next is not None:
                 raise
             error = exceptions.CreatorCallError(creator=self._creator, original_error=exc)
@@ -244,9 +237,7 @@ class Factory(AbstractProvider[types.T_co]):
         try:
             container = container.find_container(self.scope)
         except (exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
-            # Name the failing end too: without this, a captive dependency's own step never
-            # makes it into the chain, and consumer frames alone would name every provider
-            # except the one that actually failed to resolve.
+            # Name the failing end too, or no frame ever names the provider that failed to resolve.
             exc.prepend_step(self._resolution_step())
             raise
         container._warn_and_reopen_if_closed()  # noqa: SLF001

--- a/modern_di/suggester.py
+++ b/modern_di/suggester.py
@@ -5,8 +5,6 @@ import typing
 def close_matches(target: str, candidates: typing.Iterable[str], *, n: int, cutoff: float = 0.6) -> list[str]:
     """Fuzzy-match ``target`` against ``candidates``; best ``n`` at/above ``cutoff``.
 
-    Thin wrapper over ``difflib.get_close_matches`` so the similarity cutoff and
-    its tuning live in one place, and the matching is unit-testable without
-    raising an error.
+    Thin wrapper over ``difflib.get_close_matches``.
     """
     return difflib.get_close_matches(target, list(candidates), n=n, cutoff=cutoff)

--- a/modern_di/wiring.py
+++ b/modern_di/wiring.py
@@ -1,14 +1,9 @@
 """Kwarg-wiring decision for Factory providers.
 
-``WiringPlan`` is the single authoritative place where a creator's parsed
-parameters are partitioned into provider lookups, static values, and context
-lookups.  It is a pure function of its inputs — no cache, no scope, no live
-context — so it is exercisable without a Container.
-
-``absent_disposition`` is the single copy of the absent-value table:
-    default is not UNSET  → OMIT (creator default applies)
-    is_nullable           → NULL (inject None)
-    else                  → UNWIRABLE (required, no provider)
+``WiringPlan`` partitions a creator's parsed parameters into provider
+lookups, static values, and context lookups. It is a pure function of its
+inputs — no cache, no scope, no live context — so it is exercisable without
+a Container.
 """
 
 import dataclasses
@@ -33,10 +28,9 @@ class _Absent(enum.Enum):
 
 
 def absent_disposition(item: SignatureItem) -> _Absent:
-    """Single copy of the absent-value table.
+    """Decide the disposition for a parameter with no matching provider.
 
-    Precedence: default before nullable before unwirable — matches today's
-    ``_compile_kwargs`` order exactly.
+    Precedence: default before nullable before unwirable.
     """
     if item.default is not UNSET:
         return _Absent.OMIT
@@ -52,8 +46,8 @@ def find_dep_provider(
 ) -> "AbstractProvider[typing.Any] | None":
     """Look up a dependency provider for *item* in *registry*, excluding *owner* itself.
 
-    Mirrors ``Factory._find_dep_provider`` exactly: prefers ``arg_type``,
-    falls back to the first matching type in ``args`` (union members).
+    Prefers ``arg_type``; falls back to the first matching type in ``args``
+    (union members).
     """
     if item.arg_type is not None:
         provider = registry.find_provider(item.arg_type)
@@ -79,10 +73,10 @@ class WiringPlan:
                           excluding providers supplied via ``kwargs={...}``.
                           Used by ``validate()``'s graph traversal.
         unwireable:       UNWIRABLE parameters as (param-name, SignatureItem)
-                          records; ``build`` never raises. Consumers construct
-                          fresh ``ArgumentResolutionError`` instances at
-                          raise/yield time so that ``prepend_step`` mutations
-                          do not compound across repeated resolves of the same
+                          records rather than pre-built exceptions, so a fresh
+                          ``ArgumentResolutionError`` can be constructed at
+                          each raise/yield site without ``prepend_step``
+                          mutations compounding across resolves of the same
                           memoized plan.
 
     """
@@ -102,19 +96,7 @@ class WiringPlan:
         registry: "ProvidersRegistry",
         owner: "Factory[typing.Any]",
     ) -> "WiringPlan":
-        """Partition *parsed_kwargs* into wiring buckets.
-
-        Pure function of its arguments — no cache, no scope, no live context —
-        runnable outside the container lock (GIL-determinism argument preserved
-        from ``_compile_kwargs``; free-threaded/nogil caveat tracked in
-        planning/deferred.md).
-
-        The plan never raises; unwireable parameters are recorded in
-        ``unwireable`` as raw (name, SignatureItem) records — NOT pre-built
-        exceptions — so that consumers can construct a fresh
-        ``ArgumentResolutionError`` at each raise/yield site without risk of
-        ``prepend_step`` mutations compounding across repeated resolves.
-        """
+        """Partition *parsed_kwargs* into wiring buckets. Never raises."""
         provider_kwargs: dict[str, AbstractProvider[typing.Any]] = {}
         static_kwargs: dict[str, typing.Any] = {}
         context_kwargs: dict[str, tuple[ContextProvider[typing.Any], SignatureItem]] = {}

--- a/planning/changes/2026-07-07.02-docstring-cleanup.md
+++ b/planning/changes/2026-07-07.02-docstring-cleanup.md
@@ -1,0 +1,84 @@
+---
+summary: Docstring/comment policy pass over modern_di/ — one-line contracts for internals, reviewer-justification genre removed, stale wiring.py references fixed; policy added to CLAUDE.md.
+---
+
+# Design: Docstring cleanup
+
+## Summary
+
+A prose-only pass over `modern_di/` applying the docstring policy from the
+2026-07-06 verbosity benchmark: public API documents the contract; internal
+helpers get a one-line contract plus at most 1–2 lines for a genuinely
+non-obvious constraint; implementation narration and reviewer-justification
+are deleted. The policy lands in CLAUDE.md's Code Style section. No
+behavior changes — no code, messages, or tests are touched.
+
+## Motivation
+
+The benchmark measured modern-di's comment density and page sizes as normal
+but found its long docstrings inverted from the gold-standard norm
+(attrs/click/httpx: long docstrings on public API, one-liners on internals):
+the longest docstrings sit on internal helpers and narrate mechanisms or
+justify code to a reviewer. Two references are already stale —
+`modern_di/wiring.py` names `_compile_kwargs` and `Factory._find_dep_provider`,
+which no longer exist. Every style authority agrees on the floor rule:
+content restating adjacent code is noise (PEP 8, Google, Ousterhout's
+"comment repeats code").
+
+## Design
+
+Dispositions for the audit's flagged items; the same policy applies to the
+rest of the ~56 docstrings (most already comply):
+
+- `wiring.py` (42 docstring lines / 159): module docstring → what the module
+  computes (pure wiring plan: no cache, no scope, no live context); delete
+  the stale `_compile_kwargs` / `_find_dep_provider` sentences and the
+  absent-value table (the enum shows it). The fresh-`ArgumentResolutionError`
+  rationale is stated once (at `WiringPlan`), not three times.
+  `WiringPlan.build` → short pure-lookup contract.
+- `container.py` `resolve_provider` → keep the public contract; delete the
+  RecursionError-conversion narration (lives in `_find_reachable_cycle`,
+  whose two-line stack-limit constraint stays, and in
+  `architecture/validation.md`). `_convert_recursion_error` → contract line
+  plus one line for the coverage-tracer constraint.
+  `_warn_and_reopen_if_closed` → contract plus the once-per-container
+  cardinality line; drop the changelog retelling. `__init__` → keep the
+  param contract; drop prose restating the warning message emitted 50 lines
+  below. `set_context` → keep both load-bearing constraints
+  (non-propagation, cached-provider staleness), tighten the rest.
+- `exceptions.py`: `DependencyPathMixin` → first paragraph plus 1–2 lines
+  for the empty-`__slots__` constraint; delete the "not itself an
+  exception" narration. Delete the `# message built dynamically; not
+  templated` comment (3×). One-line exception docstrings and the
+  "Inspect `.attr`" convention stay as-is.
+- The 3.0 warns-then-raises story: told once per surface — warning/error
+  class docstrings stay one line; other docstrings stop retelling it.
+  Warning/error message strings are behavior and are not touched.
+- CLAUDE.md, Code Style: add — docstrings on public API document the
+  contract; internal helpers get a one-line contract, plus at most 1–2
+  lines for a genuinely non-obvious constraint; never narrate
+  implementation or justify code to a reviewer; cross-file rationale lives
+  in `architecture/`.
+
+## Non-goals
+
+- No code, message-string, comment-that-states-a-real-constraint, or test
+  changes; the diff is docstrings/comments/CLAUDE.md only.
+- `architecture/` is untouched here; its own halving (separate change) must
+  preserve the rationale kernels this pass deletes from code.
+- Keepers named by the audit stay: `Scope` docstring, one-line exception
+  docstrings, `cache_registry.fetch_cache_item`'s concurrency comment.
+
+## Testing
+
+Prose-only diff, so: `just test-ci` (full 100%-coverage gate) and
+`just lint-ci` green; `grep -rn '_compile_kwargs\|_find_dep_provider' modern_di/`
+returns nothing; reviewer verifies the diff contains no executable-line
+changes.
+
+## Risk
+
+Deleting a rationale that was load-bearing and NOT duplicated elsewhere —
+mitigated by the audit's finding that every flagged long rationale also
+lives in `architecture/` (validation.md, containers.md), and by review
+checking each deletion against that claim.


### PR DESCRIPTION
Applies the docstring policy from the 2026-07-06 verbosity benchmark across `modern_di/`: public API documents the contract; internal helpers get a one-line contract plus at most 1–2 lines for a genuinely non-obvious constraint; implementation narration and reviewer-justification deleted. The policy is added to CLAUDE.md's Code Style section. Spec: [`planning/changes/2026-07-07.02-docstring-cleanup.md`](https://github.com/modern-python/modern-di/blob/docs/docstring-cleanup/planning/changes/2026-07-07.02-docstring-cleanup.md).

Highlights:
- `wiring.py`: 42 docstring lines in a 159-line file trimmed; the stale `_compile_kwargs` / `Factory._find_dep_provider` references (functions removed long ago) are gone; the fresh-`ArgumentResolutionError` rationale is stated once instead of three times.
- `container.py`: `resolve_provider` keeps its contract, loses the RecursionError-conversion narration (lives in `architecture/validation.md`); `_convert_recursion_error`, `_warn_and_reopen_if_closed`, `__init__`, `set_context` trimmed to contract + load-bearing constraints.
- `exceptions.py`: `DependencyPathMixin` keeps the slots constraint, loses the reviewer-justification; the `# message built dynamically; not templated` comment (3×) deleted; per-category `filterwarnings` recipes on warning classes kept (public contract).

**Prose-only diff** — no code, message-string, or test changes (review verified stripped ASTs are identical for every changed file), and every deleted rationale was verified to survive in `architecture/` or on its owning class.

Gates: `just test-ci` green (277 passed, 100% coverage), `just lint-ci` green.