### PR TITLE
docs(roadmap): mark taskiq shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,13 +18,12 @@ item, or want to build one, please open or comment in
 
 ### More official integrations — "one wiring, every entrypoint"
 Each new entrypoint lets your existing container cover more of your stack.
-Already shipped: aiohttp, FastAPI, Litestar, FastStream, Starlette, Typer
-(plus the `modern-di-pytest` plugin). The gap below is drawn from Dishka's
-integration set and sorted by community demand — exploratory, not a queue.
+Already shipped: aiohttp, FastAPI, Litestar, FastStream, Starlette, taskiq,
+Typer (plus the `modern-di-pytest` plugin). The gap below is drawn from
+Dishka's integration set and sorted by community demand — exploratory, not a
+queue.
 
 **Next up — highest demand, clear fit:**
-- **Taskiq** — async task queue; sync resolution fits cleanly (resolve deps
-  synchronously inside an async task).
 - **Celery** — the largest task-queue install base in Python.
 - **aiogram** — dominant async Telegram-bot framework; a new entrypoint class.
 


### PR DESCRIPTION
`modern-di-taskiq` **2.0.0** is now published on PyPI
([repo](https://github.com/modern-python/modern-di-taskiq),
[PyPI](https://pypi.org/project/modern-di-taskiq/)), so this updates the
ROADMAP to reflect reality:

- Adds **taskiq** to the "Already shipped" integrations line.
- Removes **Taskiq** from the "Next up" tier (Celery and aiogram remain the top items).

Docs-only. Companion usage-page PR: #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)