### PR TITLE
Import providers by concrete submodule, not the package __init__

### DIFF
--- a/modern_di/providers/container_provider.py
+++ b/modern_di/providers/container_provider.py
@@ -1,6 +1,6 @@
 import typing
 
-from modern_di.providers import AbstractProvider
+from modern_di.providers.abstract import AbstractProvider
 from modern_di.scope import Scope
 
 

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -3,7 +3,7 @@ import typing
 import warnings
 
 from modern_di import exceptions, types
-from modern_di.providers import AbstractProvider
+from modern_di.providers.abstract import AbstractProvider
 
 
 if typing.TYPE_CHECKING:

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -5,8 +5,8 @@ import typing
 import warnings
 
 from modern_di import exceptions, suggester, types
-from modern_di.providers import ContextProvider
 from modern_di.providers.abstract import AbstractProvider
+from modern_di.providers.context_provider import ContextProvider
 from modern_di.types_parser import SignatureItem, parse_creator
 from modern_di.wiring import WiringPlan, _Absent, absent_disposition
 

--- a/modern_di/wiring.py
+++ b/modern_di/wiring.py
@@ -10,8 +10,8 @@ import dataclasses
 import enum
 import typing
 
-from modern_di.providers import ContextProvider
 from modern_di.providers.abstract import AbstractProvider
+from modern_di.providers.context_provider import ContextProvider
 from modern_di.types import UNSET
 from modern_di.types_parser import SignatureItem
 

--- a/planning/changes/2026-07-13.01-providers-concrete-imports.md
+++ b/planning/changes/2026-07-13.01-providers-concrete-imports.md
@@ -1,0 +1,56 @@
+---
+summary: The providers import chain (providers/*.py + wiring.py) imports siblings by concrete submodule instead of from the still-executing modern_di.providers package __init__, so the package's statement order is no longer load-bearing; an AST guard test pins the invariant.
+---
+
+# Change: Import providers by concrete submodule, not the package __init__
+
+**Lane:** lightweight — four one-line import swaps plus one guard test. Each
+edit is mechanical; kept in this lane despite the file count because no logic,
+signature, or capability contract moves.
+
+## Goal
+
+Remove a latent import-order fragility: four modules that load *while*
+`modern_di/providers/__init__.py` is still executing reach back into the
+half-initialized package (`from modern_di.providers import ...`). It works only
+because `__init__` happens to bind `AbstractProvider`/`ContextProvider` before
+`factory`, and because the top-level `__init__` eagerly imports `container`
+first. Neither ordering is marked as load-bearing.
+
+## Approach
+
+Import siblings by their concrete module instead of the package:
+
+- `providers/container_provider.py`, `providers/context_provider.py` — `from
+  modern_di.providers import AbstractProvider` → `from
+  modern_di.providers.abstract import AbstractProvider`.
+- `providers/factory.py`, `wiring.py` — `from modern_di.providers import
+  ContextProvider` → `from modern_di.providers.context_provider import
+  ContextProvider`.
+
+External consumers outside the chain (e.g. `registries/cache_registry.py`) keep
+using the package API — they load after the package is fully initialized, so
+they are unaffected and unrestricted.
+
+A new AST guard in `tests/test_packaging.py` walks `providers/*.py` + `wiring.py`
+and fails on any `from modern_di.providers import ...` (level-0, package
+exactly), pinning the invariant so the fragility cannot silently return.
+
+No `architecture/` capability contract changes (this is import hygiene, not a
+behavior change). Sourced from candidate 2 of the 2026-07-12 architecture review.
+
+## Files
+
+- `modern_di/providers/container_provider.py` — concrete `AbstractProvider` import
+- `modern_di/providers/context_provider.py` — concrete `AbstractProvider` import
+- `modern_di/providers/factory.py` — concrete `ContextProvider` import
+- `modern_di/wiring.py` — concrete `ContextProvider` import
+- `tests/test_packaging.py` — AST guard test added
+
+## Verification
+
+- [x] Failing test first — guard reports `['container_provider.py:3', 'context_provider.py:6', 'factory.py:8', 'wiring.py:13']`.
+- [x] Apply the four import swaps.
+- [x] Guard test passes; `import modern_di.providers.factory` (submodule-first) succeeds.
+- [x] `just test-ci` — 359 passed, 100% coverage.
+- [x] `just lint-ci` — clean.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,5 +1,35 @@
+import ast
+import pathlib
 import subprocess
 import sys
+
+import modern_di
+
+
+_PKG_ROOT = pathlib.Path(modern_di.__file__).parent
+
+
+def _providers_chain_files() -> list[pathlib.Path]:
+    """Modules that load while `modern_di.providers/__init__` is still executing."""
+    return [*sorted((_PKG_ROOT / "providers").glob("*.py")), _PKG_ROOT / "wiring.py"]
+
+
+def test_provider_layer_imports_concrete_modules_not_the_package() -> None:
+    """Providers-chain modules must import siblings by concrete submodule, not the package.
+
+    Modules that load while `modern_di/providers/__init__` is still executing (providers/*.py
+    and wiring.py) must not `from modern_di.providers import ...`: that back-references a
+    half-initialized `__init__` and only works because of the statement order there. Pinning
+    concrete-module imports keeps that order from being load-bearing. External consumers
+    (e.g. `registries/`) may still use the package API — they load after it is initialized.
+    """
+    offenders = [
+        f"{path.name}:{node.lineno}"
+        for path in _providers_chain_files()
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module == "modern_di.providers"
+    ]
+    assert not offenders, f"import from the providers package __init__ (use a concrete submodule): {offenders}"
 
 
 def test_modern_di_imports_without_typing_extensions() -> None:


### PR DESCRIPTION
Candidate 2 from the 2026-07-12 architecture review: removes a latent import-order fragility in the providers layer. Rationale in the change file:

- [`planning/changes/2026-07-13.01-providers-concrete-imports.md`](planning/changes/2026-07-13.01-providers-concrete-imports.md)

## What changed

Four modules that load *while* `modern_di/providers/__init__.py` is still executing (`container_provider`, `context_provider`, `factory`, `wiring`) imported siblings from the half-initialized package (`from modern_di.providers import ...`). It worked only because of the statement order in `__init__.py` plus the eager `container` import in the top-level `__init__` — neither marked load-bearing. Now they import concrete submodules (`modern_di.providers.abstract` / `.context_provider`).

An AST guard in `tests/test_packaging.py` walks `providers/*.py` + `wiring.py` and fails on any package-level `from modern_di.providers import ...`, so the fragility can't silently return. External consumers (e.g. `registries/cache_registry.py`) keep using the package API — they load after the package is fully initialized.

No behavior change, no `architecture/` capability contract moves.

## Verification

- `just test-ci` — 359 passed, 100% coverage.
- `just lint-ci` / `just check-planning` — clean.
- Guard test RED before (4 offenders) → GREEN after; `import modern_di.providers.factory` (submodule-first) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
