### PR TITLE
docs: trim architecture/ to charter — invariants only

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -25,23 +25,16 @@ Constructor parameters:
 | `validate` | `None` | Tri-state, see below. |
 
 A root container (no `parent_container`) creates fresh `ProvidersRegistry` and `OverridesRegistry`
-instances. It also auto-registers `container_provider` under the `Container` type so that any
-provider declaring `Container` as a dependency receives the resolving container instance directly.
+instances. It also auto-registers `container_provider` (see [below](#container_provider)) under the
+`Container` type.
 
 ### `validate`'s three states
 
-- `True` — runs `container.validate()` immediately after construction (see [validation](validation.md)).
-- `False` — explicit opt-out: never validates, never warns. This is the only way to stay silent
-  once modern-di 3.0 flips the default to `True`-like behavior (see below), so it remains a
-  supported, permanent choice, not just a 2.x shim.
-- `None` (the default) — behaves like `False` today (no validation), but on a **root** container
-  (`parent_container is None`) it also emits `UnvalidatedContainerWarning`
-  (a `FutureWarning`) pointing at the [migration guide](../docs/migration/to-3.x.md): modern-di 3.0
-  runs `validate()` at root construction by default, so leaving `validate` unset now is a
-  transitional state, not a permanent one. Child containers built via `build_child_container` never
-  pass `validate` explicitly, so they also reach the unset (`None`) branch — but the warning itself
-  additionally requires `parent_container is None`, which is false for every child, so children
-  never warn regardless of `validate`.
+See [validation.md](validation.md) for what each state does and why. The container-specific wrinkle:
+child containers built via `build_child_container` never pass `validate` explicitly, so they always
+land on the unset (`None`) branch — but `UnvalidatedContainerWarning` additionally requires
+`parent_container is None`, which is false for every child. So children never warn, regardless of
+`validate`'s value.
 
 Escalate the warning to catch it in CI ahead of the 3.0 upgrade:
 
@@ -87,12 +80,10 @@ tree.
 
 A singleton instance of `_ContainerProvider` is registered under the `Container` type in the
 `ProvidersRegistry` of every root container. Its `resolve` method returns the container passed to
-it, so resolving `Container` from any child yields that child container — not the root. This lets
-providers at any scope depth receive the container they are resolved from as a plain constructor
-dependency.
-
-`_ContainerProvider` has `scope=Scope.APP` and `bound_type=None` (it is registered explicitly
-under `Container` rather than inferred from a type annotation).
+it, so resolving `Container` from any child yields that child container — not the root; see
+[docs/providers/container.md](../docs/providers/container.md) for the user-facing behavior and
+examples. `_ContainerProvider` has `scope=Scope.APP` and `bound_type=None` (it is registered
+explicitly under `Container` rather than inferred from a type annotation).
 
 ## Lifecycle: close and reopen
 
@@ -133,21 +124,14 @@ alone.
 
 ### `clear_cache` per `CacheItem`
 
-After running a finalizer, each `CacheItem` calls `_clear()`. This checks the item's
-`CacheSettings.clear_cache` flag. If `True`, the cached instance is removed (`cache` is reset to
-`UNSET`) and `finalized` is reset to `False`, leaving the slot ready to be re-populated on the
-next resolution. If `False` (or no `CacheSettings`), the cached value is retained after
-finalization; the item is simply marked finalized.
+After running a finalizer, `CacheItem._clear()` evicts the cached instance (and resets `finalized`)
+only if `CacheSettings.clear_cache` is `True` (the default); otherwise the cached value survives
+close, ready to be returned again without re-running the creator.
 
 ### Reopen (context-manager protocol)
 
 `Container` implements both sync (`__enter__` / `__exit__`) and async (`__aenter__` / `__aexit__`)
-context managers.
-
-- `open()` sets `self.closed = False`. No other state is reset; `cache_registry` and
-  `context_registry` are left as-is. Reopening an already-open container is a no-op.
-- `__enter__` / `__aenter__` call `open()` and return `self`.
-- `__exit__` calls `close_sync()`; `__aexit__` calls `close_async()`.
+context managers; `open()` (documented on the method itself) is the reopen primitive they call.
 
 Concretely: using the same container object as a context manager a second time reopens it (clears
 `closed`), resolves providers fresh if `clear_cache=True` was set on their `CacheSettings` (since
@@ -161,13 +145,8 @@ exactly this: `app.on_startup(container.open)` paired with `app.after_shutdown(c
 
 ## `validate()`
 
-`container.validate()` runs a depth-first traversal of all providers in `ProvidersRegistry`,
-detecting circular dependencies and scope-ordering violations (a provider at a wider scope
-depending on one at a narrower scope). Pass `validate=True` to the constructor to run this at
-creation time, or call `container.validate()` explicitly at any point. It raises
-`ValidationFailedError` with all collected errors if any are found — see
-[validation](validation.md) for the DFS algorithm, the grouped error rendering, and the pending
-3.0 default flip.
+See [validation.md](validation.md) for what `container.validate()` checks, how it reports
+aggregated errors, and the pending 3.0 default flip.
 
 ## `set_context()`
 

--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -53,12 +53,10 @@ of parameter names to `SignatureItem` descriptors. Dependency resolution is ther
 time each parameter is matched against the container's `providers_registry` by its annotated type.
 
 If `bound_type` is supplied explicitly it overrides the inferred return type (useful when the creator returns a
-protocol or base class narrower than the concrete type).
-
-A creator parameter that cannot be resolved by type raises `UnsupportedCreatorParameterError` at **declaration
-time**. This fires when a parameter is a parameterized generic (e.g. `list[int]`, `dict[str, Foo]`) or
-positional-only, has no default, and is not supplied via `kwargs`. The three escape hatches are: pass the value
-via `kwargs={...}`, give the parameter a default, or set `skip_creator_parsing=True`.
+protocol or base class narrower than the concrete type). See
+[docs/providers/factories.md](../docs/providers/factories.md#creator-signature-support-matrix) for the full
+per-parameter-shape behavior table (`UnsupportedCreatorParameterError` conditions, escape hatches, union
+resolution order).
 
 ### Recursive resolution
 
@@ -67,35 +65,21 @@ partitions it into the plan; `Factory` then recurses into `container.resolve_pro
 provider. The plan is built once and memoized on the `CacheItem`. Resolution errors are annotated with a breadcrumb
 describing the current factory, so the full chain appears in the exception.
 
-### Static kwargs
+### Static kwargs and `skip_creator_parsing`
 
-Pass `kwargs` to supply static (non-DI-resolved) arguments that bypass type-based resolution — for
-example `kwargs={"timeout": 30}` to pin a creator's `timeout` parameter. These are merged
-last, overriding any provider-resolved value for the same key. Supplying a key that does not appear in the
-creator's signature (and whose creator has no `**kwargs`) raises `UnknownFactoryKwargError` at declaration time.
-
-### `skip_creator_parsing=True`
-
-Disables signature introspection entirely — useful for callables whose signatures cannot be reflected (built-in C
-extensions, `functools.partial`, etc.). When set without an explicit `bound_type`, a `UserWarning` is emitted
-because the provider cannot be resolved by type.
+See [docs/providers/factories.md](../docs/providers/factories.md#kwargs) for `kwargs=` (static values,
+overriding provider-resolved ones for the same key; an unknown key raises `UnknownFactoryKwargError` at
+declaration time, unless the creator accepts `**kwargs` or its signature cannot be reflected) and
+`skip_creator_parsing=True` (disables signature introspection; a `UserWarning` is
+emitted if `bound_type` isn't given explicitly, since the provider then can't be resolved by type).
 
 ---
 
 ## `CacheSettings` — singleton behavior
 
-There is **no separate `Singleton` class**. Singleton behavior is opted into via the `cache` argument:
-`cache=True` enables caching with default settings, `cache=CacheSettings(...)` enables caching and tunes it
-(finalizer, `clear_cache`), and an absent, `None`, or `False` value means a fresh instance is created on every
-resolution.
-
-```python
-providers.Factory(scope=Scope.APP, creator=Database, cache=True)
-providers.Factory(scope=Scope.APP, creator=Database, cache=providers.CacheSettings(finalizer=close))
-```
-
-`cache_settings=` is a deprecated alias of `cache` (it emits a `DeprecationWarning` and will be removed in a
-future release); passing both `cache` and `cache_settings` raises `TypeError`.
+There is no separate `Singleton` class — see [docs/providers/factories.md](../docs/providers/factories.md)
+for the user-facing singleton idiom and `cache_settings=`'s deprecation
+([advanced-api.md#deprecated-cache_settings](../docs/providers/advanced-api.md#deprecated-cache_settings)).
 
 `CacheSettings` is a `dataclass` with the following fields:
 
@@ -103,10 +87,7 @@ future release); passing both `cache` and `cache_settings` raises `TypeError`.
 |---|---|---|---|
 | `clear_cache` | `bool` | `True` | Whether the cached instance is evicted when the container closes. |
 | `finalizer` | `Callable[[T], None \| Awaitable[None]] \| None` | `None` | Optional teardown called on container close, before cache eviction. |
-| `is_async_finalizer` | `bool` | *(computed)* | Set automatically in `__post_init__`; `True` when `finalizer` is a coroutine function. |
-
-`is_async_finalizer` is not an init parameter — it is derived by `inspect.iscoroutinefunction(finalizer)` in
-`__post_init__`. The container uses it to decide whether to `await` the finalizer.
+| `is_async_finalizer` | `bool` | *(computed)* | Not an init parameter — derived by `inspect.iscoroutinefunction(finalizer)` in `__post_init__`. The container uses it to decide whether to `await` the finalizer. |
 
 Without `cache`, `Factory.resolve` calls the creator on every resolution and returns a fresh instance
 each time.
@@ -150,11 +131,9 @@ and the two paths are independent:
 providers.Alias(source_type=ConcreteDatabase, bound_type=DatabaseProtocol)
 ```
 
-This lets code that depends on `DatabaseProtocol` receive the `ConcreteDatabase` instance without the registry
-needing a separate `Factory` for the protocol. `Alias.resolve` calls `container.resolve_provider(source_provider)`,
-so caching and lifecycle are fully governed by the source.
-
-`Alias` also accepts an optional `bound_type` that overrides the inferred bound type.
+`Alias.resolve` calls `container.resolve_provider(source_provider)` — it holds no cache of its own — and also
+accepts an optional `bound_type` override. See [docs/providers/alias.md](../docs/providers/alias.md) for the
+user-facing rationale and caching implications.
 
 `Alias.effective_scope` follows alias chains transitively to the terminal non-alias provider and returns that
 provider's scope. This is what `Container.validate()` and scope-error reporting use — the alias's own `scope`
@@ -162,13 +141,10 @@ attribute is only a stored default.
 
 ### Deprecated `scope=` parameter
 
-Passing `scope=` to `Alias.__init__` emits a `DeprecationWarning`:
-
-> "The `scope` parameter of Alias is deprecated and ignored: an alias's effective scope is derived from its
-> source. It will be removed in a future release."
-
-The parameter is accepted for backwards compatibility but has no effect on resolution. It will be removed in a
-future release.
+Passing `scope=` to `Alias.__init__` emits a `DeprecationWarning` and has no effect on resolution or validation
+(both are derived from the source, per above) — see [docs/providers/alias.md](../docs/providers/alias.md) for
+the user-facing note. The stored value is kept internally only so that cosmetic consumers (`__repr__`, registry
+suggestions) continue to display it; it is scheduled for removal in a future release.
 
 ---
 

--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -4,66 +4,32 @@ How `modern-di` wires an object graph from type hints — from the first `resolv
 
 ## Entry points
 
-There are two ways to trigger resolution from a `Container`:
-
-- `container.resolve(SomeType)` — resolves by type. Looks up `SomeType` in `providers_registry`; raises
-  `ProviderNotRegisteredError` (with closest-match suggestions) if no provider is registered for that type. Then
-  delegates to `resolve_provider`.
+- `container.resolve(SomeType)` — looks up `SomeType` in `providers_registry` (raising
+  `ProviderNotRegisteredError`, with closest-match suggestions, if none is registered), then delegates to
+  `resolve_provider`.
 - `container.resolve_provider(provider)` — resolves by provider reference directly, skipping the registry lookup.
 
 ## Step 1 — Override short-circuit
 
-`resolve_provider` is the single choke-point through which every resolution passes. Before touching scope or cache it
-checks the override registry:
-
-```python
-if (
-    self.overrides_registry.overrides
-    and (override := self.overrides_registry.fetch_override(provider.provider_id)) is not types.UNSET
-):
-    return override
-```
-
-The outer guard (`self.overrides_registry.overrides`) is a cheap truthiness check on a dict; `fetch_override` is only
-called when at least one override exists. If an override is registered for this provider, it is returned immediately —
+`resolve_provider` is the single choke-point every resolution passes through, and the override registry is
+checked first — before scope or cache. An override, if registered for this provider, is returned immediately:
 no scope walk, no cache check, no creator call.
 
 ## Step 2 — Scope walk (inside Factory.resolve)
 
-After the override check, `resolve_provider` calls `provider.resolve(self)`. For `Factory` the first thing `resolve`
-does is walk to the container at the provider's declared scope:
+`Factory.resolve` walks to the container at the provider's declared scope via `find_container`, raising
+`ScopeNotInitializedError` or `ScopeSkippedError` as appropriate — see [scopes.md](scopes.md) for the rule and
+error conditions. From this point all cache and context operations use the scope-correct container.
 
-```python
-container = container.find_container(self.scope)
-```
-
-`find_container` looks up `self.scope_map`, a dict built at container construction time that maps each scope level to
-the container at that level. If the scope is deeper than the current container (not yet initialized) a
-`ScopeNotInitializedError` is raised; if it was skipped when building the child chain, a `ScopeSkippedError` is raised.
-From this point all cache and context operations use the scope-correct container.
-
-Both scope errors carry the same breadcrumb `dependency_path` as `ResolutionError` (they share
-`DependencyPathMixin`, see below), so a runtime **captive dependency** — a shallower-scoped provider
-depending, directly or transitively, on a deeper-scoped one — names both ends: the provider that
-captured the dependency and the one that actually failed to resolve, not just the two scope names.
 `Factory.resolve` wraps its own `find_container` call and prepends its own step on a scope error before
-re-raising, so the failing provider's name makes it into the chain even though this call sits outside
-the try block that wraps the rest of `resolve` (see Step 5's `prepend_step` note for the general
-mechanism). `Alias.resolve`'s except is widened the same way.
+re-raising, so the failing provider's name makes it into the breadcrumb chain even though this call sits outside
+the try block that wraps the rest of `resolve` (see Step 5's `prepend_step` note for the general mechanism).
+`Alias.resolve`'s except is widened the same way.
 
 ## Step 3 — Cache hit
 
-With the correct container in hand, `Factory.resolve` fetches (or creates) a `CacheItem` for this provider:
-
-```python
-cache_item = container.cache_registry.fetch_cache_item(self)
-
-if self.cache_settings and cache_item.cache is not types.UNSET:
-    return cache_item.cache
-```
-
 If `cache_settings` is configured **and** the cache slot already holds a value, the cached instance is returned
-immediately. (A `Factory` with no `cache_settings` always re-runs the creator.)
+immediately. A `Factory` with no `cache_settings` always re-runs the creator.
 
 ## Step 4 — Wiring plan
 
@@ -94,7 +60,7 @@ map produced at provider-declaration time by `types_parser.parse_creator` — an
    > (Python ignores it at runtime); this asymmetry is intentional, not a wiring guarantee.
 
 3. **No provider found** — a static graph fact, decided once via the shared `absent_disposition(item)` helper (the
-   single home of the absent-value table):
+   single home of the absent-value table — also applied live in Step 5, for an unset context value):
    - If the parameter has a default, it is omitted (the creator's own default applies).
    - Else if `SignatureItem.is_nullable` is `True` (the annotation included `None`, e.g. `X | None` or `Optional[X]`),
      `None` is placed in `static_kwargs`.
@@ -108,51 +74,27 @@ reads `dependencies`, `iter_validation_issues` builds a fresh error per `unwirea
 
 ## Step 5 — Recursive resolution
 
-With the wiring plan in hand, `Factory` first surfaces any unwireable parameter: if `plan.unwireable` is non-empty it
-raises a **freshly built** `ArgumentResolutionError` from the first record before calling the creator. The error is
-built fresh on every raise (never memoized) because `prepend_step` (owned by the shared `DependencyPathMixin`, mixed
-into both `ResolutionError` and the two scope errors) *mutates* the exception as it propagates up the chain — a
-stored instance would accumulate and leak breadcrumbs across repeated or nested resolves.
+`Factory` first surfaces any unwireable parameter: if `plan.unwireable` is non-empty it raises a **freshly built**
+`ArgumentResolutionError` from the first record before calling the creator. The error is built fresh on every raise
+(never memoized) because `prepend_step` (owned by the shared `DependencyPathMixin`, mixed into both
+`ResolutionError` and the two scope errors) *mutates* the exception as it propagates up the chain — a stored
+instance would accumulate and leak breadcrumbs across repeated or nested resolves.
 
-```python
-resolved_kwargs = dict(plan.static_kwargs)
-for k, v in plan.provider_kwargs.items():
-    resolved_kwargs[k] = container.resolve_provider(v)
-for k, (context_provider, item) in plan.context_kwargs.items():
-    value = self._resolve_context_value(container, k, context_provider, item)
-    if value is not types.UNSET:
-        resolved_kwargs[k] = value
-```
+Each `provider_kwargs` entry is resolved by calling back into `container.resolve_provider`, re-entering this same
+sequence from Step 1. Each `context_kwargs` entry is resolved **live**, on every resolve, via
+`_resolve_context_value` — so a `set_context` after a factory has already resolved is still picked up (across
+scopes, for non-cached factories). `_resolve_context_value` mirrors `resolve_provider`'s override check, then reads
+the live context value; when it is absent, the shared `absent_disposition` helper applies — omit (default
+applies), `None` (nullable), or raise `ArgumentResolutionError` — the same three-way disposition Step 4 computes
+statically for a missing provider, just evaluated live instead of once at plan-build time.
 
-Regular dependency providers are resolved by calling back into `container.resolve_provider`, which re-enters this same
-sequence from Step 1 — override check, then `provider.resolve(container)`.
-
-Context-backed parameters are resolved **live on every resolve**, so a `set_context` after a factory has already
-resolved is always picked up (across scopes, for non-cached factories). `_resolve_context_value` mirrors
-`resolve_provider`'s override check, then reads the live context value; when the value is absent it applies the shared
-`absent_disposition` helper — omit (default applies), `None` (nullable), or raise `ArgumentResolutionError`.
-
-The recursion bottoms out at providers with
-no dependencies or at already-cached instances.
+The recursion bottoms out at providers with no dependencies or at already-cached instances.
 
 ## Step 6 — Creator call and caching
 
-```python
-instance = self._call_creator(resolved_kwargs)
-```
-
-If `cache_settings` is `None`, the instance is returned immediately with no caching. If `cache_settings` is set, a
-lock (when `use_lock=True`) guards a double-checked read of the cache slot to handle concurrent first-resolves, then
-the instance is stored and returned.
-
-## Nullable wiring
-
-`types_parser.SignatureItem` carries an `is_nullable: bool` field. It is set to `True` when the parameter annotation
-is a union that includes `NoneType` — that is, `X | None`, `Optional[X]`, or any union spelled with `typing.Union`
-that contains `None`. When no provider is found for the parameter (or a `ContextProvider` has no value set) and the
-parameter has no default, the shared `absent_disposition` helper returns `None` for `is_nullable=True` — at plan-build
-time (`WiringPlan.build`) for a missing provider, or live at resolve time (`_resolve_context_value`) for an unset
-context value — rather than raising an error.
+`Factory` calls the creator with `resolved_kwargs`. With no `cache_settings`, the instance is returned immediately.
+Otherwise the cache-write is guarded by the double-checked locking pattern described under
+[Thread safety](#thread-safety) below, then the instance is stored and returned.
 
 ## Thread safety
 

--- a/architecture/scopes.md
+++ b/architecture/scopes.md
@@ -17,23 +17,12 @@ Every provider is bound to a scope at declaration time. The rule is:
 > (i.e., `container.scope >= provider.scope`).
 
 Attempting to resolve a provider from a container whose scope is shallower than the provider's scope raises one of
-two exceptions, depending on what went wrong:
+two exceptions, depending on what went wrong (see `exceptions.py` for the exact messages):
 
 - **`ScopeNotInitializedError`** — raised when the required scope is deeper than the resolving container's scope
-  (the child container for that scope has not been built yet). Message shape:
-
-  ```
-  Provider of scope {provider_scope} cannot be resolved in container of scope {container_scope}.
-  ```
-
+  (the child container for that scope has not been built yet).
 - **`ScopeSkippedError`** — raised when the required scope is shallower than the resolving container's scope but
-  is not present anywhere in the ancestor chain (i.e., the chain was started at a scope that skipped it). Message
-  shape:
-
-  ```
-  No {provider_scope}-scope container exists in this chain; this chain starts at {container_scope}.
-  Build a {provider_scope}-scope container as the root.
-  ```
+  is not present anywhere in the ancestor chain (i.e., the chain was started at a scope that skipped it).
 
 Both exceptions inherit from `ContainerError → ModernDIError → RuntimeError`.
 
@@ -41,8 +30,8 @@ Both also carry a breadcrumb `dependency_path` (via the shared `DependencyPathMi
 walk in [resolution.md](resolution.md)), so a **captive dependency** (a shallower-scoped provider that,
 directly or transitively, depends on a deeper-scoped one) reports both the capturing provider's name
 and the one that actually failed to resolve, in addition to the two scope names. Raised with an empty
-path (e.g. a bare `find_container` call with no provider frame involved) the message is unchanged from
-the shape shown above.
+path (e.g. a bare `find_container` call with no provider frame involved), the message falls back to
+the base one-liner with no breadcrumb prepended.
 
 ## How the container locates the right-scope container
 
@@ -66,49 +55,9 @@ parent-chain traversal during resolution.
 more levels (or different names) can define their own `IntEnum` and use it throughout. The same integer-ordering
 rules apply. Passing a non-`IntEnum` value raises `InvalidScopeTypeError`.
 
-## Worked example
+## See also
 
-```python
-from modern_di import Container, Group, Scope
-from modern_di import providers
-
-# DatabasePool and UserFromRequest are your own classes.
-class AppGroup(Group):
-    # Resolved once and cached for the lifetime of the app container.
-    db_pool = providers.Factory(scope=Scope.APP, creator=DatabasePool, cache=True)
-
-    # Resolved once per request container.
-    current_user = providers.Factory(scope=Scope.REQUEST, creator=UserFromRequest)
-
-# Root container at APP scope.
-app_container = Container(scope=Scope.APP, groups=[AppGroup])
-
-# Works: db_pool is APP-scoped, container is APP-scoped (same scope).
-pool = app_container.resolve(DatabasePool)
-
-# Fails: current_user is REQUEST-scoped, but the container is APP-scoped (too shallow).
-# Raises ScopeNotInitializedError:
-#   "Provider of scope REQUEST cannot be resolved in container of scope APP."
-app_container.resolve(UserFromRequest)  # raises
-
-# Build a child container for the request boundary.
-request_container = app_container.build_child_container(scope=Scope.REQUEST, context={...})
-
-# Works: current_user is REQUEST-scoped, container is REQUEST-scoped.
-user = request_container.resolve(UserFromRequest)
-
-# Works: db_pool is APP-scoped; find_container(APP) returns the parent app_container via scope_map.
-pool_again = request_container.resolve(DatabasePool)
-```
-
-`build_child_container` enforces that the child scope is strictly deeper than the parent scope. Passing a scope
-with a lower or equal integer value raises `InvalidChildScopeError`:
-
-```
-Scope of child container cannot be {child_scope} if parent scope is {parent_scope}
-(child scope value must be strictly greater than parent scope value).
-Possible scopes are {allowed_scopes}.
-```
-
-Calling `build_child_container()` with no `scope` argument auto-increments to the next integer in the same
-`IntEnum` class. If the parent is already at the maximum defined value, `MaxScopeReachedError` is raised.
+- [docs/providers/scopes.md](../docs/providers/scopes.md) for a worked, user-facing walk-through of
+  resolving across scopes and building child containers.
+- [containers.md](containers.md#child-containers) for `build_child_container`'s scope rules
+  (auto-increment, `MaxScopeReachedError`).

--- a/architecture/testing-and-overrides.md
+++ b/architecture/testing-and-overrides.md
@@ -28,20 +28,11 @@ root — the override is visible tree-wide. `close_async` and `close_sync` on th
 
 ### How overrides short-circuit resolution
 
-`resolve_provider` checks the registry before delegating to the provider:
-
-```python
-def resolve_provider(self, provider):
-    if self.overrides_registry.overrides and \
-       (override := self.overrides_registry.fetch_override(provider.provider_id)) is not types.UNSET:
-        return override          # returned immediately, no cache, no factory call
-    return provider.resolve(self)
-```
-
-The override value is returned directly, bypassing the scope check, cache lookup, and creator invocation. This
-means the override object does not need to be an instance of the provider's declared type at runtime (Python does
-not enforce it), but callers should pass a compatible object for type safety. See `resolution.md` for the full
-resolution flow that overrides short-circuit.
+`resolve_provider` checks the override registry before delegating to the provider — see
+[resolution.md](resolution.md)'s Step 1 for the mechanism. The override value is
+returned directly, bypassing the scope check, cache lookup, and creator invocation. This means the override
+object does not need to be an instance of the provider's declared type at runtime (Python does not enforce it),
+but callers should pass a compatible object for type safety.
 
 ### Scope behaviour under overrides
 
@@ -56,69 +47,15 @@ cached instance. After `reset_override`, the original cache entry (if any) is st
 
 ## Testing patterns
 
-### Declaring providers
-
-Define a `Group` subclass with providers as class-level attributes and pass it to `Container`:
-
-```python
-from modern_di import Container, Scope, providers, Group
-
-class MyGroup(Group):
-    service               = providers.Factory(scope=Scope.APP, creator=MyService)
-    repo                  = providers.Factory(scope=Scope.APP, creator=MyRepo)
-    request_scoped_service = providers.Factory(scope=Scope.REQUEST, creator=RequestScopedService)
-
-container = Container(scope=Scope.APP, groups=[MyGroup])
-```
-
-### Resolving in tests
-
-Resolve by provider reference (most precise — no type lookup):
-
-```python
-instance = container.resolve_provider(MyGroup.service)
-```
-
-Resolve by type (matches the type registered in `ProvidersRegistry`):
-
-```python
-instance = container.resolve(MyService)
-```
-
-Both methods go through `resolve_provider` and therefore respect overrides.
-
-### Testing scope chains
-
-Build child containers to test providers that require a deeper scope:
-
-```python
-app_container = Container(scope=Scope.APP, groups=[MyGroup])
-request_container = app_container.build_child_container(scope=Scope.REQUEST)
-instance = request_container.resolve_provider(MyGroup.request_scoped_service)
-request_container.close_sync()
-```
-
-Child containers share the parent's `providers_registry` and `overrides_registry` but have independent
-`cache_registry` instances, so each child starts with a cold cache.
-
-### Injecting overrides
-
-```python
-app_container = Container(scope=Scope.APP, groups=[MyGroup])
-app_container.override(MyGroup.repo, FakeRepo())
-
-result = app_container.resolve_provider(MyGroup.service)  # receives FakeRepo
-
-app_container.reset_override(MyGroup.repo)   # restore
-```
-
-Overrides set on the app container are visible in all child containers built afterward (shared registry), and in
-child containers already in existence too, since the registry object is the same reference.
-
-### Cleanup
-
-Call `container.reset_override()` (no argument) after a test to clear all overrides, or rely on
-`close_sync`/`close_async` on the root container — both clear the registry automatically.
+Declare providers as `Group` class attributes and pass the group to `Container` (see
+[containers.md](containers.md#creating-a-root-container)). Resolve by provider reference
+(`resolve_provider`, most precise) or by type (`resolve`) — both go through the override check.
+Test deeper scopes via `build_child_container`; each child gets its own cold `cache_registry` (see
+[Registry sharing](containers.md#registry-sharing)), so a request-scoped provider resolved in one
+child never leaks a cached instance into another. Inject overrides with
+`container.override(provider, obj)` — visible tree-wide immediately, since `OverridesRegistry` is
+shared (see above) — and reset with `reset_override()`, or rely on the root container's
+`close_sync`/`close_async` to clear all overrides automatically at teardown.
 
 ## modern-di-pytest integration
 

--- a/architecture/validation.md
+++ b/architecture/validation.md
@@ -26,36 +26,28 @@ leaving it unset (`None`) also skips it but emits `UnvalidatedContainerWarning` 
 container, because **modern-di 3.0 runs `validate()` at root construction by default** — the
 current opt-in becomes opt-out. Pass `validate=True` now to adopt the 3.0 behavior early, or
 `validate=False` to keep it off permanently (that stays a supported no-warning choice after 3.0).
-See the [migration guide](../docs/migration/to-3.x.md) for the full readiness recipe.
+See the [migration guide](../docs/migration/to-3.x.md) for the full readiness recipe. (Child
+containers never emit this warning regardless of `validate` — see
+[containers.md](containers.md#validates-three-states).)
 
 ## What validate() checks
 
-`validate()` performs a depth-first search (DFS) over every provider in `providers_registry`. It collects **all
-errors** across the entire walk before raising, so a single call surfaces all wiring bugs at once rather than
-stopping at the first one.
-
-If any errors are found, `validate()` raises `exceptions.ValidationFailedError`, whose `.errors` attribute is a
-list of all individual exceptions encountered. `ValidationFailedError.__str__` groups `.errors` by exception
-class name (sorted alphabetically) so a report mixing several error kinds reads as one section per kind rather
-than an undifferentiated flat list — see [Report rendering](#report-rendering) below for the exact shape.
+`validate()` performs a depth-first search (DFS) over every provider in `providers_registry` (the walk itself is
+`Container.validate()` in `modern_di/container.py`). It collects **all errors** across the entire walk before
+raising, so a single call surfaces all wiring bugs at once rather than stopping at the first one. `validate()`
+raises `exceptions.ValidationFailedError` if any are found; its `.errors` attribute lists every collected
+exception, and its `__str__` groups them by class name so a report mixing several error kinds reads as one
+section per kind — see `ValidationFailedError.__str__` in `modern_di/exceptions.py`. Validation runs entirely
+against `providers_registry`, so a root APP-scope container validates deeper-scoped providers without building
+child containers.
 
 ### Circular dependencies
 
 During the DFS, a provider encountered a second time while it is still on the active path (i.e., it appears in
 `visiting`) means a cycle exists. `validate()` records a `CircularDependencyError` with a `.cycle_path` list of
 type names showing the loop (e.g., `["A", "B", "A"]`). The recursive walk does **not** continue into the cycle,
-but the rest of the graph continues to be checked.
-
-`CircularDependencyError.__str__` renders `.cycle_path` as a multi-line arrow chain (the same `└─>` continuation
-glyph as the `ResolutionError` dependency-chain breadcrumb), not an inline `A -> B -> A` string:
-
-```
-Circular dependency detected:
-  A
-  └─> B
-      └─> A
-Check your provider graph for unintended cycles.
-```
+but the rest of the graph continues to be checked. `CircularDependencyError.__str__` renders `.cycle_path` as a
+multi-line arrow chain, not an inline `A -> B -> A` string — see `CircularDependencyError` in `exceptions.py`.
 
 > **Runtime resolution has a cycle guard too — but `validate()` remains the way to see all errors up front.**
 > `Container.resolve_provider` wraps the final `provider.resolve(self)` in `try/except RecursionError`. When an
@@ -79,16 +71,9 @@ Check your provider graph for unintended cycles.
 For every dependency edge `provider → dep`, `validate()` compares their **effective scopes** (see below). If
 `dep`'s effective scope is strictly deeper than `provider`'s effective scope, the dependency is inverted: a
 shallower-lived provider cannot hold a reference to a deeper-lived one. The error is recorded as
-`InvalidScopeDependencyError`, which names the provider, the parameter, the dependent provider, and the offending
-scopes. The walk continues into the dependency so further issues in that subtree are also surfaced.
-
-Error message template (from `errors.INVALID_SCOPE_DEPENDENCY_ERROR`):
-
-```
-Provider {provider_name} (scope {provider_scope}) declares parameter
-{parameter_name!r} typed as a provider of {dep_name} at deeper scope
-{dep_scope}. A provider cannot depend on a deeper-scoped provider.
-```
+`InvalidScopeDependencyError` (see `exceptions.py` for the exact message), which names the provider, the
+parameter, the dependent provider, and the offending scopes. The walk continues into the dependency so further
+issues in that subtree are also surfaced.
 
 ### Missing required dependencies
 
@@ -97,50 +82,14 @@ and appends any returned exceptions to the error list. `Factory` implements this
 `ArgumentResolutionError` for each constructor parameter that has no matching provider in `providers_registry`,
 no default value, and no static `kwargs` entry.
 
-### Report rendering
-
-`ValidationFailedError.__str__` starts with the one-line summary (`Container.validate() found N issue(s): ...`,
-used by `repr`/logging), then one section per exception class, sorted by class name, each headed
-`{ClassName} ({count}):` and listing its errors as `  - ` bullets. An error's own multi-line message (e.g. a
-`CircularDependencyError` arrow chain, or a `ProviderNotRegisteredError`'s "Did you mean" suggestion block) has
-its first line placed after the bullet and every continuation line indented four spaces so multi-line
-sub-errors read as a block rather than mangling into the bullet list. A trailing blank message line is stripped
-(the `rstrip`/empty-message guard), so an error with no extra content renders as a bare `  - ` without a dangling
-space.
-
-A container with both a circular dependency and a missing provider renders as:
-
-```
-Container.validate() found 2 issue(s): CircularDependencyError, ProviderNotRegisteredError
-
-CircularDependencyError (1):
-  - Circular dependency detected:
-      A
-      └─> B
-          └─> A
-    Check your provider graph for unintended cycles.
-
-ProviderNotRegisteredError (1):
-  - Provider of type <class 'str'> is not registered in providers registry.
-    Did you mean:
-    Str2
-```
-
 ## Effective scope and alias transparency
 
 `validate()`'s scope-ordering check uses `provider.effective_scope(container)` on both sides of every dependency
 edge — not `provider.scope` directly.
 
 For most providers, `effective_scope` simply returns `self.scope`. `Alias` overrides it to follow the alias chain
-to its terminal non-alias target and return **that provider's scope**:
-
-```
-Alias.effective_scope(container)
-  → follow chain: Alias → Alias → ... → concrete Factory
-  → return concrete_factory.scope
-```
-
-This makes validation transitive through aliases. Consider:
+to its terminal non-alias target and return **that provider's scope**. This makes validation transitive through
+aliases. Consider:
 
 ```
 Factory(scope=APP, creator=Caller)   # depends on IFace
@@ -160,61 +109,6 @@ Two edge cases in `Alias.effective_scope` are handled safely:
 - **Dangling source**: if the alias's source type is not registered, the method falls back to `self.scope`. The
   dangling source is separately detected and reported by `iter_validation_issues` or by the dependency lookup
   raising `AliasSourceNotRegisteredError` during the walk.
-
-## The deprecated `Alias(scope=...)` parameter
-
-`Alias` accepts a `scope` keyword argument that was historically intended to convey the alias's position in the
-scope hierarchy. Because an alias is a transparent redirect — resolution always delegates to the source, and (as
-of the `effective_scope` mechanism) validation now evaluates the source's scope transitively — the `scope`
-parameter has no effect on either behavior.
-
-Passing `scope=` to `Alias` now emits a `DeprecationWarning`:
-
-```
-The `scope` parameter of Alias is deprecated and ignored: an alias's effective
-scope is derived from its source. It will be removed in a future release.
-```
-
-The stored value is kept internally only so that cosmetic consumers (`__repr__`, registry suggestions) continue
-to display it. The parameter is scheduled for removal in a future release. New code should omit it.
-
-## DFS algorithm summary
-
-```
-validate():
-  visiting = set()   # providers currently on the active path
-  visited  = set()   # providers fully processed
-  path     = list()  # ordered active path (for cycle reporting)
-  errors   = list()
-
-  for each provider in providers_registry:
-      _visit(provider)
-
-  if errors:
-      raise ValidationFailedError(errors=errors)
-
-_visit(provider):
-  if provider in visited:  return        # already processed; skip
-  if provider in visiting:               # back-edge → cycle
-      record CircularDependencyError
-      return                             # don't recurse into the cycle
-
-  mark visiting; append to path
-  errors.extend(provider.iter_validation_issues(container))
-
-  provider_scope = provider.effective_scope(container)
-  for dep_name, dep_provider in provider.get_dependencies(container):
-      dep_scope = dep_provider.effective_scope(container)
-      if dep_scope > provider_scope:
-          record InvalidScopeDependencyError
-      _visit(dep_provider)               # recurse regardless of scope error
-
-  remove from path; unmark visiting; mark visited
-```
-
-`provider.get_dependencies(container)` is a pure registry lookup — it does not touch `cache_registry`, does not
-call `find_container`, and does not perform any runtime context check. This means `validate()` works correctly on
-a root APP-scope container even when the graph contains SESSION-, REQUEST-, ACTION-, or STEP-scoped providers.
 
 ## Exception types
 

--- a/planning/changes/2026-07-07.04-architecture-halving.md
+++ b/planning/changes/2026-07-07.04-architecture-halving.md
@@ -1,0 +1,86 @@
+---
+summary: architecture/ trimmed to its charter — invariants and non-obvious constraints only; pseudocode transcriptions, pasted-code narration, and verbatim error strings deleted; one stale reference fixed.
+---
+
+# Design: architecture/ halving
+
+## Summary
+
+The last item from the 2026-07-06 verbosity benchmark: trim the six
+capability files in `architecture/` (6,902 words) to their charter — the
+invariants and non-obvious constraints a maintainer cannot read off the
+code. What goes: pseudocode transcriptions, pasted code plus narration,
+verbatim error-message quotes, and retellings of stories that now have
+canonical homes elsewhere. Roughly halving is expected (~3.5k), but the
+rule is kernel-protection, not a word quota — the docs-dedupe taught us
+targets bend to protected content, and here the protected content is
+hard-constrained: **since the docstring cleanup (PR #280), `architecture/`
+is the sole home of the rationales removed from code.**
+
+## Motivation
+
+The benchmark audit found roughly a third of the corpus violates the
+charter: `validation.md` carries a 30-line pseudocode transcription of
+`Container.validate()` and quotes error-message templates verbatim
+(one already stale — it names `errors.INVALID_SCOPE_DEPENDENCY_ERROR`,
+a constant that does not exist; messages are inline f-strings);
+`resolution.md` pastes real code and then narrates the pasted lines;
+`containers.md` restates four one-line dunder methods in prose;
+`providers.md` restates two lines of `__post_init__` that its own table
+row above already describes. Transcriptions rot silently — the stale
+constant proves it.
+
+## Design
+
+Per-file dispositions (audit findings; the same charter rule sweeps the rest):
+
+- **validation.md** (1,536 w): delete the pseudocode transcription of
+  `validate()`; replace verbatim error-message quotes with the exception
+  class name + a pointer to `exceptions.py`; fix the stale
+  `INVALID_SCOPE_DEPENDENCY_ERROR` reference. KEEP (sole-home): the
+  runtime cycle-guard rationale (innermost-frame conversion, re-entrancy,
+  breadcrumb prepending — the code no longer carries this), the
+  `effective_scope` alias-transitivity rule and its two edge cases.
+- **resolution.md** (1,303 w): delete pasted-code-plus-narration (the
+  override-check walkthrough and similar); KEEP the WiringPlan bucket
+  semantics and the kwargs-bypass-validate subtlety (steps 4-5).
+- **containers.md** (1,300 w): delete the dunder-method prose and the
+  third retelling of the validate tri-state (link `validation.md`); KEEP
+  (sole-home) the registry-sharing table, the `set_context` live-vs-cached
+  staleness elaboration, the pre-2.16 closed-container note, LIFO
+  finalization + `AsyncFinalizerInSyncCloseError` retention.
+- **providers.md** (1,166 w): delete restatements of code the tables
+  already describe; KEEP `is_async_finalizer` derivation only in the table.
+- **scopes.md** (707 w): drop the verbatim error-message quotes and the
+  worked example that duplicates `docs/providers/scopes.md` (link it);
+  KEEP the resolution rule as stated for maintainers.
+- **testing-and-overrides.md** (739 w): delete the third paste of the
+  override check; KEEP override-bypasses-scope-check and its implications.
+- **Cross-cutting**: where a user-facing behavior is fully documented in
+  `docs/`, the capability file links instead of re-explaining — the two
+  axes stay unmixed (docs/ for users, architecture/ for maintainer
+  invariants). Verbatim quoting of code or messages is banned; name the
+  symbol and point at the file.
+- **README.md** (151 w): unchanged unless a charter sentence helps; the
+  file table in the repo's `CLAUDE.md` is untouched (file names keep).
+
+## Non-goals
+
+- No file renames, merges, or deletions — six capability files + README stay.
+- No behavior/code changes; `docs/` untouched.
+- No new content beyond linking lines.
+
+## Testing
+
+`just lint-ci` green (eof-fixer sweeps md);
+`grep -rn 'INVALID_SCOPE_DEPENDENCY_ERROR' architecture/` empty; reviewer
+verifies every named KEEP kernel survives verbatim-or-equivalent, verifies
+each deleted rationale exists in code/docs/ or was pure transcription, and
+checks no doc link into `architecture/` breaks (grep docs/ for
+`architecture/` references).
+
+## Risk
+
+Deleting a sole-home rationale — mitigated by the explicit KEEP lists
+above (sourced from the docstring-cleanup review's information-loss audit)
+and an adversarial reviewer pass focused exactly on that.


### PR DESCRIPTION
The last item from the 2026-07-06 verbosity benchmark. `architecture/` trimmed to its charter — the invariants, edge cases, and rationales a maintainer cannot read off the code. Deleted: a 30-line pseudocode transcription of `Container.validate()`, pasted-code-plus-narration, verbatim error-message quotes (one already stale — it named `errors.INVALID_SCOPE_DEPENDENCY_ERROR`, a constant that doesn't exist), and re-explanations of behavior `docs/` already owns (now links). Spec: [`planning/changes/2026-07-07.04-architecture-halving.md`](https://github.com/modern-python/modern-di/blob/docs/architecture-halving/planning/changes/2026-07-07.04-architecture-halving.md).

**6,902 → 5,320 words (-23%).** Short of the spec's ~halving estimate by design: since the docstring cleanup (#280), `architecture/` is the sole home of the rationales removed from code, and the trim stopped where cuts risked losing them. An adversarial information-loss review verified all ten protected kernels survive intact (cycle-guard rationale, alias transitivity + edge cases, registry-sharing table, `set_context` staleness, pre-2.16 note, LIFO finalization, WiringPlan buckets, kwargs-bypass-validate, override-bypasses-scope-check, the resolution rule) and checked every deleted passage's survival claim against the named code symbol or docs page.

| file | before | after |
|---|---|---|
| validation.md | 1,536 | 1,027 |
| resolution.md | 1,303 | 998 |
| containers.md | 1,300 | 1,073 |
| providers.md | 1,166 | 997 |
| scopes.md | 707 | 473 |
| testing-and-overrides.md | 739 | 593 |

Gates: `just lint-ci` green; stale-constant grep empty; inbound links from `docs/` and `CLAUDE.md` verified.