### PR TITLE
docs(roadmap): mark Flask shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,13 +18,12 @@ item, or want to build one, please open or comment in
 
 ### More official integrations — "one wiring, every entrypoint"
 Each new entrypoint lets your existing container cover more of your stack.
-Already shipped: aiogram, aiohttp, Celery, FastAPI, Litestar, FastStream,
+Already shipped: aiogram, aiohttp, Celery, FastAPI, FastStream, Flask, Litestar,
 Starlette, taskiq, Typer (plus the `modern-di-pytest` plugin). The gap below is
 drawn from Dishka's integration set and sorted by community demand —
 exploratory, not a queue.
 
 **Next up — highest demand, clear fit:**
-- **Flask** — enormous WSGI install base; its sync model fits sync resolution.
 - **arq** — async Redis task/job queue, common in FastAPI stacks.
 - **gRPC** (`grpcio`) — steady enterprise demand; a new RPC entrypoint.
 


### PR DESCRIPTION
`modern-di-flask` **2.0.0** is now published on PyPI
([repo](https://github.com/modern-python/modern-di-flask),
[PyPI](https://pypi.org/project/modern-di-flask/)), so this updates the ROADMAP:

- Adds **Flask** to the "Already shipped" integrations line (and tidies that line to alphabetical order).
- Removes **Flask** from "Next up" (arq and gRPC remain).

Docs-only. Companion usage-page PR: #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)