### PR TITLE
docs(roadmap): mark Celery shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,15 +18,12 @@ item, or want to build one, please open or comment in
 
 ### More official integrations — "one wiring, every entrypoint"
 Each new entrypoint lets your existing container cover more of your stack.
-Already shipped: aiogram, aiohttp, FastAPI, Litestar, FastStream, Starlette,
-taskiq, Typer (plus the `modern-di-pytest` plugin). The gap below is drawn from
-Dishka's integration set and sorted by community demand — exploratory, not a
-queue.
+Already shipped: aiogram, aiohttp, Celery, FastAPI, Litestar, FastStream,
+Starlette, taskiq, Typer (plus the `modern-di-pytest` plugin). The gap below is
+drawn from Dishka's integration set and sorted by community demand —
+exploratory, not a queue.
 
 **Next up — highest demand, clear fit:**
-- **Celery** — the largest task-queue install base in Python.
-
-**Second wave — high value:**
 - **Flask** — enormous WSGI install base; its sync model fits sync resolution.
 - **arq** — async Redis task/job queue, common in FastAPI stacks.
 - **gRPC** (`grpcio`) — steady enterprise demand; a new RPC entrypoint.


### PR DESCRIPTION
`modern-di-celery` **2.0.0** is now published on PyPI
([repo](https://github.com/modern-python/modern-di-celery),
[PyPI](https://pypi.org/project/modern-di-celery/)), so this updates the ROADMAP:

- Adds **Celery** to the "Already shipped" integrations line.
- Removes **Celery** from "Next up" and promotes the former "Second wave"
  (Flask, arq, gRPC) to the new "Next up" tier.

Docs-only. Companion usage-page PR: #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)