### PR TITLE
docs(planning): record closures for architecture-review candidates 3 and 5

### DIFF
--- a/planning/decisions/2026-07-14-grpc-registry-introspection-declined.md
+++ b/planning/decisions/2026-07-14-grpc-registry-introspection-declined.md
@@ -1,0 +1,55 @@
+---
+status: accepted
+summary: Decline a blessed provider-introspection seam (container.is_registered) for grpc's idempotent registration — one consumer is a hypothetical seam; grpc keeps its local guard.
+supersedes: null
+superseded_by: null
+---
+
+# No blessed provider-introspection seam for grpc's registry drill
+
+**Decision:** Do not add `Container.is_registered(type)` (or an
+idempotent-`add_providers` mode) for adapters to query registration state
+(Candidate 5 from the 2026-07-13 architecture review). `modern-di-grpc`
+keeps its local `_ensure_context_provider` guard.
+
+## Context
+
+`modern-di-grpc`'s `_ensure_context_provider` calls
+`container.providers_registry.find_provider(ServicerContext) is None` before
+`container.add_providers(grpc_context_provider)`, to register the context
+provider idempotently. grpc has no `setup_di` — constructing an interceptor
+*is* the setup, and both interceptors (sync `DIInterceptor` + async
+`DIAioInterceptor`) may be built on one container, so the guard prevents a
+`DuplicateProviderTypeError` from `add_providers`. The review read this as
+grpc "reaching past the blessed seam" and proposed a blessed
+`is_registered` query. The integration-kit design deferred it as a distinct
+change ([2026-07-13-integration-kit-shape](2026-07-13-integration-kit-shape.md)
+non-goals).
+
+Options on the table: (a) bless `container.is_registered(type)` and convert
+grpc; (b) add an `ignore_existing` mode to `add_providers` so grpc registers
+unconditionally; (c) close it — keep grpc's local guard.
+
+## Decision & rationale
+
+Chose (c). The deciding evidence: **grpc is the only consumer** — a grep
+across every `modern-di-*` adapter and its tests found no other reader of
+`providers_registry` / `find_provider`. By the project's standing rule (one
+adapter = hypothetical seam, two = a real one — the same principle that kept
+the integration-kit outliers' logic local rather than growing the primitives),
+a single consumer does not justify new core API.
+
+Reinforcing it: `container.providers_registry` and `find_provider` are both
+**public** — grpc is using a lower-level public API, not breaching
+encapsulation. And `add_providers`' strictness (raising on a duplicate
+`bound_type`) is a deliberate feature that catches accidental
+double-registration; option (b) would loosen it globally to serve one
+adapter, a large blast radius. grpc's guard is two legible, local lines that
+belong with grpc's unusual "the interceptor is the setup" shape.
+
+## Revisit trigger
+
+A **second** adapter needs to query registration state (making the seam real
+under the two-adapter rule), or a decision to privatize
+`container.providers_registry` as an implementation detail — at which point a
+blessed `is_registered` becomes the migration path for grpc.

--- a/planning/decisions/2026-07-14-signatureitem-opacity-superseded.md
+++ b/planning/decisions/2026-07-14-signatureitem-opacity-superseded.md
@@ -1,0 +1,58 @@
+---
+status: accepted
+summary: Making SignatureItem an opaque resolved parameter (a 2026-07-13 review candidate) is superseded — the graph-traversal unification already extracted its two behaviours as wiring.py functions.
+supersedes: null
+superseded_by: null
+---
+
+# SignatureItem opacity is superseded by the wiring extraction
+
+**Decision:** Do not pursue "make `SignatureItem` an opaque resolved
+parameter" (Candidate 3 from the 2026-07-13 architecture review). Its
+substance already shipped in the graph-traversal unification
+([2026-07-12.01-dependency-graph-module](../changes/2026-07-12.01-dependency-graph-module.md),
+PR #308), which placed the behaviour better than the candidate's sketch.
+
+## Context
+
+The review flagged `SignatureItem` (`types_parser.py`) as a shallow record
+whose five raw fields (`arg_type`, `args`, `is_nullable`, `default`,
+`raw_annotation`) were decoded independently at ~5 sites, and proposed
+absorbing that behind two operations — `match_provider(reg)` ("which provider
+backs this?") and `disposition()` ("what if absent?") — ideally as methods on
+`SignatureItem`, so callers never touch the raw fields.
+
+## Decision & rationale
+
+The core leak — the old wiring loop reading raw fields to pick providers and
+handle absence — is gone. `modern_di/wiring.py` now owns exactly those two
+operations as free functions:
+
+- `find_dep_provider(registry, owner, item)` = `match_provider` — prefers
+  `arg_type`, falls back to union `args`.
+- `absent_disposition(item)` = `disposition` — default → OMIT, nullable →
+  NULL, else UNWIRABLE.
+
+`WiringPlan.build` (the former leaky loop) calls these two and touches no raw
+field. The candidate's proposal is realized.
+
+The free-function placement in `wiring.py` is **deliberately better** than the
+candidate's "methods on `SignatureItem`" idea: `SignatureItem` stays a pure
+data record in `types_parser.py` and does not import `ProvidersRegistry` /
+`AbstractProvider`. Methods-on-`SignatureItem` would invert that layering
+(the parse-tree type depending on the resolution machinery).
+
+The residual raw-field reads that remain (all in `providers/factory.py`) are a
+thinner, different set — the parameterized-generic construction guard
+(`raw_annotation` + `default`), the error builder (`arg_type` + `args`), and
+deriving `bound_type` from the return sig's `arg_type`. None is duplication,
+none collapses into `match_provider`/`disposition`, and each is a single
+legitimate read. Forcing a further "opacity" refactor here would be churn
+without a genuine deepening.
+
+## Revisit trigger
+
+A *new* duplicated raw-field decode idiom appears across two or more sites
+(the repeated-idiom smell the review originally caught), or `types_parser.py`
+gains logic that would genuinely benefit from behaviour living on the record
+without inverting the `types_parser` → `wiring` layering.


### PR DESCRIPTION
## Summary

Records the two **closed** outcomes of the 2026-07-13 architecture review as decision records, so a future review doesn't re-suggest them. The three *shipped* candidates (1 the integration kit, 2 `CacheItem.get_or_create` #314, 4 the override short-circuit fold #315) already live in git history + change bundles; the closed ones had no durable home.

## Records added

- **`2026-07-14-signatureitem-opacity-superseded.md`** — Candidate 3 (make `SignatureItem` opaque) is **superseded by #308**: the graph-traversal unification already extracted its two behaviours as `wiring.py` functions (`find_dep_provider` = "which provider backs this", `absent_disposition` = "what if absent"), and placed them as free functions rather than methods-on-`SignatureItem` — deliberately better, since it keeps the parse-tree record from importing the resolution machinery. Residual field-reads in `factory.py` are thin and non-duplicated.
- **`2026-07-14-grpc-registry-introspection-declined.md`** — Candidate 5 (a blessed `is_registered` seam for grpc's idempotent registration) is **declined as a hypothetical seam**: grpc is the sole consumer (grep across all adapters confirms), it uses the *public* `providers_registry.find_provider`, and `add_providers`' strictness is a deliberate feature. One consumer doesn't justify new core API under the project's "two adapters = a real seam" rule. Revisit trigger: a second consumer, or a decision to privatize `providers_registry`.

Docs-only; `just lint-ci` (incl. `check-planning`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)