### PR TITLE
docs(release): 2.25.0 notes — integration seams and version-stamped plans

### DIFF
--- a/planning/releases/2.25.0.md
+++ b/planning/releases/2.25.0.md
@@ -1,0 +1,68 @@
+# modern-di 2.25.0 — blessed integration seams: add_providers and resolve_dependency
+
+Back-compatible: no behavior flips, no new warnings. `Container` gains the two
+methods framework integrations have been reaching into internals for — a
+post-construction registration verb and a provider-or-type resolve dispatch —
+plus a correctness fix that makes registration safe in any order relative to
+resolution.
+
+## Feature
+
+- **`Container.add_providers(*providers)`.** The blessed way for integrations
+  (and applications) to register providers after the container is built —
+  previously only possible by reaching into `container.providers_registry`.
+  Root-only: called on a child container it raises the new
+  `ChildContainerRegistrationError` (inspect `.scope`), because registries are
+  shared tree-wide. On a container that has validated (constructed with
+  `validate=True`, or after a manual `validate()`), the batch is re-validated
+  immediately, so wiring errors surface at the registration site — and the
+  call is **atomic**: if re-validation fails for any reason, the whole batch
+  is rolled back and the container is exactly as it was.
+- **`Container.resolve_dependency(dep)`.** One entry point that accepts a
+  provider *or* a type and dispatches to `resolve_provider`/`resolve` —
+  the `isinstance` dance every integration's marker handling re-implements
+  today, now in core. Overrides, caching, scope checks, and "did you mean"
+  suggestions behave exactly as on the underlying paths.
+
+## Fix
+
+- **Wiring plans rebuild after registration.** A provider's memoized wiring
+  plan is now stamped with the providers-registry version and rebuilt when
+  registration has changed the registry. Previously, a provider resolved
+  *before* a later registration kept its stale plan silently — an optional
+  dependency stayed `None`, a missing required one kept raising
+  `ArgumentResolutionError` even after its provider was registered. This
+  affected the old `providers_registry` reach-in path too.
+
+## Why
+
+INT-1 and INT-2 from the 2026-07-05 3.0 UX research: all seven official
+integrations reach two attributes deep to register context providers, and all
+seven copy-paste the same marker dispatch. Blessing both as `Container`
+methods gives the 3.0 surface a stable integration contract (and, per .NET /
+dishka precedent, one place for its semantics). Registration on a validated
+container re-validating by default keeps the seam correct under 3.0's
+validate-at-construction.
+
+## Downstream
+
+No floor bump required — the `providers_registry` reach-in keeps working in
+2.x. Integrations **should migrate** to `add_providers` /
+`resolve_dependency` (and bump their floor to `modern-di>=2.25` when they
+do); the reach-in path is slated for privatization after the org-wide
+migration. The
+[writing-integrations spec](https://modern-di.modern-python.org/integrations/writing-integrations/)
+already documents the new contract points.
+
+## Internals
+
+- Docs site deduplicated: every core concept now has one canonical page with
+  links elsewhere; the historical 0.x→1.x and 1.x→2.x guides are condensed.
+  Two stub pages merged away (`testing/fixtures`,
+  `introduction/that-depends-or-modern-di` — their URLs now 404; content
+  lives in `integrations/pytest` and `introduction/comparison`).
+- Docstring policy pass over the package: internal helpers carry one-line
+  contracts; two stale references to long-removed functions fixed. No
+  behavior change.
+- 100% line coverage maintained across Python 3.10–3.14; `ruff` and `ty`
+  clean; docs built under `mkdocs --strict` in CI.


### PR DESCRIPTION
Release notes for 2.25.0 (used verbatim as the GitHub Release body): the INT-1/INT-2 seams (#283), the wiring-plan version-stamp fix, and the docs-sweep internals. Tag follows merge.