### PR TITLE
refactor: deepen CacheItem to own the singleton get-or-create invariant

### DIFF
--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -288,5 +288,9 @@ class Factory(AbstractProvider[types.T_co]):
             create=self._call_creator,
         )
         if created:
+            # Registering after get_or_create releases the lock is order-safe: only the
+            # single creating thread sees created=True, and a creator resolves its own
+            # dependencies before returning, so each dependency is marked before its
+            # depender — LIFO close order holds.
             container.cache_registry.mark_created(cache_item)
         return value

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -251,17 +251,22 @@ class Factory(AbstractProvider[types.T_co]):
             raise error from exc
 
     def _resolve_kwargs(self, container: "Container", cache_item: "CacheItem") -> dict[str, typing.Any]:
-        plan = self._ensure_plan(container, cache_item)
-        if plan.unwireable:
-            name, item = plan.unwireable[0]
-            raise self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
-        resolved_kwargs = dict(plan.static_kwargs)
-        for k, v in plan.provider_kwargs.items():
-            resolved_kwargs[k] = container.resolve_provider(v)
-        for k, (context_provider, item) in plan.context_kwargs.items():
-            value = self._resolve_context_value(container, k, context_provider, item)
-            if value is not types.UNSET:
-                resolved_kwargs[k] = value
+        try:
+            plan = self._ensure_plan(container, cache_item)
+            if plan.unwireable:
+                name, item = plan.unwireable[0]
+                raise self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
+            resolved_kwargs = dict(plan.static_kwargs)
+            for k, v in plan.provider_kwargs.items():
+                resolved_kwargs[k] = container.resolve_provider(v)
+            for k, (context_provider, item) in plan.context_kwargs.items():
+                value = self._resolve_context_value(container, k, context_provider, item)
+                if value is not types.UNSET:
+                    resolved_kwargs[k] = value
+        except (exceptions.ResolutionError, exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
+            # Name the failing end too, or no frame ever names the provider that failed to resolve.
+            exc.prepend_step(self._resolution_step())
+            raise
         return resolved_kwargs
 
     def resolve(self, container: "Container") -> types.T_co:
@@ -274,29 +279,14 @@ class Factory(AbstractProvider[types.T_co]):
         container._warn_and_reopen_if_closed()  # noqa: SLF001
         cache_item = container.cache_registry.fetch_cache_item(self)
 
-        if self.cache_settings and cache_item.cache is not types.UNSET:
-            return cache_item.cache
-
-        try:
-            resolved_kwargs = self._resolve_kwargs(container, cache_item)
-        except (exceptions.ResolutionError, exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
-            exc.prepend_step(self._resolution_step())
-            raise
-
         if not self.cache_settings:
-            return self._call_creator(resolved_kwargs)
+            return self._call_creator(self._resolve_kwargs(container, cache_item))
 
-        if container._lock:  # noqa: SLF001
-            container._lock.acquire()  # noqa: SLF001
-
-        try:
-            if cache_item.cache is not types.UNSET:
-                return cache_item.cache
-
-            instance = self._call_creator(resolved_kwargs)
-            cache_item.cache = instance
+        value, created = cache_item.get_or_create(
+            container._lock,  # noqa: SLF001
+            resolve=lambda: self._resolve_kwargs(container, cache_item),
+            create=self._call_creator,
+        )
+        if created:
             container.cache_registry.mark_created(cache_item)
-            return instance
-        finally:
-            if container._lock:  # noqa: SLF001
-                container._lock.release()  # noqa: SLF001
+        return value

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -7,7 +7,13 @@ from modern_di.providers import CacheSettings, Factory
 
 
 if typing.TYPE_CHECKING:
+    import threading
+
     from modern_di.wiring import WiringPlan
+
+
+_R = typing.TypeVar("_R")
+_V = typing.TypeVar("_V")
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -23,6 +29,35 @@ class CacheItem:
         if self.settings and self.settings.clear_cache:
             self.cache = types.UNSET
             self.finalized = False
+
+    def get_or_create(
+        self,
+        lock: "threading.RLock | None",
+        resolve: typing.Callable[[], _R],
+        create: typing.Callable[[_R], _V],
+    ) -> tuple[_V, bool]:
+        """Return the memoized singleton, or resolve-and-create it once under `lock`.
+
+        Two phases: `resolve()` runs unlocked (recursive dependency resolution must not
+        hold the lock); creation and the store run under `lock`, double-checked so at
+        most one caller creates. `lock` is the resolving container's `RLock` (or None
+        when the container was built with `use_lock=False`). Returns `(value, created)`;
+        `created` is True only when this call ran `create`.
+        """
+        if self.cache is not types.UNSET:
+            return self.cache, False
+        resolved = resolve()
+        if lock is not None:
+            lock.acquire()
+        try:
+            if self.cache is not types.UNSET:
+                return self.cache, False
+            value = create(resolved)
+            self.cache = value
+            return value, True
+        finally:
+            if lock is not None:
+                lock.release()
 
     async def close_async(self) -> None:
         if self.cache is not types.UNSET and not self.finalized and self.settings and self.settings.finalizer:

--- a/planning/changes/2026-07-14.02-cacheitem-get-or-create.md
+++ b/planning/changes/2026-07-14.02-cacheitem-get-or-create.md
@@ -1,0 +1,132 @@
+---
+summary: Deepen CacheItem with a get_or_create method that owns the singleton double-checked-lock + memoization, so Factory.resolve stops reaching into cache_item.cache and container._lock field-by-field.
+---
+
+# Design: CacheItem owns the singleton get-or-create invariant
+
+## Summary
+
+`Factory.resolve` hand-writes the singleton double-checked lock (DCL):
+unlocked fast-read of `cache_item.cache`, an unlocked kwargs resolution, then
+`container._lock.acquire()`, a locked re-check, the creator call, the
+`cache_item.cache` write, and `release()`. `CacheItem` itself owns only the
+close/finalize half of its lifecycle. This change moves the get-or-create
+half onto `CacheItem` as a single `get_or_create` method, so `Factory.resolve`
+touches neither `cache_item.cache` nor `container._lock`. Behaviour and public
+API are unchanged; this is an internal deepening (Candidate 2 from the
+2026-07-13 architecture review).
+
+## Motivation
+
+The "resolved once, cached forever" invariant is split across two files.
+`CacheItem` (`registries/cache_registry.py`) holds the state fields
+(`cache`, `finalized`, `settings`, `wiring_plan`, `wiring_plan_version`) but
+exposes no method for the locked memoization; `Factory.resolve`
+(`providers/factory.py`) reads/writes `cache_item.cache` at four sites and
+reaches past `Container._lock` with `# noqa: SLF001` to run the DCL by hand.
+`Factory` is the *only* caching provider — `Alias`, `ContextProvider`, and
+`_ContainerProvider` resolve without caching — so the DCL has exactly one
+author and one natural home. Pulling it onto `CacheItem` gives the
+concurrency invariant an interface that can be understood and tested on its
+own, instead of only through `Factory.resolve`.
+
+## Design
+
+Add one method to `CacheItem`:
+
+```python
+def get_or_create(self, lock, resolve, create) -> tuple[value, created]:
+    if self.cache is not types.UNSET:        # fast path — skips resolve
+        return self.cache, False
+    resolved = resolve()                      # unlocked: expensive/recursive
+    if lock is not None:
+        lock.acquire()
+    try:
+        if self.cache is not types.UNSET:     # double-check (race loser)
+            return self.cache, False
+        value = create(resolved)
+        self.cache = value
+        return value, True
+    finally:
+        if lock is not None:
+            lock.release()
+```
+
+`lock` is the resolving container's `RLock | None`; `resolve` is a
+zero-arg thunk returning the resolved creator kwargs; `create` maps those
+kwargs to the instance. It returns `(value, created)` — `created` tells the
+caller whether to register the item for finalization. The two-phase shape
+(resolve **unlocked**, create **locked**) is preserved exactly: kwargs
+resolution is recursive and must not hold the lock.
+
+`Factory.resolve`'s caching tail collapses to:
+
+```python
+value, created = cache_item.get_or_create(
+    container._lock,
+    resolve=lambda: self._resolve_kwargs(container, cache_item),
+    create=self._call_creator,
+)
+if created:
+    container.cache_registry.mark_created(cache_item)
+return value
+```
+
+**Error decoration.** `CreatorCallError` and `ArgumentResolutionError` are
+both subclasses of `ResolutionError`. Today `Factory.resolve` catches
+resolve-time errors in one `try/except (ResolutionError,
+ScopeNotInitializedError, ScopeSkippedError)` block and calls `prepend_step`,
+while creator errors self-decorate inside `_call_creator`. If `get_or_create`
+caught `ResolutionError`, a creator error would get its step prepended twice.
+So the resolve-time decoration moves **into `_resolve_kwargs`** (its only
+caller is `resolve`): both thunks then self-decorate, `get_or_create` catches
+nothing, and every error carries exactly one step — byte-identical trace
+output to today.
+
+## Non-goals
+
+- The close/finalize half of `CacheItem` (`close_async`/`close_sync`/`_clear`)
+  — unchanged.
+- The nogil-sensitive `wiring_plan` publication (`_ensure_plan`) — stays
+  unlocked inside `_resolve_kwargs`; the `planning/deferred.md` free-threaded
+  caveat is unaffected.
+- `find_container` + `_warn_and_reopen_if_closed` (and their own
+  `prepend_step`) — pre-cache concerns, stay at the top of `Factory.resolve`.
+- The non-caching path (`not self.cache_settings`) — stays a direct
+  `_call_creator(_resolve_kwargs(...))`; it has no cache and never calls
+  `get_or_create`.
+- `mark_created` — stays in `Factory`, driven by the `created` flag;
+  `CacheItem` gains no back-reference to its registry (LIFO finalization
+  order is a registry concern).
+- Candidate 4 (the override short-circuit) — adjacent but a separate change.
+
+## Testing
+
+- `just test-ci` — 100% line coverage, the gate.
+- `get_or_create` gains direct unit tests through its own interface:
+  cache-miss → `resolve`/`create` each called once, returns `(value, True)`,
+  `cache` set; pre-set cache → returns `(cached, False)` without calling
+  `resolve`/`create`; `lock=None` path.
+- Existing end-to-end guarantees are carried unchanged by their current
+  tests: `test_singleton_threading_concurrency` still drives threads through
+  the inner locked re-check; the reentrancy/deadlock test still passes (the
+  same `RLock` is passed in); `use_lock=False` still resolves; every
+  finalizer / `close_sync` / `close_async` test is untouched.
+- Error-trace parity: `test_dependency_path` / `test_error_rendering` assert
+  the resolution-step chains — they must render identically after the
+  decoration moves into `_resolve_kwargs`.
+
+## Risk
+
+- **Double-decorated creator errors** (low likelihood now that it's called
+  out × medium impact — visible in traces). Mitigated by moving decoration
+  into `_resolve_kwargs` rather than wrapping `get_or_create`; guarded by the
+  error-rendering tests.
+- **A concurrency branch drops out of coverage** after the restructure (low ×
+  low — the 100% gate fails loudly). Mitigated by preserving the exact DCL
+  shape so `test_singleton_threading_concurrency` still exercises the inner
+  re-check.
+- **Reentrancy regression** if the lock were replaced rather than passed
+  through (low × high — deadlock). Mitigated by passing `container._lock`
+  (the existing `RLock`) straight into `get_or_create`; the deadlock test
+  guards it.

--- a/planning/changes/2026-07-14.02-cacheitem-get-or-create.md
+++ b/planning/changes/2026-07-14.02-cacheitem-get-or-create.md
@@ -1,5 +1,5 @@
 ---
-summary: Deepen CacheItem with a get_or_create method that owns the singleton double-checked-lock + memoization, so Factory.resolve stops reaching into cache_item.cache and container._lock field-by-field.
+summary: CacheItem.get_or_create now owns the singleton double-checked-lock + memoization (fast-read, unlocked resolve, locked re-check/create/store); Factory.resolve delegates to it and only drives mark_created via the created flag; resolve-time error decoration moved into _resolve_kwargs; no public-API or behaviour change.
 ---
 
 # Design: CacheItem owns the singleton get-or-create invariant

--- a/tests/registries/test_cache_registry.py
+++ b/tests/registries/test_cache_registry.py
@@ -1,0 +1,85 @@
+import threading
+import typing
+
+from modern_di.registries.cache_registry import CacheItem
+
+
+def _item() -> CacheItem:
+    return CacheItem(settings=None)
+
+
+def test_get_or_create_miss_calls_resolve_and_create_once_and_caches() -> None:
+    item = _item()
+    calls = {"resolve": 0, "create": 0}
+
+    def resolve() -> dict[str, typing.Any]:
+        calls["resolve"] += 1
+        return {"x": 1}
+
+    def create(kwargs: dict[str, typing.Any]) -> tuple[str, dict[str, typing.Any]]:
+        calls["create"] += 1
+        return ("made", kwargs)
+
+    value, created = item.get_or_create(None, resolve=resolve, create=create)
+
+    assert created is True
+    assert value == ("made", {"x": 1})
+    assert item.cache == ("made", {"x": 1})
+    assert calls == {"resolve": 1, "create": 1}
+
+
+def test_get_or_create_hit_returns_cache_without_resolving() -> None:
+    item = _item()
+    item.cache = "cached"
+
+    def resolve() -> object:  # pragma: no cover
+        msg = "resolve must not run on a cache hit"
+        raise AssertionError(msg)
+
+    def create(_: object) -> str:  # pragma: no cover
+        msg = "create must not run on a cache hit"
+        raise AssertionError(msg)
+
+    value, created = item.get_or_create(None, resolve=resolve, create=create)
+
+    assert created is False
+    assert value == "cached"
+
+
+def test_get_or_create_double_checks_after_lock() -> None:
+    # The inner re-check fires when the cache is UNSET at the fast read but SET
+    # by the time the lock is held (a losing thread in production). Simulate it
+    # deterministically: resolve() sets the cache as a side effect, so the
+    # post-lock re-check must return it and skip create.
+    item = _item()
+    created_calls: list[object] = []
+
+    def resolve() -> dict[str, typing.Any]:
+        item.cache = "won-the-race"
+        return {}
+
+    def create(kwargs: dict[str, typing.Any]) -> str:  # pragma: no cover
+        created_calls.append(kwargs)
+        return "should-not-be-used"
+
+    value, created = item.get_or_create(threading.RLock(), resolve=resolve, create=create)
+
+    assert created is False
+    assert value == "won-the-race"
+    assert created_calls == []
+
+
+def test_get_or_create_releases_lock_and_fast_path_on_second_call() -> None:
+    item = _item()
+    lock = threading.RLock()
+
+    value, created = item.get_or_create(lock, resolve=lambda: 0, create=lambda _: "v")
+    assert (value, created) == ("v", True)
+
+    # Second call hits the fast path (cache set) — returns before touching the lock.
+    value2, created2 = item.get_or_create(lock, resolve=lambda: 0, create=lambda _: "v2")
+    assert (value2, created2) == ("v", False)
+
+    # The lock was released by the first call's finally (not left held).
+    assert lock.acquire(blocking=False)
+    lock.release()


### PR DESCRIPTION
## Summary

Internal deepening — **no public-API or behaviour change**. The singleton double-checked-lock (DCL) + memoization moves off `Factory.resolve` onto a new `CacheItem.get_or_create` method, so `Factory.resolve` stops reaching into `cache_item.cache` and `container._lock` field-by-field. This is Candidate 2 from the 2026-07-13 architecture review (Candidate 1 was the integration kit).

Design/rationale: `planning/changes/2026-07-14.02-cacheitem-get-or-create.md`.

## What changes

- **`CacheItem.get_or_create(lock, resolve, create) -> (value, created)`** (`registries/cache_registry.py`) owns the full two-phase dance: fast-read of `self.cache`, an **unlocked** `resolve()` (recursive kwargs resolution must not hold the lock), then acquire the lock, double-check, `create(resolved)`, store, release. Returns `created` so the caller knows whether to register for finalization.
- **`Factory.resolve`** (`providers/factory.py`) delegates to it and only drives `mark_created` via the `created` flag — it no longer acquires/releases the lock or writes the cache field.
- **Error-trace parity:** because `CreatorCallError`/`ArgumentResolutionError` are `ResolutionError` subclasses, the resolve-time `prepend_step` decoration moves *into* `_resolve_kwargs` (its only caller), so both thunks self-decorate and `get_or_create` catches nothing — no double-prepended resolution step. Traces render byte-identically.

Untouched: the close/finalize half of `CacheItem`; the nogil-sensitive `wiring_plan` publication (stays unlocked); `find_container`/reopen; the non-caching path; `mark_created` orchestration (stays a registry concern, no back-reference).

## Test plan

- [x] `just test-ci` — 100% line coverage, 379 tests. New direct unit tests for `get_or_create` (miss / hit / post-lock double-check / lock-release) in `tests/registries/test_cache_registry.py`; zero changes to existing tests.
- [x] `just lint-ci` — ruff (`select=ALL`), `ty`, `check-planning` clean.
- [x] Concurrency: `test_singleton_threading_concurrency` (4-thread race) drives the inner double-check; reentrancy/deadlock and `use_lock=False` tests pass unchanged (same `RLock` passed through).
- [x] Error-trace parity: `test_dependency_path` + `test_error_rendering` pass unmodified.
- [x] Per-task spec+quality review (3 tasks) + adversarial whole-branch review (concurrency + error-trace parity traced against baseline; no Critical/Important findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)