### PR TITLE
docs(roadmap): mark gRPC shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,12 +19,9 @@ item, or want to build one, please open or comment in
 ### More official integrations — "one wiring, every entrypoint"
 Each new entrypoint lets your existing container cover more of your stack.
 Already shipped: aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask,
-Litestar, Starlette, taskiq, Typer (plus the `modern-di-pytest` plugin). The gap below is
-drawn from Dishka's integration set and sorted by community demand —
-exploratory, not a queue.
-
-**Next up — highest demand, clear fit:**
-- **gRPC** (`grpcio`) — steady enterprise demand; a new RPC entrypoint.
+gRPC, Litestar, Starlette, taskiq, Typer (plus the `modern-di-pytest` plugin).
+The gap below is drawn from Dishka's integration set and sorted by community
+demand — exploratory, not a queue.
 
 **Lower / niche demand:**
 - **aiogram-dialog** — aiogram addon; only after aiogram lands.


### PR DESCRIPTION
`modern-di-grpc` 2.0.0 is [live on PyPI](https://pypi.org/project/modern-di-grpc/) and its [repo](https://github.com/modern-python/modern-di-grpc) is public with green CI. This moves **gRPC** into the shipped integrations list.

With both **arq** and **gRPC** now shipped, the "Next up — highest demand, clear fit" tier is empty, so this removes that subsection; the remaining exploratory gap is the lower/niche-demand and community-maintained candidates.

Usage docs land in #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)