### PR TITLE
docs(roadmap): mark aiogram shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,14 +18,13 @@ item, or want to build one, please open or comment in
 
 ### More official integrations — "one wiring, every entrypoint"
 Each new entrypoint lets your existing container cover more of your stack.
-Already shipped: aiohttp, FastAPI, Litestar, FastStream, Starlette, taskiq,
-Typer (plus the `modern-di-pytest` plugin). The gap below is drawn from
+Already shipped: aiogram, aiohttp, FastAPI, Litestar, FastStream, Starlette,
+taskiq, Typer (plus the `modern-di-pytest` plugin). The gap below is drawn from
 Dishka's integration set and sorted by community demand — exploratory, not a
 queue.
 
 **Next up — highest demand, clear fit:**
 - **Celery** — the largest task-queue install base in Python.
-- **aiogram** — dominant async Telegram-bot framework; a new entrypoint class.
 
 **Second wave — high value:**
 - **Flask** — enormous WSGI install base; its sync model fits sync resolution.


### PR DESCRIPTION
`modern-di-aiogram` **2.0.0** is now published on PyPI
([repo](https://github.com/modern-python/modern-di-aiogram),
[PyPI](https://pypi.org/project/modern-di-aiogram/)), so this updates the
ROADMAP to reflect reality:

- Adds **aiogram** to the "Already shipped" integrations line.
- Removes **aiogram** from the "Next up" tier (Celery remains the top item).

Docs-only. Companion usage-page PR: #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)