### PR TITLE
Add modern_di.integrations — the framework-agnostic integration kit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Where the detail lives — read the matching capability file before changing beh
 | [architecture/resolution.md](architecture/resolution.md) | how `resolve()` wires deps from type hints |
 | [architecture/validation.md](architecture/validation.md) | `validate()` cycle + scope checks |
 | [architecture/testing-and-overrides.md](architecture/testing-and-overrides.md) | overrides + the `modern-di-pytest` integration |
+| [architecture/integration-kit.md](architecture/integration-kit.md) | framework-agnostic primitives for building an integration adapter |
 
 ### Key files
 

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -20,6 +20,8 @@ These files carry **no frontmatter** — they are prose, dated by git.
 - [validation.md](validation.md) — `validate()` cycle and scope checks.
 - [testing-and-overrides.md](testing-and-overrides.md) — overrides and the
   `modern-di-pytest` integration.
+- [integration-kit.md](integration-kit.md) — framework-agnostic primitives for
+  building a framework integration adapter.
 
 ## Promotion rule
 

--- a/architecture/glossary.md
+++ b/architecture/glossary.md
@@ -1,0 +1,23 @@
+# Glossary
+
+The project's ubiquitous language — the domain terms that code, specs, and
+capability pages share. Living prose, no frontmatter, dated by git. Each entry is
+a term, what it *is* (not what it does), and the synonyms to avoid. No
+implementation detail; this is a glossary, not a spec.
+
+**Connection**:
+The framework-specific object a unit of work carries — an HTTP request, a
+broker message, a CLI invocation's context. Not every unit of work has one (a
+Typer command's underlying callable does not).
+_Avoid_: request (too HTTP-specific — a broker message is also a connection)
+
+**Connection match**:
+A child container's derived `scope` and `context`, produced by binding a
+connection to one `ContextProvider`. See
+[integration-kit.md](integration-kit.md).
+
+**Integration kit**:
+The framework-agnostic primitives (`modern_di.integrations`) an integration
+adapter composes to derive connection scope/context and to run the
+`Annotated`-marker injector, instead of hand-rolling either. See
+[integration-kit.md](integration-kit.md).

--- a/architecture/integration-kit.md
+++ b/architecture/integration-kit.md
@@ -1,0 +1,76 @@
+# Integration Kit
+
+Framework-agnostic primitives for building a **modern-di integration** — the
+shared skeleton every framework adapter (FastAPI, Starlette, gRPC, ...) needs,
+extracted so it has one home instead of thirteen. Lives in
+`modern_di/integrations.py`. See
+[docs/integrations/writing-integrations.md](../docs/integrations/writing-integrations.md)
+for the user-facing spec an integration author follows; this page is the
+capability's truth home.
+
+## Layer 1 — connection derivation
+
+`ConnectionMatch(scope, context)` pairs a child container's intended scope with
+the context dict `build_child_container(context=...)` expects.
+
+`bind(provider, connection) -> ConnectionMatch` derives both from one
+`ContextProvider` and one connection object: `scope=provider.scope`,
+`context={provider.context_type: connection}`. Neither `bind` nor
+`classify_connection` calls `build_child_container` itself — the caller's own
+call stays the single, un-wrapped way to open a child; these functions only
+decide what to pass it.
+
+`classify_connection(connection, providers) -> ConnectionMatch | None` is
+isinstance-over-tuple dispatch built on `bind`: the first provider whose
+`context_type` `connection` is an instance of wins. Returns `None` — never
+raises — on no match, matching every dispatch adapter's existing fallback of
+opening an auto-scoped, context-less child.
+
+Not every adapter's shape fits either primitive. A single-connection-kind
+adapter with no context to inject (a CLI command) has nothing to derive and
+calls `build_child_container(scope=...)` directly. A multi-provider fan-in that
+merges several providers' context into one child at a hardcoded scope (rather
+than deriving scope from any one of them) also bypasses both — see
+[decisions/2026-07-13-integration-kit-shape.md](../planning/decisions/2026-07-13-integration-kit-shape.md)
+for which adapters land where.
+
+## Layer 2 — the `Annotated` marker injector
+
+`Marker(dependency)` is what `resolve_dependency` should resolve for one
+`Annotated[T, marker]` parameter; `dependency` is an `AbstractProvider` or a
+bare type, exactly `resolve_dependency`'s own accepted shape.
+`Marker.resolve(container)` resolves it — the shape every native-DI
+integration's own per-parameter resolver (`Dependency.__call__`) already had,
+now shared instead of duplicated per adapter.
+
+`from_di(dependency) -> T` is the default `Marker` factory —
+`Annotated[T, from_di(dep)]` type-checks as `T` via `typing.cast`. Integrations
+with their own per-handler injection seam (FastAPI's `Depends`, Litestar's
+`Provide`) define their own factory that wraps a `Marker` instead; the rest
+re-export `from_di` verbatim as their public `FromDI`.
+
+`parse_markers(func) -> dict[str, Marker]` scans `func`'s `Annotated`
+parameter hints once, at decoration time, and returns every parameter whose
+metadata holds a `Marker` — the first one found per parameter, `return` never
+scanned. `resolve_markers(container, markers) -> dict[str, Any]` resolves each
+by name. Together these are the `_parse_inject_params`/resolve pair that was
+duplicated near-verbatim across every integration without native DI.
+
+## Double-wrap guard
+
+`is_injected(func)` / `mark_injected(wrapper)` read and set one shared
+attribute flag (`__modern_di_injected__`). An adapter whose auto-inject sweep
+can visit the same handler twice (a shared view function registered under two
+routes, a handler re-wrapped on plugin re-init) marks it on first wrap and
+skips on the next. Adapters with no auto-inject sweep — a single `@inject` per
+handler is never applied twice — have no need for either.
+
+## What stays per-adapter
+
+Root-container lifecycle (open/close, where it's attached to framework state),
+where the per-connection child is stashed and read back, `close_sync` vs
+`close_async`, and any handler-signature rewriting (stripping a parameter,
+inserting a context object) are irreducibly framework-specific and are not
+part of this module. See
+[docs/integrations/writing-integrations.md](../docs/integrations/writing-integrations.md)
+for the full contract an integration implements around these primitives.

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -300,7 +300,7 @@ either way.
 
 - **Decoration time** — the decorator introspects
   `typing.get_type_hints(func, include_extras=True)`, finds parameters whose
-  `Annotated` metadata holds a `_FromDI`, then **rewrites the signature**:
+  `Annotated` metadata holds a `Marker`, then **rewrites the signature**:
   *remove* those parameters (so the arg parser never treats them as CLI options)
   and *insert* the framework's context parameter (`typer.Context`) at position 0
   if the handler didn't declare one. Assign the cleaned signature to
@@ -329,7 +329,7 @@ strips **only** the marked ones; everything else still reaches the parser.
 
 | Contract point | Native DI | Decorator |
 |---|---|---|
-| `FromDI` returns | framework marker (`Depends` / `Provide`) | inert `_FromDI` marker |
+| `FromDI` returns | framework marker (`Depends` / `Provide`) | inert `Marker` |
 | Child container built by | framework, via your resolver | the decorator wrapper |
 | Handler receives value via | framework's DI | signature rewrite + fill-by-name at call time |
 | Root-container access | connection object passed in | framework's per-call context, injected into the signature if absent |

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -146,12 +146,59 @@ def FromDI(dependency: providers.AbstractProvider[T_co] | type[T_co]) -> T_co:  
     return typing.cast(T_co, myfw.Depends(Dependency(dependency)))
 ```
 
+`Dependency.__call__`'s body — `return request_container.resolve_dependency(self.dependency)`
+— is `modern_di.integrations.Marker.resolve`. Hold a `Marker` instead of a
+hand-rolled dataclass:
+
+```python
+from modern_di import integrations
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class Dependency(typing.Generic[T_co]):
+    marker: integrations.Marker[T_co]
+
+    async def __call__(self, request_container: typing.Annotated[Container, myfw.Depends(build_di_container)]) -> T_co:
+        return self.marker.resolve(request_container)
+
+
+def FromDI(dependency: providers.AbstractProvider[T_co] | type[T_co]) -> T_co:  # noqa: N802
+    return typing.cast(T_co, myfw.Depends(Dependency(integrations.Marker(dependency))))
+```
+
 The dispatch is a single call, invariant across every integration and both
 modes: `resolve_dependency` takes either an `AbstractProvider` or a bare type
 and routes to `resolve_provider`/`resolve` accordingly — overrides, caching,
 and did-you-mean suggestions are inherited from whichever it dispatches to.
 `FromDI` is spelled in PascalCase (with `# noqa: N802`) because it stands in for
 a type at call sites.
+
+### Deriving scope and context with the integration kit
+
+The isinstance loop above is `modern_di.integrations.classify_connection`.
+Use it instead of hand-rolling the loop:
+
+```python
+from modern_di import integrations
+
+async def build_di_container(connection: HTTPConnection) -> typing.AsyncIterator[Container]:
+    match = integrations.classify_connection(connection, _CONNECTION_PROVIDERS)
+    container = fetch_di_container(connection.app).build_child_container(
+        scope=match.scope if match else None,
+        context=match.context if match else None,
+    )
+    try:
+        yield container
+    finally:
+        await container.close_async()
+```
+
+For a single connection kind with no dispatch to do, call `integrations.bind`
+directly instead: `match = integrations.bind(my_provider, connection)`. Some
+adapters have nothing to derive at all (a CLI command with no connection
+object) and call `build_child_container(scope=...)` directly, with no
+integration-kit call in the middle — see
+[architecture/integration-kit.md](https://github.com/modern-python/modern-di/blob/main/architecture/integration-kit.md)
+for which shape fits which adapter.
 
 ## Lifecycle rules
 
@@ -243,9 +290,9 @@ either way.
 
 ### How it works
 
-- **`FromDI` is inert.** It returns a frozen `_FromDI(provider)` dataclass, cast
-  to the resolved type so checkers still see `T`. On its own it does nothing; the
-  decorator interprets it.
+- **`FromDI` is inert.** Returns `integrations.from_di(dependency)` — a
+  `Marker` cast to the resolved type so checkers still see `T`. On its own it
+  does nothing; the decorator interprets it.
 
   ```python
   service: typing.Annotated[MyService, FromDI(Dependencies.service)]
@@ -259,6 +306,15 @@ either way.
   if the handler didn't declare one. Assign the cleaned signature to
   `wrapper.__signature__` — the parser reads that, and `functools.wraps` alone
   won't set it.
+
+- **Use the integration kit instead of hand-rolling the scan and resolve.**
+  `integrations.parse_markers(func)` is the decoration-time scan;
+  `integrations.resolve_markers(container, markers)` is the call-time resolve.
+  Both are framework-agnostic — only the signature-rewriting and
+  argument-binding around them (below) is yours to write. If your adapter
+  sweeps an existing app/router to auto-inject handlers (rather than one
+  `@inject` per handler), guard against double-wrapping with
+  `integrations.is_injected(func)` / `integrations.mark_injected(wrapper)`.
 
 - **Call time** — bind incoming args against the rewritten signature, pull out
   the context object (deleting it again if the decorator added it implicitly),
@@ -353,7 +409,8 @@ Each official integration is its own repository and PyPI package, mirroring the
       `ContainerClosedWarning` (or, in 3.0, raise `ContainerClosedError`).
 - [ ] `close_async` / `close_sync` matches the framework's async-ness.
 - [ ] `FromDI` accepts `AbstractProvider[T] | type[T]` and resolves it via
-      `resolve_dependency`.
+      `resolve_dependency` — use `modern_di.integrations.from_di` (or a
+      factory wrapping `integrations.Marker`) rather than hand-rolling it.
 - [ ] **No native DI?** `FromDI` is an inert marker and a decorator rewrites the
       handler signature (strips DI params, threads the context object, sets
       `wrapper.__signature__`), resolves at call time, and closes the per-call

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -99,12 +99,15 @@ depends on how the framework runs handlers:
               context[provider.context_type] = connection
               scope = provider.scope
               break
-      container = fetch_di_container(connection.app).build_child_container(context=context, scope=scope)
-      try:
+      async with fetch_di_container(connection.app).build_child_container(context=context, scope=scope) as container:
           yield container
-      finally:
-          await container.close_async()
   ```
+
+  `Container` implements both sync and async context-manager protocols
+  (`__enter__`/`__exit__`, `__aenter__`/`__aexit__`) — `async with`/`with` on a
+  freshly built child opens it (a no-op, since a new child is already open) and
+  closes it on exit, equivalent to a `try`/`finally` around `close_async`/`close_sync`
+  but without hand-writing it.
 
 - **Middleware** (FastStream) — a `BaseMiddleware` whose `consume_scope` builds
   the child, stashes it in the framework context for the duration of the call,
@@ -182,14 +185,11 @@ from modern_di import integrations
 
 async def build_di_container(connection: HTTPConnection) -> typing.AsyncIterator[Container]:
     match = integrations.classify_connection(connection, _CONNECTION_PROVIDERS)
-    container = fetch_di_container(connection.app).build_child_container(
+    async with fetch_di_container(connection.app).build_child_container(
         scope=match.scope if match else None,
         context=match.context if match else None,
-    )
-    try:
+    ) as container:
         yield container
-    finally:
-        await container.close_async()
 ```
 
 For a single connection kind with no dispatch to do, call `integrations.bind`

--- a/modern_di/__init__.py
+++ b/modern_di/__init__.py
@@ -1,4 +1,4 @@
-from modern_di import exceptions
+from modern_di import exceptions, integrations
 from modern_di.container import Container
 from modern_di.group import Group
 from modern_di.scope import Scope
@@ -9,5 +9,6 @@ __all__ = [
     "Group",
     "Scope",
     "exceptions",
+    "integrations",
     "providers",
 ]

--- a/modern_di/integrations.py
+++ b/modern_di/integrations.py
@@ -74,3 +74,28 @@ def from_di(dependency: "AbstractProvider[types.T] | type[types.T]") -> types.T:
     define their own factory instead; the rest re-export this one.
     """
     return typing.cast(types.T, Marker(dependency))
+
+
+def parse_markers(func: typing.Callable[..., typing.Any]) -> dict[str, Marker[typing.Any]]:
+    """Scan `func`'s `Annotated` parameter hints for `Marker`s.
+
+    Call once at decoration time, not per call. The first `Marker` found in a
+    parameter's metadata wins; `return` is never scanned. Unresolvable forward
+    references propagate `get_type_hints`'s own error unchanged.
+    """
+    hints = typing.get_type_hints(func, include_extras=True)
+    markers: dict[str, Marker[typing.Any]] = {}
+    for name, hint in hints.items():
+        if name == "return":
+            continue
+        if typing.get_origin(hint) is typing.Annotated:
+            for meta in typing.get_args(hint)[1:]:
+                if isinstance(meta, Marker):
+                    markers[name] = meta
+                    break
+    return markers
+
+
+def resolve_markers(container: "Container", markers: typing.Mapping[str, Marker[typing.Any]]) -> dict[str, typing.Any]:
+    """Resolve every marker in `markers` from `container`, keyed by parameter name."""
+    return {name: marker.resolve(container) for name, marker in markers.items()}

--- a/modern_di/integrations.py
+++ b/modern_di/integrations.py
@@ -17,6 +17,9 @@ import typing
 from modern_di import types
 
 
+_INJECTED_ATTR = "__modern_di_injected__"
+
+
 if typing.TYPE_CHECKING:
     from modern_di.container import Container
     from modern_di.providers.abstract import AbstractProvider
@@ -99,3 +102,13 @@ def parse_markers(func: typing.Callable[..., typing.Any]) -> dict[str, Marker[ty
 def resolve_markers(container: "Container", markers: typing.Mapping[str, Marker[typing.Any]]) -> dict[str, typing.Any]:
     """Resolve every marker in `markers` from `container`, keyed by parameter name."""
     return {name: marker.resolve(container) for name, marker in markers.items()}
+
+
+def is_injected(func: typing.Callable[..., typing.Any]) -> bool:
+    """Whether `mark_injected` has already been applied to `func`."""
+    return bool(getattr(func, _INJECTED_ATTR, False))
+
+
+def mark_injected(wrapper: typing.Callable[..., typing.Any]) -> None:
+    """Mark `wrapper` as already injected, so a later sweep skips re-wrapping it."""
+    setattr(wrapper, _INJECTED_ATTR, True)

--- a/modern_di/integrations.py
+++ b/modern_di/integrations.py
@@ -34,3 +34,18 @@ def bind(provider: "ContextProvider[typing.Any]", connection: object) -> Connect
     `build_child_container(context=...)` expects.
     """
     return ConnectionMatch(scope=provider.scope, context={provider.context_type: connection})
+
+
+def classify_connection(
+    connection: object, providers: "tuple[ContextProvider[typing.Any], ...]"
+) -> ConnectionMatch | None:
+    """Pick the first provider `connection` is an instance of and `bind` it.
+
+    Returns `None` on no match rather than raising — the caller decides the
+    fallback, matching every dispatch adapter's existing behavior of building
+    an auto-scoped, context-less child when nothing matches.
+    """
+    for provider in providers:
+        if isinstance(connection, provider.context_type):
+            return bind(provider, connection)
+    return None

--- a/modern_di/integrations.py
+++ b/modern_di/integrations.py
@@ -14,8 +14,12 @@ import dataclasses
 import enum
 import typing
 
+from modern_di import types
+
 
 if typing.TYPE_CHECKING:
+    from modern_di.container import Container
+    from modern_di.providers.abstract import AbstractProvider
     from modern_di.providers.context_provider import ContextProvider
 
 
@@ -49,3 +53,24 @@ def classify_connection(
         if isinstance(connection, provider.context_type):
             return bind(provider, connection)
     return None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Marker(typing.Generic[types.T_co]):
+    """What `resolve_dependency` should resolve for one `Annotated` parameter."""
+
+    dependency: "AbstractProvider[types.T_co] | type[types.T_co]"
+
+    def resolve(self, container: "Container") -> types.T_co:
+        """Resolve this marker's dependency from `container`."""
+        return container.resolve_dependency(self.dependency)
+
+
+def from_di(dependency: "AbstractProvider[types.T] | type[types.T]") -> types.T:
+    """Marker factory for dependency injection.
+
+    Default factory: `Annotated[T, from_di(dep)]` type-checks as `T`.
+    Integrations with their own per-handler injection seam (native `Depends`)
+    define their own factory instead; the rest re-export this one.
+    """
+    return typing.cast(types.T, Marker(dependency))

--- a/modern_di/integrations.py
+++ b/modern_di/integrations.py
@@ -1,0 +1,36 @@
+"""Framework-agnostic primitives for building a modern-di integration.
+
+Layer 1 (`bind`, `classify_connection`) derives a child container's scope and
+context from one or more `ContextProvider`s. Neither wraps
+`build_child_container` — the caller's own call to it stays the single
+blessed way to open a child; these functions only decide what to pass it.
+Layer 2 (`Marker`, `from_di`, `parse_markers`, `resolve_markers`) is the
+`Annotated`-marker injector shared by every integration without a native
+per-handler injection seam. `is_injected`/`mark_injected` guard against
+double-wrapping a handler an auto-inject sweep visits more than once.
+"""
+
+import dataclasses
+import enum
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from modern_di.providers.context_provider import ContextProvider
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ConnectionMatch:
+    """A child container's scope and context, derived from one connection."""
+
+    scope: enum.IntEnum
+    context: dict[type[typing.Any], typing.Any]
+
+
+def bind(provider: "ContextProvider[typing.Any]", connection: object) -> ConnectionMatch:
+    """Derive a child's scope and context from one connection bound to one provider.
+
+    `context` is keyed by `provider.context_type` — the same convention
+    `build_child_container(context=...)` expects.
+    """
+    return ConnectionMatch(scope=provider.scope, context={provider.context_type: connection})

--- a/planning/changes/2026-07-13.02-integration-kit.md
+++ b/planning/changes/2026-07-13.02-integration-kit.md
@@ -1,0 +1,127 @@
+---
+summary: Extract the framework-agnostic adapter skeleton into a core integration kit; the 13 integrations shrink to thin framework glue.
+---
+
+# Design: Integration kit for framework adapters
+
+## Summary
+
+The 13 framework integrations (fastapi, starlette, litestar, aiohttp, flask,
+typer, grpc, celery, arq, taskiq, aiogram, faststream, plus pytest) each
+re-implement the same framework-agnostic skeleton: an annotation-scanning
+injector and a per-request child-container lifecycle. This change extracts that
+skeleton into a new **framework-agnostic module inside `modern-di` core** (two
+low-level primitives), so each adapter drops to thin, genuinely
+framework-specific glue. Zero new runtime dependencies; no user-facing change to
+any adapter's public API.
+
+## Motivation
+
+The duplication is measured, not abstract:
+
+- `_parse_inject_params` + the `_FromDI` marker are **copied near-verbatim in 8
+  adapters** (aiohttp, starlette, flask, typer, grpc, celery, arq, aiogram) —
+  ~40 lines each. typer's marker even names its field `provider` while the other
+  seven use `dependency`, a gratuitous divergence.
+- The `build_di_container` child generator is **copied in 3** (fastapi, litestar,
+  taskiq), line-for-line but for the connection type.
+- `_compose_lifespan` is **copied in 2** (fastapi, starlette).
+- The isinstance scope-dispatch loop is **copied in 3** (fastapi, starlette,
+  litestar).
+
+The shared logic imports nothing but stdlib + `modern_di` — it is agnostic, yet
+it has no home, so it rots in 13 places. Testability suffers too: grpc's inject
+tests import private internals (`_build_child`, `_request_container`) because the
+wiring is entangled with the interceptor, and every Family-B adapter re-tests its
+own copy of the same skeleton.
+
+## Design
+
+A new agnostic module in core, `modern_di.integrations`, exports:
+
+- **Layer 1 — child derivation** (never wraps `build_child_container` itself —
+  that stays the caller's direct call): `ConnectionMatch(scope, context)`;
+  `bind(provider, connection) -> ConnectionMatch` derives scope+context from one
+  `ContextProvider`; `classify_connection(connection, providers) -> ConnectionMatch
+  | None` is isinstance-over-tuple dispatch built on `bind`, returning `None`
+  (never raising) on no match — a faithful translation of every dispatch
+  adapter's current silent fallback.
+- **Layer 2 — inject**: `Marker(dependency)` with a `.resolve(container)` method
+  (the shape already shared, byte-for-byte, by every native-DI adapter's
+  `Dependency.__call__`); `from_di(dependency) -> T`, the default marker factory;
+  `parse_markers(func)` (the `Annotated`-hint scan duplicated in 8 adapters);
+  `resolve_markers(container, markers)`; `is_injected`/`mark_injected`, the
+  `__modern_di_injected__` double-wrap guard duplicated in flask/celery/aiogram.
+
+Each adapter keeps its public `FromDI`/`setup_di`/`inject`/`fetch_di_container`
+exported unchanged, now built by composing the primitives.
+
+**Public `FromDI` stays per-adapter** for the four native-DI adapters (they must
+wrap the framework's own `Depends`/`Provide`); the other seven non-native-DI
+adapters that hand-roll `_FromDI` today re-export the kit's `from_di` verbatim.
+
+**Only typer fully bypasses Layer 1** — it binds no connection at all. aiohttp
+and grpc use `bind()` for scope+context derivation (grpc's `_build_child` drops
+its post-hoc `set_context` call entirely) even though neither uses
+`classify_connection` — aiohttp because both its providers share one type
+(isinstance can't distinguish), grpc because it has exactly one provider, no
+dispatch needed. aiogram's multi-provider context merge doesn't fit `bind()`
+either and stays a two-line literal. No primitive grows adapter-specific
+parameters to absorb these; see
+[decisions/2026-07-13-integration-kit-shape.md](../decisions/2026-07-13-integration-kit-shape.md).
+
+**Docs.** `docs/integrations/writing-integrations.md` is the literal spec a new
+integration author follows; its contract points 4–5 currently quote the
+hand-rolled pattern as the reference implementation. Update it to teach the kit
+primitives **in the kit's own shipping PR** — not deferred to adapter
+conversions, since a new adapter author reads this the moment the kit exists,
+regardless of how many of the 13 have converted. Each adapter's row in the
+"How the existing integrations realize the contract" table updates in that
+adapter's own conversion PR. Once the last non-outlier adapter converts, delete
+the old hand-rolled code blocks (the isinstance-loop snippet, the
+`_FromDI`/`_parse_inject_params` walkthrough) rather than leaving two parallel
+paths.
+
+**Rollout:** ship the kit in a `modern-di` release; then convert one adapter per
+PR — starlette first (richest non-native-DI skeleton, exercises both layers),
+fastapi second (proves Layer 1 stands alone). Each conversion raises that repo's
+`modern-di>=` floor and swaps internals only. New domain terms (**integration
+kit**, **connection match**, **connection provider**) promote into a new
+`architecture/integration-kit.md` and `architecture/glossary.md` in the PR that
+lands the kit.
+
+## Non-goals
+
+- High-level convenience factories (`make_inject`, a child context-manager) —
+  rejected as shallow; see the decision record.
+- `bind`/`classify_connection` growing adapter-specific parameters (a scope
+  override, a post-build hook) to absorb typer/aiogram's shapes — rejected;
+  those stay direct `build_child_container` calls or literal dicts.
+- A separate `modern-di-integrations` package — rejected; the kit is agnostic and
+  core is the universal dependency, so a 14th repo buys only coordinated-release
+  cost.
+- Candidate 5 (`container.is_registered` seam for grpc's registry drill) — related
+  but a distinct change.
+- Any change to Family A's reliance on the framework's own `Depends`.
+
+## Testing
+
+- The primitives get one interface-level suite in `modern-di` — agnostic, so no
+  app is needed. `just test-ci` (100% line coverage) is the gate.
+- Each converted adapter drops its now-redundant skeleton unit tests and keeps
+  only its real-seam integration test (spin up the real framework, assert a
+  handler resolves a dep) — which covers the glue that actually varies.
+- Signal that grpc's entanglement is gone: `test_inject.py` no longer imports
+  `_build_child` / `_request_container`.
+
+## Risk
+
+- **Wrong interface, discovered late** (med likelihood × med impact). Mitigated
+  by one-adapter-per-PR: a flaw surfaces on starlette before the other 12 commit,
+  and the kit can still flex.
+- **Cross-repo version-floor coordination** (high likelihood × low impact). The
+  kit must ship in a `modern-di` release before any adapter can import it; adapter
+  PRs bump the floor. Sequencing only, no breakage — public symbols are stable, so
+  an un-migrated adapter keeps working on its old floor.
+- **Coverage gate on new core module** (low × low). The kit's agnostic primitives
+  are straightforward to cover through their interface.

--- a/planning/changes/2026-07-13.02-integration-kit.md
+++ b/planning/changes/2026-07-13.02-integration-kit.md
@@ -1,5 +1,5 @@
 ---
-summary: Extract the framework-agnostic adapter skeleton into a core integration kit; the 13 integrations shrink to thin framework glue.
+summary: Add modern_di.integrations (bind/classify_connection, Marker/from_di/parse_markers/resolve_markers, is_injected/mark_injected); adapter conversions are separate follow-up PRs.
 ---
 
 # Design: Integration kit for framework adapters

--- a/planning/decisions/2026-07-13-integration-kit-shape.md
+++ b/planning/decisions/2026-07-13-integration-kit-shape.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+summary: Integration kit lives in core as low-level primitives; outliers bypass rather than the primitive absorbing them.
+supersedes: null
+superseded_by: null
+---
+
+# Integration kit is low-level primitives in core, and outliers bypass it
+
+**Decision:** Extract the shared adapter skeleton into a framework-agnostic
+module inside `modern-di` core, exposing only low-level primitives; genuine
+outliers call core's `build_child_container` directly rather than the primitives
+growing parameters to swallow them. See the design in
+[changes/2026-07-13.02-integration-kit.md](../changes/2026-07-13.02-integration-kit.md).
+
+## Context
+
+The 13 integrations duplicate a framework-agnostic skeleton (annotation-scanning
+injector + per-request child lifecycle). Options on the table for each axis:
+
+- **Home:** core module · new `modern-di-integrations` package · status quo.
+- **Interface width:** low-level primitives only · two-tier (primitives + a
+  `make_inject`/child-context-manager convenience layer).
+- **Outliers** (aiohttp websocket probe, grpc `set_context` split, typer
+  no-context): bypass the kit · primitive absorbs them via extra parameters.
+
+## Decision & rationale
+
+- **In core, not a new package.** The skeleton imports only stdlib + `modern_di`,
+  so it doesn't threaten core's zero-dependency stance, and it deepens the same
+  `add_providers`/`resolve_dependency` seam core already blesses. A 14th repo
+  would add coordinated-release cost for agnostic code every adapter already
+  reaches via its `modern-di` dependency.
+- **Low-level primitives only.** A `make_inject` convenience fails the deletion
+  test: the adapters' wrapper shapes are *not* identical (each fetches the child
+  differently — request, ASGI scope, `g`, contextvar), so the convenience must
+  take a `get_container` callable and just wraps three primitives — a shallow
+  module, exactly what the extraction exists to remove.
+- **Outliers bypass.** Each absorbing parameter (scope-resolver callable,
+  post-build `set_context` hook, no-context mode) is needed by exactly one
+  adapter — a hypothetical seam, not a real one. Adding them taxes the 10
+  common-case adapters and lowers depth. The outliers already call
+  `build_child_container` (the real blessed primitive) directly; keeping the weird
+  logic in the weird adapter is better locality.
+
+## Addendum (2026-07-13): "bypass" is narrower than first assumed
+
+Reading all 13 adapters concretely (not just the 4 sampled at design time)
+showed only **typer** is a true Layer-1 bypass — it binds no connection at all.
+aiohttp and grpc both use `bind(provider, connection)` for scope+context
+derivation; they only skip `classify_connection` (aiohttp because both its
+providers share one type, so isinstance can't dispatch; grpc because it has one
+provider and no dispatch to do). grpc's `_build_child` collapses to one `bind()`
+call, dropping its post-hoc `set_context` entirely. aiogram's context is a
+multi-provider merge with a hardcoded scope — a third shape `bind()` doesn't fit
+either, so it stays a two-line literal, but for a different reason than typer's
+(no connection to bind) or aiohttp's (dispatch, not derivation, is the
+mismatch). The **decision stands** — no primitive grew parameters to absorb any
+of these — the correction is only which adapters end up calling which
+primitive.
+
+## Revisit trigger
+
+A third adapter needs the same non-isinstance scope-dispatch (making the
+"absorb it" seam real, two-adapters rule), or the convenience layer is requested
+by adapter authors because the residual `inject` glue proves non-trivial in
+practice.

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,5 +1,15 @@
+import typing
+
 from modern_di import Container, Group, Scope, providers
-from modern_di.integrations import ConnectionMatch, Marker, bind, classify_connection, from_di
+from modern_di.integrations import (
+    ConnectionMatch,
+    Marker,
+    bind,
+    classify_connection,
+    from_di,
+    parse_markers,
+    resolve_markers,
+)
 
 
 class _Request:
@@ -70,3 +80,53 @@ def test_classify_connection_first_provider_wins_on_ambiguous_match() -> None:
     match = classify_connection(conn, (base_provider, sub_provider))
 
     assert match == ConnectionMatch(scope=Scope.REQUEST, context={_Request: conn})
+
+
+def test_parse_markers_finds_annotated_marker_params() -> None:
+    marker = Marker(_Service)
+
+    def handler(a: int, b: typing.Annotated[_Service, marker], *, c: str = "x") -> None:
+        pass  # pragma: no cover
+
+    assert parse_markers(handler) == {"b": marker}
+
+
+def test_parse_markers_skips_return_annotation() -> None:
+    marker = Marker(_Service)
+
+    def handler() -> typing.Annotated[_Service, marker]:
+        raise NotImplementedError  # pragma: no cover
+
+    assert parse_markers(handler) == {}
+
+
+def test_parse_markers_first_marker_wins_per_parameter() -> None:
+    first = Marker(_Service)
+    second: Marker[int] = Marker(int)
+
+    def handler(a: typing.Annotated[_Service, first, second]) -> None:
+        pass  # pragma: no cover
+
+    assert parse_markers(handler) == {"a": first}
+
+
+def test_parse_markers_returns_empty_dict_when_no_markers() -> None:
+    def handler(a: int) -> None:
+        pass  # pragma: no cover
+
+    assert parse_markers(handler) == {}
+
+
+def test_resolve_markers_resolves_each_marker_by_name() -> None:
+    container = Container(groups=[_Deps], validate=True)
+    markers = {"service": Marker(_Service)}
+
+    resolved = resolve_markers(container, markers)
+
+    assert isinstance(resolved["service"], _Service)
+
+
+def test_resolve_markers_empty_input_returns_empty_dict() -> None:
+    container = Container(groups=[_Deps], validate=True)
+
+    assert resolve_markers(container, {}) == {}

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,5 +1,5 @@
 from modern_di import Scope, providers
-from modern_di.integrations import ConnectionMatch, bind
+from modern_di.integrations import ConnectionMatch, bind, classify_connection
 
 
 class _Request:
@@ -13,3 +13,36 @@ def test_bind_derives_scope_and_context_from_provider() -> None:
     match = bind(provider, connection)
 
     assert match == ConnectionMatch(scope=Scope.REQUEST, context={_Request: connection})
+
+
+class _WebSocket:
+    pass
+
+
+def test_classify_connection_dispatches_to_first_isinstance_match() -> None:
+    request_provider = providers.ContextProvider(_Request, scope=Scope.REQUEST)
+    websocket_provider = providers.ContextProvider(_WebSocket, scope=Scope.SESSION)
+    ws = _WebSocket()
+
+    match = classify_connection(ws, (request_provider, websocket_provider))
+
+    assert match == ConnectionMatch(scope=Scope.SESSION, context={_WebSocket: ws})
+
+
+def test_classify_connection_returns_none_when_nothing_matches() -> None:
+    request_provider = providers.ContextProvider(_Request, scope=Scope.REQUEST)
+
+    assert classify_connection(object(), (request_provider,)) is None
+
+
+def test_classify_connection_first_provider_wins_on_ambiguous_match() -> None:
+    class _Sub(_Request):
+        pass
+
+    base_provider = providers.ContextProvider(_Request, scope=Scope.REQUEST)
+    sub_provider = providers.ContextProvider(_Sub, scope=Scope.SESSION)
+    conn = _Sub()
+
+    match = classify_connection(conn, (base_provider, sub_provider))
+
+    assert match == ConnectionMatch(scope=Scope.REQUEST, context={_Request: conn})

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -145,3 +145,9 @@ def test_mark_injected_then_is_injected_round_trips() -> None:
 
 def test_is_injected_defaults_false_for_unmarked_callable() -> None:
     assert is_injected(lambda: None) is False
+
+
+def test_integrations_accessible_from_top_level_namespace() -> None:
+    import modern_di  # noqa: PLC0415
+
+    assert modern_di.integrations.bind is bind

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,5 +1,5 @@
-from modern_di import Scope, providers
-from modern_di.integrations import ConnectionMatch, bind, classify_connection
+from modern_di import Container, Group, Scope, providers
+from modern_di.integrations import ConnectionMatch, Marker, bind, classify_connection, from_di
 
 
 class _Request:
@@ -27,6 +27,30 @@ def test_classify_connection_dispatches_to_first_isinstance_match() -> None:
     match = classify_connection(ws, (request_provider, websocket_provider))
 
     assert match == ConnectionMatch(scope=Scope.SESSION, context={_WebSocket: ws})
+
+
+class _Service:
+    pass
+
+
+class _Deps(Group):
+    service = providers.Factory(creator=_Service, scope=Scope.APP)
+
+
+def test_marker_resolve_delegates_to_container_resolve_dependency() -> None:
+    container = Container(groups=[_Deps], validate=True)
+    marker: Marker[_Service] = Marker(_Service)
+
+    resolved = marker.resolve(container)
+
+    assert isinstance(resolved, _Service)
+
+
+def test_from_di_returns_a_marker_cast_as_the_dependency_type() -> None:
+    result = from_di(_Service)
+
+    assert isinstance(result, Marker)
+    assert result.dependency is _Service
 
 
 def test_classify_connection_returns_none_when_nothing_matches() -> None:

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -7,6 +7,8 @@ from modern_di.integrations import (
     bind,
     classify_connection,
     from_di,
+    is_injected,
+    mark_injected,
     parse_markers,
     resolve_markers,
 )
@@ -130,3 +132,16 @@ def test_resolve_markers_empty_input_returns_empty_dict() -> None:
     container = Container(groups=[_Deps], validate=True)
 
     assert resolve_markers(container, {}) == {}
+
+
+def test_mark_injected_then_is_injected_round_trips() -> None:
+    def handler() -> None:
+        pass  # pragma: no cover
+
+    assert is_injected(handler) is False
+    mark_injected(handler)
+    assert is_injected(handler) is True
+
+
+def test_is_injected_defaults_false_for_unmarked_callable() -> None:
+    assert is_injected(lambda: None) is False

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 import typing
 
 from modern_di import Container, Group, Scope, providers
@@ -148,6 +150,16 @@ def test_is_injected_defaults_false_for_unmarked_callable() -> None:
 
 
 def test_integrations_accessible_from_top_level_namespace() -> None:
-    import modern_di  # noqa: PLC0415
+    """`modern_di.integrations` must be reachable via `import modern_di` alone.
 
-    assert modern_di.integrations.bind is bind
+    Runs in a fresh subprocess — this file's own top-level
+    `from modern_di.integrations import ...` would otherwise attach the
+    submodule to the package as a side effect, masking a regression in
+    `modern_di/__init__.py`'s own import.
+    """
+    code = "import modern_di\nprint(modern_di.integrations.bind.__name__)\n"
+    result = subprocess.run(  # noqa: S603 — fixed literal command, no untrusted input
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert "bind" in result.stdout

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,15 @@
+from modern_di import Scope, providers
+from modern_di.integrations import ConnectionMatch, bind
+
+
+class _Request:
+    pass
+
+
+def test_bind_derives_scope_and_context_from_provider() -> None:
+    provider = providers.ContextProvider(_Request, scope=Scope.REQUEST)
+    connection = _Request()
+
+    match = bind(provider, connection)
+
+    assert match == ConnectionMatch(scope=Scope.REQUEST, context={_Request: connection})

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -163,3 +163,10 @@ def test_integrations_accessible_from_top_level_namespace() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "bind" in result.stdout
+
+
+def test_parse_markers_ignores_annotated_metadata_that_is_not_a_marker() -> None:
+    def handler(a: typing.Annotated[int, "not a marker"]) -> None:
+        pass  # pragma: no cover
+
+    assert parse_markers(handler) == {}


### PR DESCRIPTION
## Summary

- Adds `modern_di/integrations.py`: the shared, framework-agnostic skeleton the 13 integration adapters (fastapi, starlette, grpc, ...) currently hand-roll independently — an annotation-scanning `Annotated`-marker injector (`Marker`, `from_di`, `parse_markers`, `resolve_markers`, `is_injected`/`mark_injected`) and connection-to-scope/context derivation (`ConnectionMatch`, `bind`, `classify_connection`) that never wraps `Container.build_child_container` itself.
- Wires `modern_di.integrations` into the top-level package namespace, matching the existing `providers`/`exceptions` pattern.
- Promotes the design into `architecture/integration-kit.md` (new) and seeds `architecture/glossary.md`, and updates `docs/integrations/writing-integrations.md` to teach the new module as the recommended path for future integration authors.
- Adapter conversions (the 13 sibling repos actually adopting this) are explicitly out of scope — separate follow-up PRs per the rollout plan in `planning/changes/2026-07-13.02-integration-kit.md`.

Design background: `planning/changes/2026-07-13.02-integration-kit.md` (spec) and `planning/decisions/2026-07-13-integration-kit-shape.md` (accepted decision + addendum on which adapters land where).

## Test plan

- [x] `just test-ci` — 375 passed, 100% line coverage
- [x] `just lint-ci` — ruff format/check, `ty check`, and `planning/index.py --check` all clean
- [x] `just docs-build` (strict mode) — passes cleanly
- [x] Built via subagent-driven-development: 9 planned tasks, each with an independent spec+quality review; two review-driven fixes applied (a false-positive regression test isolated via subprocess, stale terminology reconciled in the docs); one whole-branch review — verdict "Ready to merge: Yes"