### PR TITLE
docs(roadmap): mark arq shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,13 +18,12 @@ item, or want to build one, please open or comment in
 
 ### More official integrations — "one wiring, every entrypoint"
 Each new entrypoint lets your existing container cover more of your stack.
-Already shipped: aiogram, aiohttp, Celery, FastAPI, FastStream, Flask, Litestar,
-Starlette, taskiq, Typer (plus the `modern-di-pytest` plugin). The gap below is
+Already shipped: aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask,
+Litestar, Starlette, taskiq, Typer (plus the `modern-di-pytest` plugin). The gap below is
 drawn from Dishka's integration set and sorted by community demand —
 exploratory, not a queue.
 
 **Next up — highest demand, clear fit:**
-- **arq** — async Redis task/job queue, common in FastAPI stacks.
 - **gRPC** (`grpcio`) — steady enterprise demand; a new RPC entrypoint.
 
 **Lower / niche demand:**


### PR DESCRIPTION
`modern-di-arq` 2.0.0 is [live on PyPI](https://pypi.org/project/modern-di-arq/) and its [repo](https://github.com/modern-python/modern-di-arq) is public with green CI. This moves **arq** from "Next up" into the shipped integrations list; **gRPC** remains the next entrypoint under consideration.

Usage docs land in #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)