### PR TITLE
refactor: fold the override short-circuit into OverridesRegistry

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -206,10 +206,8 @@ class Container:
         """Resolve a specific provider by reference (enforces closed-state and applies overrides)."""
         self._warn_and_reopen_if_closed()
 
-        if (
-            self.overrides_registry.overrides
-            and (override := self.overrides_registry.fetch_override(provider.provider_id)) is not types.UNSET
-        ):
+        override = self.overrides_registry.fetch_override(provider.provider_id)
+        if override is not types.UNSET:
             return override  # ty: ignore[invalid-return-type]
 
         try:

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -200,10 +200,9 @@ class Factory(AbstractProvider[types.T_co]):
         Absent value falls back to the creator default (omit), ``None`` (nullable), or raises
         ``ArgumentResolutionError`` (required).
         """
-        if container.overrides_registry.overrides:
-            override = container.overrides_registry.fetch_override(provider.provider_id)
-            if override is not types.UNSET:
-                return override
+        override = container.overrides_registry.fetch_override(provider.provider_id)
+        if override is not types.UNSET:
+            return override
         value = provider.fetch_context_value(container)
         if value is not types.UNSET:
             return value

--- a/modern_di/registries/overrides_registry.py
+++ b/modern_di/registries/overrides_registry.py
@@ -7,19 +7,21 @@ from modern_di import types
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class OverridesRegistry:
-    overrides: dict[int, typing.Any] = dataclasses.field(init=False, default_factory=dict)
+    _overrides: dict[int, typing.Any] = dataclasses.field(init=False, default_factory=dict)
 
     def override(self, provider_id: int, override_object: object) -> None:
-        self.overrides[provider_id] = override_object
+        self._overrides[provider_id] = override_object
 
     def reset_override(self, provider_id: int | None = None) -> None:
         if provider_id is None:
-            self.overrides.clear()
+            self._overrides.clear()
         else:
-            self.overrides.pop(provider_id, None)
+            self._overrides.pop(provider_id, None)
 
     def fetch_override(self, provider_id: int) -> object:
-        return self.overrides.get(provider_id, types.UNSET)
+        if not self._overrides:
+            return types.UNSET
+        return self._overrides.get(provider_id, types.UNSET)
 
 
 class OverrideHandle(typing.Generic[types.T]):

--- a/planning/changes/2026-07-14.03-overrides-registry-owns-short-circuit.md
+++ b/planning/changes/2026-07-14.03-overrides-registry-owns-short-circuit.md
@@ -1,0 +1,119 @@
+---
+summary: Fold the empty-dict fast-path into OverridesRegistry.fetch_override and privatize the overrides dict, so the two resolution sites stop reading the raw field and repeating the override short-circuit idiom.
+---
+
+# Design: OverridesRegistry owns the override short-circuit
+
+## Summary
+
+Two resolution sites — `Container.resolve_provider` and
+`Factory._resolve_context_value` — each read `OverridesRegistry.overrides`
+(the raw public dict) directly and repeat the same short-circuit idiom:
+"if there are overrides and this provider has one, return it." This change
+folds the empty-dict fast-path into `OverridesRegistry.fetch_override` and
+renames the field `overrides` → `_overrides` (private), so both call sites
+call one method and no code outside the registry touches the dict. Behaviour
+and public API are unchanged; this is an internal deepening (Candidate 4 from
+the 2026-07-13 architecture review).
+
+## Motivation
+
+`OverridesRegistry` (`registries/overrides_registry.py`) already exposes
+`fetch_override(provider_id) -> value | UNSET`, but its `overrides` dict is a
+public field and both hot-path call sites read it directly to add an
+empty-dict guard before calling `fetch_override`:
+
+```python
+# container.py — resolve_provider
+if (
+    self.overrides_registry.overrides
+    and (override := self.overrides_registry.fetch_override(provider.provider_id)) is not types.UNSET
+):
+    return override  # ty: ignore[invalid-return-type]
+
+# factory.py — _resolve_context_value
+if container.overrides_registry.overrides:
+    override = container.overrides_registry.fetch_override(provider.provider_id)
+    if override is not types.UNSET:
+        return override
+```
+
+The `if …overrides:` guard is a deliberate optimization — skip hashing the
+provider_id on the common no-override path — but it means the raw dict is read
+through the seam at two sites, and the "there's an override, use it"
+short-circuit is spelled twice. The registry wrapper hides nothing. Verified
+that **no other code reads `.overrides`** (no tests, no plugin — the pytest
+integration uses the `override()`/`reset_override()` methods), so the field
+can be privatized cheaply.
+
+## Design
+
+**`registries/overrides_registry.py`:**
+
+- Rename the field `overrides` → `_overrides` (it is `dataclasses.field(init=False,
+  default_factory=dict)`, so nothing constructs it positionally; the `slots`
+  entry renames with it). Keep its type `dict[int, typing.Any]`. Update
+  `override` and `reset_override` to use `self._overrides`.
+- Fold the empty-dict fast-path into `fetch_override`:
+
+  ```python
+  def fetch_override(self, provider_id: int) -> object:
+      if not self._overrides:
+          return types.UNSET
+      return self._overrides.get(provider_id, types.UNSET)
+  ```
+
+**Call sites** drop the raw `.overrides` read; both become the same shape:
+
+```python
+# container.py — resolve_provider
+override = self.overrides_registry.fetch_override(provider.provider_id)
+if override is not types.UNSET:
+    return override  # ty: ignore[invalid-return-type]
+
+# factory.py — _resolve_context_value
+override = container.overrides_registry.fetch_override(provider.provider_id)
+if override is not types.UNSET:
+    return override
+```
+
+Behaviour is byte-identical: the empty-dict short-circuit moves from the two
+call sites into `fetch_override`, which every caller already routed through.
+`override()`'s prior-snapshot caller (container.py, `prior =
+...fetch_override(...)`) is unaffected — it still receives the value or
+`UNSET`.
+
+This is one atomic change: the field rename and the two call-site edits must
+land in the same commit, or a call site would read a field that no longer
+exists.
+
+## Non-goals
+
+- Any change to override *semantics*, the `override()`/`reset_override()`
+  contract, or the `OverrideHandle` context-manager.
+- Changing the `_overrides` value type or adding new override features.
+- Candidates 3 and 5 from the same review — separate changes.
+
+## Testing
+
+- `just test-ci` — 100% line coverage, the gate. This is a behaviour-
+  preserving refactor: existing override tests carry it —
+  resolve-through-override, context-provider override (the
+  `_resolve_context_value` path), `reset_override`, and the `OverrideHandle`
+  context-manager. Both `fetch_override` branches stay covered: the
+  empty-dict fast-path by every no-override resolution, the populated path by
+  the with-override tests.
+- `just lint-ci` — ruff (`select=ALL`), `ty check`, `check-planning`. The
+  `# ty: ignore[invalid-return-type]` on `container.py`'s `return override`
+  stays (the method returns `types.T`, `override` is `object`).
+
+## Risk
+
+- **A `fetch_override` branch loses coverage** after the fold (low likelihood
+  × low impact — the 100% gate fails loudly). Mitigated: the empty and
+  populated paths are both exercised today (resolution with and without
+  overrides); the fold only relocates the guard.
+- **A hidden external reader of `.overrides`** breaks on the rename (low
+  likelihood — grep across `modern_di/` and `tests/` found only the two
+  refactored sites × low impact — a caught `AttributeError` at import/test
+  time, not silent).


### PR DESCRIPTION
## Summary

Internal deepening — **no public-API or behaviour change**. `Container.resolve_provider` and `Factory._resolve_context_value` each read the raw `OverridesRegistry.overrides` dict and repeated the same "if there's an override, use it" short-circuit. This folds the empty-dict fast-path into `OverridesRegistry.fetch_override` and privatizes the field (`overrides` → `_overrides`), so both call sites go through one method and nothing outside the registry touches the dict. Candidate 4 from the 2026-07-13 architecture review.

Design/rationale: `planning/changes/2026-07-14.03-overrides-registry-owns-short-circuit.md`.

## What changes (3 files)

- **`registries/overrides_registry.py`** — field `overrides` → `_overrides` (private; `init=False`, slots renamed); `override`/`reset_override` use it; `fetch_override` gains the empty-dict fast-path:
  ```python
  def fetch_override(self, provider_id: int) -> object:
      if not self._overrides:
          return types.UNSET
      return self._overrides.get(provider_id, types.UNSET)
  ```
- **`container.py` / `factory.py`** — both call sites drop the raw `.overrides` read + walrus idiom, becoming the identical `override = ...fetch_override(pid); if override is not types.UNSET: return override`.

The empty-dict short-circuit (a deliberate hot-path opt — skip hashing the provider_id when there are no overrides) just moves from the two call sites into the one method every caller already routed through. `OverrideHandle` and override semantics are untouched.

## Test plan

- [x] `just test-ci` — 100% line coverage, 379 tests, **zero test-file changes** (behaviour-preserving; existing override tests cover both `fetch_override` branches and both call-site branches).
- [x] `just lint-ci` — ruff (`select=ALL`), `ty`, `check-planning` clean. `grep "\.overrides\b"` across `modern_di/` + `tests/` is now empty.
- [x] Adversarial review: behaviour parity traced byte-identical across all cases (no-overrides / present-but-absent / present), the prior-snapshot path (`OverrideHandle`) confirmed unaffected, and the pre-existing "override value could be `UNSET`" edge confirmed identical old-vs-new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)