### PR TITLE
feat: integration seams — add_providers and resolve_dependency (INT-1/INT-2)

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -67,7 +67,7 @@ The four registries split into two categories:
 
 | Registry | Shared across container tree? | Purpose |
 |---|---|---|
-| `ProvidersRegistry` | Yes — all containers share one instance | Maps `type → AbstractProvider`; populated once at root construction time from `groups`. |
+| `ProvidersRegistry` | Yes — all containers share one instance | Maps `type → AbstractProvider`; populated at root construction time from `groups`, and later via `Container.add_providers`. |
 | `OverridesRegistry` | Yes — all containers share one instance | Maps `provider_id → override object`; used by tests to substitute real instances. |
 | `CacheRegistry` | No — each container has its own | Maps `provider_id → CacheItem`; stores resolved singleton instances and the memoized `WiringPlan` for this scope level. |
 | `ContextRegistry` | No — each container has its own | Maps `type → runtime object`; populated via `context=` at construction or `container.set_context()` after the fact. |
@@ -75,6 +75,21 @@ The four registries split into two categories:
 Because `ProvidersRegistry` and `OverridesRegistry` are shared, registering a group or setting an
 override on any container in the tree is immediately visible to all other containers in the same
 tree.
+
+### Integration seam
+
+`add_providers` (registration) and `resolve_dependency` (provider-or-type
+dispatch) are the blessed integration seam — see
+[writing-integrations.md](../docs/integrations/writing-integrations.md).
+`add_providers` is **root-only**: called on a child, it raises
+`ChildContainerRegistrationError` (`modern_di/exceptions.py`), since the
+registry it mutates is shared tree-wide. `Container` tracks a private
+`_validated` flag, set once `validate()` succeeds (construction or a manual
+call); `add_providers` on an already-validated container re-runs `validate()`
+after registering and, if that fails, removes the just-added batch again —
+the container ends up either fully registered and valid, or unchanged.
+`resolve_dependency` carries no such restriction; it is a resolve verb,
+callable on any container regardless of validation state.
 
 ## `container_provider`
 

--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -62,7 +62,8 @@ resolution order).
 
 When a `Factory` is resolved, `WiringPlan.build` (in `modern_di/wiring.py`) iterates the parsed parameter map and
 partitions it into the plan; `Factory` then recurses into `container.resolve_provider(dep_provider)` for each matched
-provider. The plan is built once and memoized on the `CacheItem`. Resolution errors are annotated with a breadcrumb
+provider. The plan is memoized on the `CacheItem` and rebuilt when the providers-registry version has changed
+(i.e. after `add_providers`). Resolution errors are annotated with a breadcrumb
 describing the current factory, so the full chain appears in the exception.
 
 ### Static kwargs and `skip_creator_parsing`

--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -34,12 +34,14 @@ immediately. A `Factory` with no `cache_settings` always re-runs the creator.
 ## Step 4 — Wiring plan
 
 If no cached instance is returned, `Factory` builds the **wiring plan**: the partition of the creator's parameters by
-how each is satisfied. This is done once per container per provider via `_ensure_plan`, which stores a single
-`WiringPlan` on the `CacheItem` so subsequent calls (within the same container lifetime) reuse it.
+how each is satisfied. `_ensure_plan` memoizes a single `WiringPlan` on the `CacheItem`, stamped with the
+`ProvidersRegistry.version` it was built against; subsequent calls (within the same container lifetime) reuse it while
+that stamp matches the registry's current version, and rebuild it when the registry has changed (i.e. after
+`add_providers`).
 
 `WiringPlan.build` (in `modern_di/wiring.py`) is a **pure function** of `(parsed_kwargs, kwargs, providers_registry,
-owner)` — it reads no cache, scope, or live context, so it runs outside the container lock and never goes stale (the
-providers registry is fixed after construction). It is **type matching only**: it decides *which* provider (if any)
+owner)` — it reads no cache, scope, or live context, so it runs outside the container lock; the version stamp keeps the
+memoized result from going stale against a mutated registry. It is **type matching only**: it decides *which* provider (if any)
 backs each parameter, not what value that provider currently holds. It iterates `_parsed_kwargs` — the `SignatureItem`
 map produced at provider-declaration time by `types_parser.parse_creator` — and sorts each parameter:
 

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -63,6 +63,10 @@ Frameworks with a plugin system realize this differently: Litestar ships a
 instead of a free `setup_di` function. Prefer the framework's idiomatic
 extension point.
 
+`add_providers` is a startup-time operation: concurrent calls on the same root
+container are not coordinated beyond the registry's internal lock, so don't
+call it from request-handling code running alongside other registrations.
+
 ### 3. `fetch_di_container(app_or_ctx) -> Container`
 
 Read the root container back out of framework state. This is where the

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -52,8 +52,8 @@ startup/shutdown. Return the container.
 
 ```python
 def setup_di(app: myfw.App, container: Container) -> Container:
-    app.state.di_container = container                              # attach
-    container.providers_registry.add_providers(*_CONNECTION_PROVIDERS)  # register
+    app.state.di_container = container            # attach
+    container.add_providers(*_CONNECTION_PROVIDERS)  # register
     # wire lifecycle (see "Lifecycle rules" below)
     return container
 ```
@@ -135,17 +135,17 @@ class Dependency(typing.Generic[T_co]):
     dependency: providers.AbstractProvider[T_co] | type[T_co]
 
     async def __call__(self, request_container: typing.Annotated[Container, myfw.Depends(build_di_container)]) -> T_co:
-        if isinstance(self.dependency, providers.AbstractProvider):
-            return request_container.resolve_provider(self.dependency)
-        return request_container.resolve(dependency_type=self.dependency)
+        return request_container.resolve_dependency(self.dependency)
 
 
 def FromDI(dependency: providers.AbstractProvider[T_co] | type[T_co]) -> T_co:  # noqa: N802
     return typing.cast(T_co, myfw.Depends(Dependency(dependency)))
 ```
 
-The two dispatch arms are invariant across every integration and both modes:
-`resolve_provider` for an `AbstractProvider`, `resolve` for a bare type.
+The dispatch is a single call, invariant across every integration and both
+modes: `resolve_dependency` takes either an `AbstractProvider` or a bare type
+and routes to `resolve_provider`/`resolve` accordingly — overrides, caching,
+and did-you-mean suggestions are inherited from whichever it dispatches to.
 `FromDI` is spelled in PascalCase (with `# noqa: N802`) because it stands in for
 a type at call sites.
 
@@ -348,8 +348,8 @@ Each official integration is its own repository and PyPI package, mirroring the
 - [ ] Root container **reopens on startup** so restarts don't emit a
       `ContainerClosedWarning` (or, in 3.0, raise `ContainerClosedError`).
 - [ ] `close_async` / `close_sync` matches the framework's async-ness.
-- [ ] `FromDI` accepts `AbstractProvider[T] | type[T]` and dispatches
-      `resolve_provider` vs `resolve`.
+- [ ] `FromDI` accepts `AbstractProvider[T] | type[T]` and resolves it via
+      `resolve_dependency`.
 - [ ] **No native DI?** `FromDI` is an inert marker and a decorator rewrites the
       handler signature (strips DI params, threads the context object, sets
       `wrapper.__signature__`), resolves at call time, and closes the per-call

--- a/docs/providers/container.md
+++ b/docs/providers/container.md
@@ -67,6 +67,20 @@ The same holds for type-based injection: a creator with a `Container` parameter 
 container that is resolving it. This means request-scoped code reaches the request container (and its
 context/cache), while app-scoped code reaches the app container.
 
+## Registering providers after construction
+
+`container.add_providers(*providers)` registers additional providers on a **root** container after
+it's built — the blessed seam framework integrations use instead of reaching into
+`providers_registry` directly. Raises `ChildContainerRegistrationError` if called on a child
+container. See [Writing an integration](../integrations/writing-integrations.md#the-contract) for
+the full contract.
+
+## Resolving a provider or type
+
+`container.resolve_dependency(dep)` accepts either a provider reference or a type and dispatches to
+`resolve_provider` or `resolve` accordingly — the single entry point integrations use to resolve a
+`FromDI`-style marker. See [Writing an integration](../integrations/writing-integrations.md#the-contract).
+
 ## See also
 
 - **Context propagation** — how context values reach (and don't reach) a `ContextProvider` is

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -124,7 +124,8 @@ Catch `RegistrationError` for declaration- and registration-time problems.
 - **`ChildContainerRegistrationError`** — raised by `Container.add_providers()` when called on a child
   container; registration is root-only because the providers registry is shared tree-wide, so
   registering from a child would mutate every container in the tree. Call `add_providers` on the root
-  container instead. See [Container: registering after construction](container.md#registering-providers-after-construction).
+  container instead. Inspect `.scope` for the offending child container's scope. See
+  [Container: registering after construction](container.md#registering-providers-after-construction).
 - **`UnknownFactoryKwargError`** — raised when `Factory(kwargs={...})` contains a key that is not a
   parameter of the creator's signature; lists the known parameters and "did you mean" hints.
 - **`UnsupportedCreatorParameterError`** — raised when a creator's signature has a parameter

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -30,6 +30,7 @@ ModernDIError (RuntimeError)
 │   └── ContextValueNotSetError
 ├── RegistrationError
 │   ├── DuplicateProviderTypeError
+│   ├── ChildContainerRegistrationError
 │   ├── UnknownFactoryKwargError
 │   ├── UnsupportedCreatorParameterError
 │   └── InvalidScopeDependencyError
@@ -120,6 +121,10 @@ Catch `RegistrationError` for declaration- and registration-time problems.
 - **`DuplicateProviderTypeError`** — raised when two providers are registered for the same bound type
   (within one group, across groups passed together, or against an already-registered type). See
   [Troubleshooting: Duplicate type](../troubleshooting/duplicate-type-error.md).
+- **`ChildContainerRegistrationError`** — raised by `Container.add_providers()` when called on a child
+  container; registration is root-only because the providers registry is shared tree-wide, so
+  registering from a child would mutate every container in the tree. Call `add_providers` on the root
+  container instead. See [Container: registering after construction](container.md#registering-providers-after-construction).
 - **`UnknownFactoryKwargError`** — raised when `Factory(kwargs={...})` contains a key that is not a
   parameter of the creator's signature; lists the known parameters and "did you mean" hints.
 - **`UnsupportedCreatorParameterError`** — raised when a creator's signature has a parameter

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -81,6 +81,7 @@ class Container:
     __slots__ = (
         "_lock",
         "_scope_map",
+        "_validated",
         "cache_registry",
         "closed",
         "context_registry",
@@ -119,6 +120,7 @@ class Container:
                 allowed_scopes=[x.name for x in type(parent_container.scope) if x > parent_container.scope],
             )
         self._lock = threading.RLock() if use_lock else None
+        self._validated = False
         self.closed = False
         self.scope = scope
         self.parent_container = parent_container
@@ -278,6 +280,32 @@ class Container:
 
         if validation_errors:
             raise exceptions.ValidationFailedError(errors=validation_errors)
+        self._validated = True
+
+    def add_providers(self, *providers: AbstractProvider[typing.Any]) -> None:
+        """Register providers on this (root) container after construction.
+
+        This is the blessed seam for framework integrations that discover providers
+        after the container is built. Root-only: calling this on a child container
+        raises :class:`~modern_di.exceptions.ChildContainerRegistrationError`, since
+        the providers registry is shared tree-wide. If this container has already
+        been validated (via ``validate=True`` at construction or a manual
+        :meth:`validate` call), it is re-validated after registering, so a
+        newly-added provider that breaks the graph raises
+        :class:`~modern_di.exceptions.ValidationFailedError` here rather than later.
+        Atomic: if that re-validation fails, the whole batch is removed again —
+        either the batch is fully registered and valid, or the container is unchanged.
+        """
+        if self.parent_container is not None:
+            raise exceptions.ChildContainerRegistrationError
+        self.providers_registry.add_providers(*providers)
+        if self._validated:
+            try:
+                self.validate()
+            except exceptions.ValidationFailedError:
+                added_types = [provider.bound_type for provider in providers if provider.bound_type]
+                self.providers_registry.remove_providers(*added_types)
+                raise
 
     async def close_async(self) -> None:
         if not self.parent_container:

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -299,23 +299,26 @@ class Container:
         This is the blessed seam for framework integrations that discover providers
         after the container is built. Root-only: calling this on a child container
         raises :class:`~modern_di.exceptions.ChildContainerRegistrationError`, since
-        the providers registry is shared tree-wide. If this container has already
-        been validated (via ``validate=True`` at construction or a manual
-        :meth:`validate` call), it is re-validated after registering, so a
-        newly-added provider that breaks the graph raises
-        :class:`~modern_di.exceptions.ValidationFailedError` here rather than later.
-        Atomic: if that re-validation fails, the whole batch is removed again —
-        either the batch is fully registered and valid, or the container is unchanged.
+        the providers registry is shared tree-wide. If validation has run **on this
+        container** (via ``validate=True`` at construction or a manual :meth:`validate`
+        call — ``_validated`` is per-container, not inherited from a parent), it is
+        re-validated after registering, so a newly-added provider that breaks the
+        graph raises :class:`~modern_di.exceptions.ValidationFailedError` here rather
+        than later. Atomic: if that re-validation raises *any* exception, the whole
+        batch is removed again before the error propagates — either the batch is
+        fully registered and valid, or the container is unchanged. Registration is a
+        startup-time operation: concurrent ``add_providers`` calls on the same root
+        are not coordinated beyond the registry's internal lock.
         """
         if self.parent_container is not None:
-            raise exceptions.ChildContainerRegistrationError
+            raise exceptions.ChildContainerRegistrationError(scope=self.scope)
         self.providers_registry.add_providers(*providers)
         if self._validated:
             try:
                 self.validate()
-            except exceptions.ValidationFailedError:
+            except Exception:
                 added_types = [provider.bound_type for provider in providers if provider.bound_type]
-                self.providers_registry.remove_providers(*added_types)
+                self.providers_registry._remove_providers(*added_types)  # noqa: SLF001
                 raise
 
     async def close_async(self) -> None:

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -216,6 +216,17 @@ class Container:
 
         return self.resolve_provider(provider)
 
+    def resolve_dependency(self, dependency: "AbstractProvider[types.T] | type[types.T]") -> types.T:
+        """Resolve a provider reference or a type — the marker-dispatch entry point for integrations.
+
+        A provider argument goes to :meth:`resolve_provider`; a type argument goes to
+        :meth:`resolve`. Overrides, caching, and did-you-mean suggestions are inherited
+        from whichever of the two it dispatches to.
+        """
+        if isinstance(dependency, AbstractProvider):
+            return self.resolve_provider(dependency)
+        return self.resolve(dependency)
+
     def resolve_provider(self, provider: "AbstractProvider[types.T]") -> types.T:
         """Resolve a specific provider by reference (enforces closed-state and applies overrides)."""
         self._warn_and_reopen_if_closed()

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -356,15 +356,16 @@ class DuplicateProviderTypeError(RegistrationError):
 
 
 class ChildContainerRegistrationError(RegistrationError):
-    """``add_providers`` was called on a child container; registration is root-only."""
+    """``add_providers`` was called on a child container; registration is root-only. Inspect ``.scope``."""
 
-    __slots__ = ()
+    __slots__ = ("scope",)
 
-    def __init__(self) -> None:
+    def __init__(self, *, scope: enum.IntEnum) -> None:
+        self.scope = scope
         super().__init__(
-            "Container.add_providers can only be called on a root container: the providers "
-            "registry is shared tree-wide, so registering on a child would mutate every "
-            "container in the tree. Call add_providers on the root container instead."
+            f"Container.add_providers can only be called on a root container: the providers "
+            f"registry is shared tree-wide, so registering on a child container (scope {scope.name}) "
+            "would mutate every container in the tree. Call add_providers on the root container instead."
         )
 
 

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -355,6 +355,19 @@ class DuplicateProviderTypeError(RegistrationError):
         )
 
 
+class ChildContainerRegistrationError(RegistrationError):
+    """``add_providers`` was called on a child container; registration is root-only."""
+
+    __slots__ = ()
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Container.add_providers can only be called on a root container: the providers "
+            "registry is shared tree-wide, so registering on a child would mutate every "
+            "container in the tree. Call add_providers on the root container instead."
+        )
+
+
 class UnknownFactoryKwargError(RegistrationError):
     """Factory kwargs had unknown keys. Attrs: ``creator``, ``unknown_keys``, ``known_keys``, ``suggestions``."""
 

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -151,14 +151,18 @@ class Factory(AbstractProvider[types.T_co]):
 
     def _ensure_plan(self, container: "Container", cache_item: "CacheItem") -> WiringPlan:
         # Plan runs outside the container lock — safe under the GIL since it's a deterministic
-        # function of the fixed providers registry (free-threaded/nogil caveat: planning/deferred.md).
-        if cache_item.wiring_plan is None:
+        # function of the providers registry as of the version it was built against (free-threaded/nogil
+        # caveat: planning/deferred.md). The version stamp on the registry lets a stale memoized plan
+        # (built before a later Container.add_providers call) be detected and rebuilt.
+        current_version = container.providers_registry.version
+        if cache_item.wiring_plan is None or cache_item.wiring_plan_version != current_version:
             cache_item.wiring_plan = WiringPlan.build(
                 parsed_kwargs=self._parsed_kwargs,
                 kwargs=self._kwargs,
                 registry=container.providers_registry,
                 owner=self,
             )
+            cache_item.wiring_plan_version = current_version
         return cache_item.wiring_plan
 
     def _resolve_context_value(

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -16,6 +16,8 @@ class CacheItem:
     cache: typing.Any = types.UNSET
     finalized: bool = False
     wiring_plan: "WiringPlan | None" = None
+    # `ProvidersRegistry.version` the memoized `wiring_plan` was built against; see `Factory._ensure_plan`.
+    wiring_plan_version: int | None = None
 
     def _clear(self) -> None:
         if self.settings and self.settings.clear_cache:

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -24,17 +24,27 @@ def _hierarchy_hint(requested_type: type, provider: AbstractProvider[typing.Any]
 
 
 class ProvidersRegistry:
-    __slots__ = ("_lock", "_providers")
+    __slots__ = ("_lock", "_providers", "_version")
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._providers: dict[type, AbstractProvider[typing.Any]] = {}
+        self._version = 0
 
     def __len__(self) -> int:
         return len(self._providers)
 
     def __iter__(self) -> typing.Iterator[AbstractProvider[typing.Any]]:
         return iter(list(self._providers.values()))
+
+    @property
+    def version(self) -> int:
+        """Monotonically increasing counter, bumped on every mutation.
+
+        Lets memoized `WiringPlan`s (see `Factory._ensure_plan`) detect that the registry
+        changed underneath them and rebuild instead of resolving against a stale plan.
+        """
+        return self._version
 
     def find_provider(self, dependency_type: type[types.T]) -> AbstractProvider[types.T] | None:
         return self._providers.get(dependency_type)
@@ -44,6 +54,7 @@ class ProvidersRegistry:
             if provider_type in self._providers:
                 raise exceptions.DuplicateProviderTypeError(provider_type=provider_type)
             self._providers[provider_type] = provider
+            self._version += 1
 
     def add_providers(self, *args: AbstractProvider[typing.Any]) -> None:
         new_providers: dict[type, AbstractProvider[typing.Any]] = {}
@@ -59,11 +70,14 @@ class ProvidersRegistry:
                 if provider_type in self._providers:
                     raise exceptions.DuplicateProviderTypeError(provider_type=provider_type)
             self._providers.update(new_providers)
+            self._version += 1
 
-    def remove_providers(self, *provider_types: type) -> None:
+    def _remove_providers(self, *provider_types: type) -> None:
+        """Rollback helper for `Container.add_providers`; not part of the public API."""
         with self._lock:
             for provider_type in provider_types:
                 self._providers.pop(provider_type, None)
+            self._version += 1
 
     def build_suggestions(self, requested_type: type) -> list[str]:
         requested_is_class = inspect.isclass(requested_type)

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -60,6 +60,11 @@ class ProvidersRegistry:
                     raise exceptions.DuplicateProviderTypeError(provider_type=provider_type)
             self._providers.update(new_providers)
 
+    def remove_providers(self, *provider_types: type) -> None:
+        with self._lock:
+            for provider_type in provider_types:
+                self._providers.pop(provider_type, None)
+
     def build_suggestions(self, requested_type: type) -> list[str]:
         requested_is_class = inspect.isclass(requested_type)
         requested_name = getattr(requested_type, "__name__", str(requested_type))

--- a/planning/changes/2026-07-07.05-integration-seams.md
+++ b/planning/changes/2026-07-07.05-integration-seams.md
@@ -1,0 +1,99 @@
+---
+summary: INT-1 + INT-2 — Container.add_providers (root-only, auto re-validating) and Container.resolve_dependency (provider-or-type dispatch) as the blessed integration seams.
+---
+
+# Design: Integration seams — add_providers and resolve_dependency
+
+## Summary
+
+Two additive `Container` methods from the accepted 3.0 UX research rulings
+(INT-1, INT-2): `add_providers(*providers)` as the blessed post-construction
+registration verb (today all seven sibling integrations reach into
+`container.providers_registry`), and `resolve_dependency(dep)` as the single
+provider-or-type dispatch (today the same `isinstance` dispatch is
+copy-pasted in seven sibling packages). No breaking changes;
+`resolve`/`resolve_provider` untouched.
+
+## Motivation
+
+Research report items 11–12 (both verified): the registration seam is
+un-blessed internals access that contradicts `architecture/containers.md`'s
+"populated once at root construction", and the marker-dispatch contract
+lives in copy-paste across every integration. Precedents: .NET MEDI's
+extension-method seam on `IServiceCollection`; dishka/svcs routing ~24 and 5
+integrations respectively through one entry point. Landing these unblocks
+the sibling-repo migration and re-triggers the deferred INT-6 conformance
+suite (`planning/deferred.md`).
+
+## Design
+
+### `Container.add_providers(*providers: AbstractProvider) -> None`
+
+- Delegates to `ProvidersRegistry.add_providers` (existing duplicate-type
+  checks, intra-batch and against registered, both raising
+  `DuplicateProviderTypeError`).
+- **Root-only** (ruled): called on a child container it raises the new
+  `ChildContainerRegistrationError(RegistrationError)` — registration is a
+  composition-root activity; the registry is shared tree-wide and a child
+  call would mutate every container.
+- **Auto re-validate** (ruled): `Container` gains a private `_validated`
+  flag, set by `validate()` (both the constructor path and manual calls).
+  When `add_providers` runs on a validated container it re-runs
+  `validate()` after registering, so wiring errors surface at the
+  registration site — the seam stays correct under 3.0's
+  validate-by-default. **Atomic** (ruled): if that re-validation fails,
+  the just-added batch is removed again before the error propagates —
+  either the batch is fully registered and valid, or the container is
+  unchanged. Closes the open question recorded in
+  `2026-07-05.04-v3-bridges.md`.
+- Closed-container interaction: follows whatever `resolve` does today —
+  registration itself does not touch cache/lifecycle, so no closed-state
+  check (a provider added to a closed root simply resolves after reopen;
+  in 3.0 the closed root raises on resolve anyway).
+- `register_groups` deliberately skipped (ruled — YAGNI; groups are a
+  construction-time concept).
+
+### `Container.resolve_dependency(dep: AbstractProvider[T] | type[T]) -> T`
+
+- `isinstance(dep, AbstractProvider)` → `resolve_provider(dep)`, else
+  `resolve(dep)`. One place; overrides, scope checks, caching, and
+  did-you-mean suggestions inherited from the two existing paths.
+- Callable on any container (it is a resolve verb, not a registration one).
+
+### Promotions and docs
+
+- `architecture/containers.md`: registry-sharing text updated ("populated
+  at root construction **and via `add_providers`**"); a short "Integration
+  seam" note naming both verbs and the root-only + re-validate contract.
+- `docs/integrations/writing-integrations.md`: the integration spec
+  switches its registration and dispatch contract points to the new verbs
+  (reach-in examples replaced).
+- `docs/providers/errors-and-exceptions.md`: `ChildContainerRegistrationError`
+  catalog entry.
+- `docs/providers/container.md`: brief method mentions with links.
+
+## Non-goals
+
+- No sibling-repo changes here (their migration is per-repo follow-up work;
+  INT-6 conformance suite stays deferred until they migrate).
+- No privatization of `providers_registry` yet (research: "a later step").
+- No changes to `resolve`, `resolve_provider`, `override`, or validation
+  semantics beyond the `_validated` flag.
+
+## Testing
+
+TDD; `just test-ci` (100% line coverage) green; `just lint-ci` green;
+`just docs-build` green. New tests: registration via the verb resolves;
+duplicate raises; child call raises `ChildContainerRegistrationError`;
+validated-root re-validation catches a bad provider at the
+`add_providers` call site; unvalidated root does not validate;
+`resolve_dependency` dispatches both arms (provider and type) including
+override and suggestion behavior.
+
+## Risk
+
+- Re-validation cost on registration-heavy startups — negligible: validate
+  is static graph traversal, integrations register once at startup.
+- Semantic drift between `resolve_dependency` and sibling copy-paste during
+  the migration window — mitigated by the docs contract switch and the
+  eventual conformance suite.

--- a/planning/changes/2026-07-07.05-integration-seams.md
+++ b/planning/changes/2026-07-07.05-integration-seams.md
@@ -46,6 +46,17 @@ suite (`planning/deferred.md`).
   either the batch is fully registered and valid, or the container is
   unchanged. Closes the open question recorded in
   `2026-07-05.04-v3-bridges.md`.
+- **Rollback on any exception** (whole-branch review, ruled): the re-validate
+  try/except catches `Exception`, not just `ValidationFailedError`, so any
+  error raised while re-validating still rolls the batch back before
+  propagating.
+- **Stale `WiringPlan` rebuild** (whole-branch review, ruled): `ProvidersRegistry`
+  carries a monotonically increasing `version`, bumped under its lock on every
+  mutation and memoized alongside each `Factory`'s cached `WiringPlan`
+  (`CacheItem.wiring_plan_version`); `Factory._ensure_plan` rebuilds the plan
+  when the stamps differ, so a dependency registered via `add_providers` after
+  a dependent provider's first resolve is wired in on that provider's next
+  (non-cached) resolve instead of being stuck with the earlier plan.
 - Closed-container interaction: follows whatever `resolve` does today —
   registration itself does not touch cache/lifecycle, so no closed-state
   check (a provider added to a closed root simply resolves after reopen;
@@ -89,6 +100,15 @@ validated-root re-validation catches a bad provider at the
 `add_providers` call site; unvalidated root does not validate;
 `resolve_dependency` dispatches both arms (provider and type) including
 override and suggestion behavior.
+
+Whole-branch review fix wave added: a rollback test that stubs `validate()`
+to raise a plain `RuntimeError` (not `ValidationFailedError`) and asserts the
+batch is still removed; two version-stamp tests reproducing the stale-plan
+bug — an optional dependency silently left `None` and a required dependency
+raising `ArgumentResolutionError` — both resolved correctly once the missing
+provider is added via `add_providers` and the provider is resolved again; and
+a closed-root test pinning that `add_providers` registers successfully on a
+closed root with no closed-state check (ruled).
 
 ## Risk
 

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -6,8 +6,10 @@ Items intentionally not actioned in the current work, kept here so they aren't l
 
 `Factory._ensure_plan` builds the `WiringPlan` outside the container lock and publishes it to
 `cache_item.wiring_plan` (`modern_di/providers/factory.py`). Under the GIL this is safe: the plan is a
-deterministic function of the fixed providers registry, so two threads that both see
-`wiring_plan is None` build identical plans — at worst the work is repeated once — and the GIL ensures a
+deterministic function of the providers registry's state as of the version it was built against (a
+`ProvidersRegistry.version` stamp, bumped on every `register`/`add_providers`/removal, is memoized
+alongside the plan so a later registration invalidates it), so two threads that both see the same
+`wiring_plan_version` build identical plans — at worst the work is repeated once — and the GIL ensures a
 thread seeing a non-`None` `wiring_plan` also sees the fully-built (frozen) object.
 
 Under free-threaded CPython that publication guarantee is lost: without a memory barrier a reader could

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -660,6 +660,7 @@ def test_add_providers_on_child_container_raises() -> None:
     with pytest.raises(ChildContainerRegistrationError, match="root") as exc:
         child.add_providers(str_factory)
     assert isinstance(exc.value, exceptions.RegistrationError)
+    assert exc.value.scope is Scope.REQUEST
 
 
 def test_add_providers_on_validated_root_reraises_validation_failure() -> None:
@@ -775,6 +776,92 @@ def test_resolve_dependency_with_provider_returns_same_instance_as_resolve_provi
     via_dispatch = container.resolve_dependency(G.cached)
     via_resolve_provider = container.resolve_provider(G.cached)
     assert via_dispatch is via_resolve_provider
+
+
+def test_add_providers_rebuilds_stale_wiring_plan_for_optional_dependency() -> None:
+    """A memoized WiringPlan built before `add_providers` must not keep an optional dep as None."""
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Inner:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Outer:
+        inner: Inner | None = None
+
+    container = Container(scope=Scope.APP, validate=True)
+    outer_factory = providers.Factory(creator=Outer)  # not cached: second resolve rebuilds
+
+    first = container.resolve_provider(outer_factory)
+    assert first.inner is None
+
+    container.add_providers(providers.Factory(creator=Inner))
+
+    second = container.resolve_provider(outer_factory)
+    assert isinstance(second.inner, Inner)
+
+
+def test_add_providers_rebuilds_stale_wiring_plan_for_required_dependency() -> None:
+    """A memoized WiringPlan that recorded a required dep as unwireable must retry after registration."""
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Inner:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Outer:
+        inner: Inner
+
+    container = Container(scope=Scope.APP, validate=False)
+    outer_factory = providers.Factory(creator=Outer)
+
+    with pytest.raises(ArgumentResolutionError):
+        container.resolve_provider(outer_factory)
+
+    container.add_providers(providers.Factory(creator=Inner))
+
+    result = container.resolve_provider(outer_factory)
+    assert isinstance(result.inner, Inner)
+
+
+def test_add_providers_rolls_back_on_any_exception_from_revalidation() -> None:
+    """Rollback must not be tied to ValidationFailedError specifically — any exception rolls back."""
+    container = Container(scope=Scope.APP, validate=True)
+    str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
+
+    def _boom(_self: Container) -> None:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(Container, "validate", _boom)
+        with pytest.raises(RuntimeError, match="boom"):
+            container.add_providers(str_factory)
+
+    with pytest.raises(ProviderNotRegisteredError):
+        container.resolve(str)
+
+
+def test_add_providers_on_validated_root_with_valid_batch_succeeds() -> None:
+    """Positive branch: a validated root re-validates successfully and the batch resolves afterwards."""
+    container = Container(scope=Scope.APP, validate=True)
+    str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
+
+    container.add_providers(str_factory)
+
+    assert container.resolve(str) == "added"
+
+
+def test_add_providers_on_closed_root_registers_fine() -> None:
+    """Ruled: no closed-state check on add_providers — registering on a closed root just works."""
+    container = Container(scope=Scope.APP, validate=False)
+    container.close_sync()
+    str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
+
+    container.add_providers(str_factory)  # no ContainerClosedWarning: registration doesn't touch closed state
+
+    with pytest.warns(ContainerClosedWarning):
+        assert container.resolve(str) == "added"
 
 
 def test_resolve_dependency_with_type_returns_same_instance_as_resolve() -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -10,9 +10,11 @@ import pytest
 from modern_di import Container, Group, Scope, exceptions, providers
 from modern_di.exceptions import (
     ArgumentResolutionError,
+    ChildContainerRegistrationError,
     CircularDependencyError,
     ContainerClosedError,
     ContainerClosedWarning,
+    DuplicateProviderTypeError,
     InvalidChildScopeError,
     InvalidScopeDependencyError,
     InvalidScopeTypeError,
@@ -617,3 +619,149 @@ def test_unvalidated_warning_pyproject_filter_matches_live_message() -> None:
     assert pattern is not None, "no ignore:...:FutureWarning filter found in pyproject.toml filterwarnings"
 
     assert re.compile(pattern.group("message")).match(str(record[0].message)) is not None
+
+
+def test_add_providers_registers_and_resolves_by_type_and_reference() -> None:
+    container = Container(scope=Scope.APP, validate=False)
+    str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
+
+    container.add_providers(str_factory)
+
+    assert container.resolve(str) == "added"
+    assert container.resolve_provider(str_factory) == "added"
+
+
+def test_add_providers_raises_on_duplicate_against_registered() -> None:
+    str_factory = providers.Factory(creator=lambda: "one", bound_type=str)
+    other_str_factory = providers.Factory(creator=lambda: "two", bound_type=str)
+    container = Container(scope=Scope.APP, validate=False)
+    container.add_providers(str_factory)
+
+    with pytest.raises(DuplicateProviderTypeError) as exc:
+        container.add_providers(other_str_factory)
+    assert exc.value.provider_type is str
+
+
+def test_add_providers_raises_on_duplicate_intra_batch() -> None:
+    str_factory = providers.Factory(creator=lambda: "one", bound_type=str)
+    other_str_factory = providers.Factory(creator=lambda: "two", bound_type=str)
+    container = Container(scope=Scope.APP, validate=False)
+
+    with pytest.raises(DuplicateProviderTypeError) as exc:
+        container.add_providers(str_factory, other_str_factory)
+    assert exc.value.provider_type is str
+
+
+def test_add_providers_on_child_container_raises() -> None:
+    root = Container(scope=Scope.APP, validate=False)
+    child = root.build_child_container(scope=Scope.REQUEST)
+    str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
+
+    with pytest.raises(ChildContainerRegistrationError, match="root") as exc:
+        child.add_providers(str_factory)
+    assert isinstance(exc.value, exceptions.RegistrationError)
+
+
+def test_add_providers_on_validated_root_reraises_validation_failure() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Missing:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Broken:
+        missing: Missing
+
+    container = Container(scope=Scope.APP, validate=True)
+    broken_factory = providers.Factory(creator=Broken)
+
+    with pytest.raises(ValidationFailedError) as exc:
+        container.add_providers(broken_factory)
+    [issue] = exc.value.errors
+    assert isinstance(issue, ArgumentResolutionError)
+
+
+def test_add_providers_on_validate_false_root_does_not_validate() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Missing:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Broken:
+        missing: Missing
+
+    container = Container(scope=Scope.APP, validate=False)
+    broken_factory = providers.Factory(creator=Broken)
+
+    container.add_providers(broken_factory)  # should not raise
+
+
+def test_add_providers_on_unset_validate_root_does_not_validate() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Missing:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Broken:
+        missing: Missing
+
+    with pytest.warns(exceptions.UnvalidatedContainerWarning):
+        container = Container(scope=Scope.APP)
+    broken_factory = providers.Factory(creator=Broken)
+
+    container.add_providers(broken_factory)  # should not raise
+
+
+def test_add_providers_rolls_back_whole_batch_when_revalidation_fails() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Original:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Inner:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Outer:
+        inner: Inner
+
+    class G(Group):
+        original = providers.Factory(creator=Original)
+
+    container = Container(scope=Scope.APP, groups=[G], validate=True)
+
+    valid_factory = providers.Factory(creator=lambda: "ok", bound_type=str)
+    inner_factory = providers.Factory(scope=Scope.REQUEST, creator=Inner)
+    outer_factory = providers.Factory(scope=Scope.APP, creator=Outer)  # scope-invalid: APP depends on REQUEST
+
+    with pytest.raises(ValidationFailedError):
+        container.add_providers(valid_factory, inner_factory, outer_factory)
+
+    # the whole batch rolled back, including the valid providers
+    with pytest.raises(ProviderNotRegisteredError):
+        container.resolve(str)
+    with pytest.raises(ProviderNotRegisteredError):
+        container.resolve(Inner)
+    with pytest.raises(ProviderNotRegisteredError):
+        container.resolve(Outer)
+    # the container is unchanged: original providers still resolve and the graph is still valid
+    assert isinstance(container.resolve(Original), Original)
+    container.validate()
+
+
+def test_add_providers_after_manual_validate_reraises_validation_failure() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Missing:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Broken:
+        missing: Missing
+
+    container = Container(scope=Scope.APP, validate=False)
+    container.validate()  # manual call also sets the flag
+    broken_factory = providers.Factory(creator=Broken)
+
+    with pytest.raises(ValidationFailedError) as exc:
+        container.add_providers(broken_factory)
+    [issue] = exc.value.errors
+    assert isinstance(issue, ArgumentResolutionError)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -765,3 +765,69 @@ def test_add_providers_after_manual_validate_reraises_validation_failure() -> No
         container.add_providers(broken_factory)
     [issue] = exc.value.errors
     assert isinstance(issue, ArgumentResolutionError)
+
+
+def test_resolve_dependency_with_provider_returns_same_instance_as_resolve_provider() -> None:
+    class G(Group):
+        cached = providers.Factory(creator=lambda: "value", bound_type=str, cache=True)
+
+    container = Container(groups=[G])
+    via_dispatch = container.resolve_dependency(G.cached)
+    via_resolve_provider = container.resolve_provider(G.cached)
+    assert via_dispatch is via_resolve_provider
+
+
+def test_resolve_dependency_with_type_returns_same_instance_as_resolve() -> None:
+    class G(Group):
+        cached = providers.Factory(creator=lambda: "value", bound_type=str, cache=True)
+
+    container = Container(groups=[G])
+    via_dispatch = container.resolve_dependency(str)
+    via_resolve = container.resolve(str)
+    assert via_dispatch is via_resolve
+
+
+def test_resolve_dependency_with_provider_returns_override() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Service:
+        name: str = "original"
+
+    class G(Group):
+        app_factory = providers.Factory(creator=Service)
+
+    container = Container(groups=[G])
+    override = Service(name="override")
+    container.override(G.app_factory, override)
+
+    assert container.resolve_dependency(G.app_factory) is override
+
+
+def test_resolve_dependency_with_unregistered_type_raises_with_suggestion() -> None:
+    class Database:
+        pass
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class PostgresDatabase(Database):
+        pass
+
+    class G(Group):
+        db = providers.Factory(creator=PostgresDatabase)
+
+    container = Container(groups=[G])
+    with pytest.raises(ProviderNotRegisteredError) as exc_info:
+        container.resolve_dependency(Database)
+
+    exc = exc_info.value
+    assert exc.provider_type is Database
+    assert exc.suggestions == ["  - PostgresDatabase (registered subclass, scope=APP)"]
+
+
+def test_resolve_dependency_works_on_child_container_for_both_arms() -> None:
+    class G(Group):
+        request_factory = providers.Factory(scope=Scope.REQUEST, creator=lambda: "value", bound_type=str)
+
+    app_container = Container(groups=[G])
+    request_container = app_container.build_child_container(scope=Scope.REQUEST)
+
+    assert request_container.resolve_dependency(str) == "value"
+    assert request_container.resolve_dependency(G.request_factory) == "value"


### PR DESCRIPTION
The two blessed integration seams from the accepted 3.0 UX research rulings. Spec: [`planning/changes/2026-07-07.05-integration-seams.md`](https://github.com/modern-python/modern-di/blob/feat/integration-seams/planning/changes/2026-07-07.05-integration-seams.md).

- **`Container.add_providers(*providers)`** (INT-1): the post-construction registration verb all seven sibling integrations currently reach into `container.providers_registry` for. Root-only (`ChildContainerRegistrationError`, with `.scope`); on a validated container it re-validates so wiring errors surface at the registration site; **atomic** — any exception from re-validation rolls the batch back.
- **`Container.resolve_dependency(dep)`** (INT-2): the provider-or-type dispatch seven siblings copy-paste, now one core entry point; overrides, caching, and did-you-mean behavior inherited.
- **Registry version-stamped wiring plans:** review caught (with repro) that memoized `WiringPlan`s went stale after post-construction registration — a provider resolved before `add_providers` kept its old plan silently. Plans now carry the registry version and rebuild when it changes, so registration is correct in every ordering.
- Docs: `writing-integrations.md` contract points switched to the new verbs; error-catalog entry; `architecture/containers.md`/`resolution.md`/`providers.md` promoted in-PR.

Rulings applied (maintainer): root-only, auto re-validate, atomic rollback, no `register_groups`, version-stamp over docs-only ordering constraint, `except Exception` rollback breadth.

Follow-up (not this PR): sibling-repo migration onto the seams, then the deferred INT-6 conformance suite.

Gates: `just test-ci` 296 passed / 100% coverage, `just lint-ci` green, `just docs-build` green. All TDD (red-first evidence per behavior).