### PR TITLE
docs: realistic examples for the integration pages

### DIFF
--- a/docs/integrations/aiogram.md
+++ b/docs/integrations/aiogram.md
@@ -31,21 +31,35 @@ a per-update child container automatically.
 ### 2. Apply to your application
 
 ```python
+import dataclasses
 import typing
 
 from aiogram import Dispatcher
-from aiogram.types import Message
+from aiogram.types import Message, Update
 from modern_di import Container, Group, Scope, providers
 from modern_di_aiogram import FromDI, inject, setup_di
 
 
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    def __init__(self) -> None:
-        self.greeting = "hello"
+    service_name: str = "catalog"
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class UpdateReport:
+    settings: Settings   # APP-scoped, injected by type
+    update: Update       # per-update context object, injected by type
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "update_id": str(self.update.update_id),
+        }
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    update_report = providers.Factory(UpdateReport, scope=Scope.REQUEST)
 
 
 dispatcher = Dispatcher()
@@ -54,11 +68,11 @@ setup_di(dispatcher, Container(groups=[AppGroup], validate=True))
 
 @dispatcher.message()
 @inject
-async def greet(
+async def report(
     message: Message,
-    settings: typing.Annotated[Settings, FromDI(AppGroup.settings)],
+    update_report: typing.Annotated[UpdateReport, FromDI(UpdateReport)],
 ) -> None:
-    await message.answer(f"{settings.greeting}, {message.from_user.first_name}")
+    await message.answer(str(update_report.as_dict()))
 ```
 
 `setup_di(dispatcher, container)` stores the container on the dispatcher,
@@ -194,6 +208,12 @@ async def log_message(
 ) -> None:
     assert message is same_message
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and container teardown.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/aiogram.md
+++ b/docs/integrations/aiogram.md
@@ -35,7 +35,7 @@ import dataclasses
 import typing
 
 from aiogram import Dispatcher
-from aiogram.types import Message, Update
+from aiogram.types import Message
 from modern_di import Container, Group, Scope, providers
 from modern_di_aiogram import FromDI, inject, setup_di
 
@@ -46,20 +46,16 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class UpdateReport:
+class Report:
     settings: Settings   # APP-scoped, injected by type
-    update: Update       # per-update context object, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "update_id": str(self.update.update_id),
-        }
+        return {"service": self.settings.service_name}
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    update_report = providers.Factory(UpdateReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 dispatcher = Dispatcher()
@@ -68,11 +64,11 @@ setup_di(dispatcher, Container(groups=[AppGroup], validate=True))
 
 @dispatcher.message()
 @inject
-async def report(
+async def greet(
     message: Message,
-    update_report: typing.Annotated[UpdateReport, FromDI(UpdateReport)],
+    report: typing.Annotated[Report, FromDI(Report)],
 ) -> None:
-    await message.answer(str(update_report.as_dict()))
+    await message.answer(str(report.as_dict()))
 ```
 
 `setup_di(dispatcher, container)` stores the container on the dispatcher,

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -21,6 +21,12 @@ opens a per-connection child container automatically.
       pip install modern-di-aiohttp
       ```
 
+=== "poetry"
+
+      ```bash
+      poetry add modern-di-aiohttp
+      ```
+
 ### 2. Apply to your application
 
 ```python
@@ -32,25 +38,39 @@ from modern_di import Container, Group, Scope, providers
 from modern_di_aiohttp import FromDI, inject, setup_di
 
 
-@dataclasses.dataclass(kw_only=True)
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    debug: bool = True
+    service_name: str = "catalog"
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class RequestReport:
+    settings: Settings      # APP-scoped, injected by type
+    request: web.Request    # REQUEST context object, injected by type
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "method": self.request.method,
+            "path": self.request.path,
+        }
 
 
 class AppGroup(Group):
-    settings = providers.Factory(Settings, scope=Scope.APP)
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
 
 
 @inject
-async def homepage(
+async def report(
     request: web.Request,
-    settings: typing.Annotated[Settings, FromDI(AppGroup.settings)],
+    request_report: typing.Annotated[RequestReport, FromDI(RequestReport)],
 ) -> web.Response:
-    return web.json_response({"debug": settings.debug})
+    return web.json_response(request_report.as_dict())
 
 
 app = web.Application()
-app.router.add_get("/", homepage)
+app.router.add_get("/report", report)
 setup_di(app, Container(groups=[AppGroup], validate=True))
 ```
 
@@ -102,6 +122,13 @@ async def ws_handler(
                 ...  # resolve REQUEST-scoped providers for this message
     return ws
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Async SQLAlchemy](../recipes/sqlalchemy.md) — engine + session + repository through the request container.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -44,33 +44,28 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class RequestReport:
-    settings: Settings      # APP-scoped, injected by type
-    request: web.Request    # REQUEST context object, injected by type
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "method": self.request.method,
-            "path": self.request.path,
-        }
+        return {"service": self.settings.service_name}
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 @inject
-async def report(
+async def get_report(
     request: web.Request,
-    request_report: typing.Annotated[RequestReport, FromDI(RequestReport)],
+    report: typing.Annotated[Report, FromDI(Report)],
 ) -> web.Response:
-    return web.json_response(request_report.as_dict())
+    return web.json_response(report.as_dict())
 
 
 app = web.Application()
-app.router.add_get("/report", report)
+app.router.add_get("/report", get_report)
 setup_di(app, Container(groups=[AppGroup], validate=True))
 ```
 

--- a/docs/integrations/arq.md
+++ b/docs/integrations/arq.md
@@ -25,6 +25,7 @@
 ### 2. Apply to your application
 
 ```python
+import dataclasses
 import typing
 
 from arq.connections import RedisSettings
@@ -32,35 +33,34 @@ from modern_di import Container, Group, Scope, providers
 from modern_di_arq import FromDI, inject, setup_di
 
 
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    def __init__(self) -> None:
-        self.greeting = "hello"
+    service_name: str = "catalog"
 
 
-class Greeter:
-    def __init__(self, settings: Settings) -> None:   # auto-injected by type
-        self._settings = settings
+@dataclasses.dataclass(kw_only=True, slots=True)
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
-    def greet(self, name: str) -> str:
-        return f"{self._settings.greeting}, {name}"
+    def render(self) -> str:
+        return f"service={self.settings.service_name}"
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    greeter = providers.Factory(Greeter, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 @inject
-async def greet(
-    ctx: dict[str, typing.Any],       # arq passes its context dict as the first argument
-    name: str,
-    greeter: typing.Annotated[Greeter, FromDI(Greeter)],   # resolve by type
+async def run_report(
+    ctx: dict[str, typing.Any],      # arq passes its context dict as the first argument
+    report: typing.Annotated[Report, FromDI(Report)],
 ) -> str:
-    return greeter.greet(name)
+    return report.render()
 
 
 class WorkerSettings:
-    functions = [greet]
+    functions = [run_report]
     redis_settings = RedisSettings(host="localhost")
 
 
@@ -77,7 +77,7 @@ from arq.connections import RedisSettings
 
 async def main() -> None:
     pool = await create_pool(RedisSettings(host="localhost"))
-    await pool.enqueue_job("greet", "world")    # pass only real args; DI params are resolved for you
+    await pool.enqueue_job("run_report")
 ```
 
 `setup_di(worker_settings, container)` seeds the container into arq's `ctx` dict
@@ -139,6 +139,13 @@ with `*args` or `**kwargs` cannot be bound unambiguously, so `@inject` raises a
 `TypeError` **at decoration time** rather than silently misrouting arguments.
 Give an `@inject` task explicit named parameters. (A task with no `FromDI`
 parameter is untouched and may use `*args`/`**kwargs` freely.)
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Async resources via lifespan](../recipes/async-lifespan.md) — constructing async resources with finalizers.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/celery.md
+++ b/docs/integrations/celery.md
@@ -35,27 +35,20 @@ from modern_di_celery import FromDI, inject, setup_di
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    greeting: str = "hello"
+    service_name: str = "catalog"
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class Greeter:
-    settings: Settings        # auto-injected by type
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
-    def greet(self, name: str) -> str:
-        return f"{self.settings.greeting}, {name}"
+    def render(self) -> str:
+        return f"service={self.settings.service_name}"
 
 
 class AppGroup(Group):
-    settings = providers.Factory(
-        Settings,
-        scope=Scope.APP,
-        cache=True,
-    )
-    greeter = providers.Factory(
-        Greeter,
-        scope=Scope.REQUEST,
-    )
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 app = Celery("myapp", broker="redis://localhost")
@@ -64,14 +57,8 @@ setup_di(app, Container(groups=[AppGroup], validate=True))
 
 @app.task
 @inject
-def greet(
-    name: str,
-    greeter: typing.Annotated[
-        Greeter,
-        FromDI(Greeter),    # resolve by type
-    ],
-) -> str:
-    return greeter.greet(name)
+def run_report(report: typing.Annotated[Report, FromDI(Report)]) -> str:
+    return report.render()
 ```
 
 `setup_di(app, container)` stores the container on `app.conf` and registers `worker_process_init`/`worker_process_shutdown` signal handlers that open/close it — those fire when a real `celery worker` process starts and stops, so a script or test that calls tasks without spinning one up (e.g. with `task_always_eager = True`) must drive the container lifecycle itself; see [Worker-process lifecycle](#worker-process-lifecycle) below.
@@ -186,6 +173,13 @@ signals.worker_process_init.send(sender=None)    # a real worker fires this on s
 print(ping.delay().get())    # -> "pong"
 signals.worker_process_shutdown.send(sender=None)    # a real worker fires this on shutdown
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Multi-Group organization](../recipes/multi-group.md) — structuring a larger container.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and container teardown.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -40,21 +40,16 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class RequestReport:
+class Report:
     settings: Settings              # APP-scoped, injected by type
-    request: fastapi.Request        # REQUEST context object, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "method": self.request.method,
-            "path": self.request.url.path,
-        }
+        return {"service": self.settings.service_name}
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 app = fastapi.FastAPI()
@@ -62,10 +57,10 @@ modern_di_fastapi.setup_di(app, Container(groups=[AppGroup], validate=True))
 
 
 @app.get("/report")
-async def report(
-    request_report: typing.Annotated[RequestReport, modern_di_fastapi.FromDI(RequestReport)],
+async def get_report(
+    report: typing.Annotated[Report, modern_di_fastapi.FromDI(Report)],
 ) -> dict[str, str]:
-    return request_report.as_dict()
+    return report.as_dict()
 ```
 
 ## Websockets

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -26,8 +26,7 @@
 
 ### 2. Apply to your application
 ```python
-import datetime
-import contextlib
+import dataclasses
 import typing
 
 import fastapi
@@ -35,37 +34,38 @@ import modern_di_fastapi
 from modern_di import Container, Group, Scope, providers
 
 
-app = fastapi.FastAPI()
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class Settings:
+    service_name: str = "catalog"
 
 
-def create_singleton() -> datetime.datetime:
-    return datetime.datetime.now(tz=datetime.timezone.utc)
+@dataclasses.dataclass(kw_only=True, slots=True)
+class RequestReport:
+    settings: Settings              # APP-scoped, injected by type
+    request: fastapi.Request        # REQUEST context object, injected by type
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "method": self.request.method,
+            "path": self.request.url.path,
+        }
 
 
 class AppGroup(Group):
-    singleton = providers.Factory(
-        create_singleton,
-        scope=Scope.APP,
-        cache=True
-    )
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
 
 
-# Register your groups
-ALL_GROUPS = [AppGroup]
-
-# Setup DI with your groups
-modern_di_fastapi.setup_di(app, Container(groups=ALL_GROUPS, validate=True))
+app = fastapi.FastAPI()
+modern_di_fastapi.setup_di(app, Container(groups=[AppGroup], validate=True))
 
 
-@app.get("/")
-async def read_root(
-    instance: typing.Annotated[
-        datetime.datetime,
-        modern_di_fastapi.FromDI(datetime.datetime),  # Resolve by type instead of provider
-    ],
-) -> datetime.datetime:
-    return instance
-
+@app.get("/report")
+async def report(
+    request_report: typing.Annotated[RequestReport, modern_di_fastapi.FromDI(RequestReport)],
+) -> dict[str, str]:
+    return request_report.as_dict()
 ```
 
 ## Websockets
@@ -159,6 +159,13 @@ class AppGroup(Group):
         kwargs={"request": modern_di_fastapi.fastapi_request_provider}
     )
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Async SQLAlchemy](../recipes/sqlalchemy.md) — engine + session + repository through the request container.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/faststream.md
+++ b/docs/integrations/faststream.md
@@ -36,44 +36,36 @@ from modern_di import Container, Group, Scope, providers
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    feature_flag: bool = False
+    service_name: str = "catalog"
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class OrderProcessor:
-    settings: Settings        # auto-injected by type
+class MessageReport:
+    settings: Settings                    # APP-scoped, injected by type
+    message: faststream.StreamMessage     # per-message context object, injected by type
 
-    def process(self, payload: dict) -> dict:
-        return {"ok": True, "feature_flag": self.settings.feature_flag}
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "message_id": str(self.message.message_id),
+        }
 
 
 class AppGroup(Group):
-    settings = providers.Factory(
-        Settings,
-        scope=Scope.APP,
-        cache=True,
-    )
-    order_processor = providers.Factory(
-        OrderProcessor,
-        scope=Scope.REQUEST,
-    )
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    message_report = providers.Factory(MessageReport, scope=Scope.REQUEST)
 
 
 broker = NatsBroker()
 app = faststream.FastStream(broker=broker)
-
 modern_di_faststream.setup_di(app, Container(groups=[AppGroup], validate=True))
 
 
 @broker.subscriber("orders.in")
 async def handle_order(
-    payload: dict,
-    processor: typing.Annotated[
-        OrderProcessor,
-        modern_di_faststream.FromDI(OrderProcessor),    # resolve by type
-    ],
-) -> dict:
-    return processor.process(payload)
+    report: typing.Annotated[MessageReport, modern_di_faststream.FromDI(MessageReport)],
+) -> dict[str, str]:
+    return report.as_dict()
 ```
 
 ## Scopes
@@ -131,6 +123,13 @@ class AppGroup(Group):
         kwargs={"message": modern_di_faststream.faststream_message_provider},
     )
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Async resources via lifespan](../recipes/async-lifespan.md) — constructing async resources with finalizers.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/faststream.md
+++ b/docs/integrations/faststream.md
@@ -40,20 +40,16 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class MessageReport:
-    settings: Settings                    # APP-scoped, injected by type
-    message: faststream.StreamMessage     # per-message context object, injected by type
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "message_id": str(self.message.message_id),
-        }
+        return {"service": self.settings.service_name}
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    message_report = providers.Factory(MessageReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 broker = NatsBroker()
@@ -63,7 +59,7 @@ modern_di_faststream.setup_di(app, Container(groups=[AppGroup], validate=True))
 
 @broker.subscriber("orders.in")
 async def handle_order(
-    report: typing.Annotated[MessageReport, modern_di_faststream.FromDI(MessageReport)],
+    report: typing.Annotated[Report, modern_di_faststream.FromDI(Report)],
 ) -> dict[str, str]:
     return report.as_dict()
 ```

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -22,35 +22,56 @@ Resolution is **sync-only** — the child container is closed with `close_sync()
       pip install modern-di-flask
       ```
 
+=== "poetry"
+
+      ```bash
+      poetry add modern-di-flask
+      ```
+
 ### 2. Apply to your application
 
 ```python
+import dataclasses
 import typing
 
-from flask import Flask
+from flask import Flask, Request
 from modern_di import Container, Group, Scope, providers
 from modern_di_flask import FromDI, inject, setup_di
 
 
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    def __init__(self) -> None:
-        self.greeting = "hello"
+    service_name: str = "catalog"
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class RequestReport:
+    settings: Settings   # APP-scoped, injected by type
+    request: Request     # REQUEST context object, injected by type
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "method": self.request.method,
+            "path": self.request.path,
+        }
 
 
 class Dependencies(Group):
-    settings = providers.Factory(scope=Scope.APP, creator=Settings)
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
 
 
 app = Flask(__name__)
 
 
-@app.route("/hello/<name>")
+@app.route("/report")
 @inject
-def hello(name: str, settings: typing.Annotated[Settings, FromDI(Dependencies.settings)]) -> str:
-    return f"{settings.greeting}, {name}"
+def report(request_report: typing.Annotated[RequestReport, FromDI(RequestReport)]) -> dict[str, str]:
+    return request_report.as_dict()
 
 
-# call setup_di AFTER registering routes — required when using auto_inject
+# call setup_di AFTER registering routes
 setup_di(app, Container(groups=[Dependencies], validate=True))
 ```
 
@@ -172,6 +193,13 @@ class AppGroup(Group):
         kwargs={"request": flask_request_provider},
     )
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Multi-Group organization](../recipes/multi-group.md) — structuring a larger container.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -34,7 +34,7 @@ Resolution is **sync-only** — the child container is closed with `close_sync()
 import dataclasses
 import typing
 
-from flask import Flask, Request
+from flask import Flask
 from modern_di import Container, Group, Scope, providers
 from modern_di_flask import FromDI, inject, setup_di
 
@@ -45,21 +45,16 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class RequestReport:
+class Report:
     settings: Settings   # APP-scoped, injected by type
-    request: Request     # REQUEST context object, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "method": self.request.method,
-            "path": self.request.path,
-        }
+        return {"service": self.settings.service_name}
 
 
 class Dependencies(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 app = Flask(__name__)
@@ -67,8 +62,8 @@ app = Flask(__name__)
 
 @app.route("/report")
 @inject
-def report(request_report: typing.Annotated[RequestReport, FromDI(RequestReport)]) -> dict[str, str]:
-    return request_report.as_dict()
+def get_report(report: typing.Annotated[Report, FromDI(Report)]) -> dict[str, str]:
+    return report.as_dict()
 
 
 # call setup_di AFTER registering routes

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -198,7 +198,7 @@ class AppGroup(Group):
 
 - [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
 - [Multi-Group organization](../recipes/multi-group.md) — structuring a larger container.
-- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and container teardown.
 - [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API

--- a/docs/integrations/grpc.md
+++ b/docs/integrations/grpc.md
@@ -41,20 +41,22 @@ from myapp import greeter_pb2, greeter_pb2_grpc   # your generated stubs
 
 class Settings:
     def __init__(self) -> None:
-        self.greeting = "hello"
+        self.service_name = "catalog"
 
 
-class Greeter:
-    def __init__(self, settings: Settings) -> None:   # auto-injected by type
-        self._settings = settings
+class RpcReport:
+    def __init__(self, settings: Settings, context: grpc.ServicerContext | None = None) -> None:
+        self._settings = settings                  # APP-scoped, injected by type
+        self._context = context                    # REQUEST context object, injected by type
 
-    def greet(self, name: str) -> str:
-        return f"{self._settings.greeting}, {name}"
+    def line(self) -> str:
+        peer = self._context.peer() if self._context is not None else "unknown"
+        return f"{self._settings.service_name} <- {peer}"
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    greeter = providers.Factory(Greeter, scope=Scope.REQUEST)
+    rpc_report = providers.Factory(RpcReport, scope=Scope.REQUEST)
 
 
 class GreeterService(greeter_pb2_grpc.GreeterServicer):
@@ -63,9 +65,9 @@ class GreeterService(greeter_pb2_grpc.GreeterServicer):
         self,
         request: greeter_pb2.HelloRequest,
         context: grpc.ServicerContext,
-        greeter: typing.Annotated[Greeter, FromDI(Greeter)],   # resolve by type
+        report: typing.Annotated[RpcReport, FromDI(RpcReport)],   # resolve by type
     ) -> greeter_pb2.HelloReply:
-        return greeter_pb2.HelloReply(message=greeter.greet(request.name))
+        return greeter_pb2.HelloReply(message=report.line())
 
 
 container = Container(groups=[AppGroup], validate=True)
@@ -175,6 +177,12 @@ container = fetch_di_container()   # raises LookupError outside an intercepted R
 Unlike the Celery/Typer decorator integrations, gRPC always calls a servicer
 method as `(request, context)`, so `@inject` needs no signature rewrite and
 imposes no restriction on the method signature beyond the injected parameters.
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and container teardown.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -39,30 +39,25 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class RequestReport:
-    settings: Settings           # APP-scoped, injected by type
-    request: litestar.Request    # REQUEST context object, injected by type
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "method": self.request.method,
-            "path": self.request.url.path,
-        }
+        return {"service": self.settings.service_name}
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
-@litestar.get("/report", dependencies={"report": modern_di_litestar.FromDI(RequestReport)})
-async def report(report: RequestReport) -> dict[str, str]:
+@litestar.get("/report", dependencies={"report": modern_di_litestar.FromDI(Report)})
+async def get_report(report: Report) -> dict[str, str]:
     return report.as_dict()
 
 
 app = litestar.Litestar(
-    route_handlers=[report],
+    route_handlers=[get_report],
     plugins=[modern_di_litestar.ModernDIPlugin(Container(groups=[AppGroup], validate=True))],
 )
 ```

--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -26,37 +26,44 @@
 
 ### 2. Apply to your application
 ```python
-import datetime
+import dataclasses
 
-from litestar import Litestar, get
+import litestar
 import modern_di_litestar
 from modern_di import Container, Group, Scope, providers
 
 
-def create_singleton() -> datetime.datetime:
-    return datetime.datetime.now(tz=datetime.timezone.utc)
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class Settings:
+    service_name: str = "catalog"
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class RequestReport:
+    settings: Settings           # APP-scoped, injected by type
+    request: litestar.Request    # REQUEST context object, injected by type
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "method": self.request.method,
+            "path": self.request.url.path,
+        }
 
 
 class AppGroup(Group):
-    singleton = providers.Factory(
-        create_singleton,
-        scope=Scope.APP,
-        cache=True
-    )
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
 
 
-# Register your groups
-ALL_GROUPS = [AppGroup]
+@litestar.get("/report", dependencies={"report": modern_di_litestar.FromDI(RequestReport)})
+async def report(report: RequestReport) -> dict[str, str]:
+    return report.as_dict()
 
 
-@get("/", dependencies={"injected": modern_di_litestar.FromDI(datetime.datetime)})  # Resolve by type
-async def index(injected: datetime.datetime) -> str:
-    return injected.isoformat()
-
-
-app = Litestar(
-    route_handlers=[index],
-    plugins=[modern_di_litestar.ModernDIPlugin(Container(groups=ALL_GROUPS, validate=True))],
+app = litestar.Litestar(
+    route_handlers=[report],
+    plugins=[modern_di_litestar.ModernDIPlugin(Container(groups=[AppGroup], validate=True))],
 )
 ```
 
@@ -197,6 +204,13 @@ class AppGroup(Group):
         kwargs={"request": modern_di_litestar.litestar_request_provider}
     )
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Async SQLAlchemy](../recipes/sqlalchemy.md) — engine + session + repository through the request container.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/pytest.md
+++ b/docs/integrations/pytest.md
@@ -170,3 +170,8 @@ def mock_user_repo(di_container: modern_di.Container) -> typing.Iterator[None]:
 ```
 
 For deeper patterns (transactional DB sessions, resetting all overrides) see the [testing-with-overrides recipe](../recipes/testing-overrides.md).
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — override patterns beyond fixtures.
+- [Scopes](../providers/scopes.md) — session vs request container fixtures.

--- a/docs/integrations/starlette.md
+++ b/docs/integrations/starlette.md
@@ -47,32 +47,27 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class RequestReport:
-    settings: Settings      # APP-scoped, injected by type
-    request: Request        # REQUEST context object, injected by type
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "method": self.request.method,
-            "path": self.request.url.path,
-        }
+        return {"service": self.settings.service_name}
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 @inject
-async def report(
+async def get_report(
     request: Request,
-    request_report: typing.Annotated[RequestReport, FromDI(RequestReport)],
+    report: typing.Annotated[Report, FromDI(Report)],
 ) -> JSONResponse:
-    return JSONResponse(request_report.as_dict())
+    return JSONResponse(report.as_dict())
 
 
-app = Starlette(routes=[Route("/report", report)])
+app = Starlette(routes=[Route("/report", get_report)])
 setup_di(app, Container(groups=[AppGroup], validate=True))
 ```
 

--- a/docs/integrations/starlette.md
+++ b/docs/integrations/starlette.md
@@ -21,6 +21,12 @@ per-connection child container automatically.
       pip install modern-di-starlette
       ```
 
+=== "poetry"
+
+      ```bash
+      poetry add modern-di-starlette
+      ```
+
 ### 2. Apply to your application
 
 ```python
@@ -35,24 +41,38 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 
-@dataclasses.dataclass(kw_only=True)
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    debug: bool = True
+    service_name: str = "catalog"
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class RequestReport:
+    settings: Settings      # APP-scoped, injected by type
+    request: Request        # REQUEST context object, injected by type
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "method": self.request.method,
+            "path": self.request.url.path,
+        }
 
 
 class AppGroup(Group):
-    settings = providers.Factory(Settings, scope=Scope.APP)
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    request_report = providers.Factory(RequestReport, scope=Scope.REQUEST)
 
 
 @inject
-async def homepage(
+async def report(
     request: Request,
-    settings: typing.Annotated[Settings, FromDI(AppGroup.settings)],
+    request_report: typing.Annotated[RequestReport, FromDI(RequestReport)],
 ) -> JSONResponse:
-    return JSONResponse({"debug": settings.debug})
+    return JSONResponse(request_report.as_dict())
 
 
-app = Starlette(routes=[Route("/", homepage)])
+app = Starlette(routes=[Route("/report", report)])
 setup_di(app, Container(groups=[AppGroup], validate=True))
 ```
 
@@ -134,6 +154,13 @@ class AppGroup(Group):
         kwargs={"request": modern_di_starlette.starlette_request_provider},
     )
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Async SQLAlchemy](../recipes/sqlalchemy.md) — engine + session + repository through the request container.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/taskiq.md
+++ b/docs/integrations/taskiq.md
@@ -30,7 +30,7 @@ import typing
 
 from modern_di import Container, Group, Scope, providers
 from modern_di_taskiq import FromDI, setup_di
-from taskiq import InMemoryBroker, TaskiqMessage
+from taskiq import InMemoryBroker
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
@@ -39,20 +39,16 @@ class Settings:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class TaskReport:
-    settings: Settings          # APP-scoped, injected by type
-    message: TaskiqMessage      # per-task context object, injected by type
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
     def as_dict(self) -> dict[str, str]:
-        return {
-            "service": self.settings.service_name,
-            "task": self.message.task_name,
-        }
+        return {"service": self.settings.service_name}
 
 
 class AppGroup(Group):
     settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
-    task_report = providers.Factory(TaskReport, scope=Scope.REQUEST)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 broker = InMemoryBroker()
@@ -60,10 +56,10 @@ setup_di(broker, Container(groups=[AppGroup], validate=True))
 
 
 @broker.task
-async def report(
-    task_report: typing.Annotated[TaskReport, FromDI(TaskReport)],
+async def get_report(
+    report: typing.Annotated[Report, FromDI(Report)],
 ) -> dict[str, str]:
-    return task_report.as_dict()
+    return report.as_dict()
 ```
 
 `setup_di(broker, container)` stores the container on `broker.state` and registers `TaskiqEvents.WORKER_STARTUP`/`WORKER_SHUTDOWN` handlers that open/close it — those fire when the broker's worker process starts and stops, so a script that just calls tasks directly (like `InMemoryBroker` in a test) must drive the container lifecycle itself, e.g. `async with broker: ...` or an explicit `container.open()` / `await container.close_async()`.

--- a/docs/integrations/taskiq.md
+++ b/docs/integrations/taskiq.md
@@ -30,32 +30,29 @@ import typing
 
 from modern_di import Container, Group, Scope, providers
 from modern_di_taskiq import FromDI, setup_di
-from taskiq import InMemoryBroker
+from taskiq import InMemoryBroker, TaskiqMessage
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    greeting: str = "hello"
+    service_name: str = "catalog"
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class Greeter:
-    settings: Settings        # auto-injected by type
+class TaskReport:
+    settings: Settings          # APP-scoped, injected by type
+    message: TaskiqMessage      # per-task context object, injected by type
 
-    def greet(self, name: str) -> str:
-        return f"{self.settings.greeting}, {name}"
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "service": self.settings.service_name,
+            "task": self.message.task_name,
+        }
 
 
 class AppGroup(Group):
-    settings = providers.Factory(
-        Settings,
-        scope=Scope.APP,
-        cache=True,
-    )
-    greeter = providers.Factory(
-        Greeter,
-        scope=Scope.REQUEST,
-    )
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    task_report = providers.Factory(TaskReport, scope=Scope.REQUEST)
 
 
 broker = InMemoryBroker()
@@ -63,14 +60,10 @@ setup_di(broker, Container(groups=[AppGroup], validate=True))
 
 
 @broker.task
-async def greet(
-    name: str,
-    greeter: typing.Annotated[
-        Greeter,
-        FromDI(Greeter),    # resolve by type
-    ],
-) -> str:
-    return greeter.greet(name)
+async def report(
+    task_report: typing.Annotated[TaskReport, FromDI(TaskReport)],
+) -> dict[str, str]:
+    return task_report.as_dict()
 ```
 
 `setup_di(broker, container)` stores the container on `broker.state` and registers `TaskiqEvents.WORKER_STARTUP`/`WORKER_SHUTDOWN` handlers that open/close it — those fire when the broker's worker process starts and stops, so a script that just calls tasks directly (like `InMemoryBroker` in a test) must drive the container lifecycle itself, e.g. `async with broker: ...` or an explicit `container.open()` / `await container.close_async()`.
@@ -134,6 +127,13 @@ class AppGroup(Group):
         kwargs={"message": modern_di_taskiq.taskiq_message_provider},
     )
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Async resources via lifespan](../recipes/async-lifespan.md) — constructing async resources with finalizers.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and `close_async()`.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/typer.md
+++ b/docs/integrations/typer.md
@@ -35,27 +35,20 @@ from modern_di import Container, Group, Scope, providers
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Settings:
-    environment: str = "production"
+    service_name: str = "catalog"
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class HealthReporter:
-    settings: Settings    # auto-injected by type
+class Report:
+    settings: Settings   # APP-scoped, injected by type
 
-    def report(self) -> str:
-        return f"healthy in {self.settings.environment}"
+    def render(self) -> str:
+        return f"service={self.settings.service_name}"
 
 
 class AppGroup(Group):
-    settings = providers.Factory(
-        Settings,
-        scope=Scope.APP,
-        cache=True,
-    )
-    health_reporter = providers.Factory(
-        HealthReporter,
-        scope=Scope.REQUEST,
-    )
+    settings = providers.Factory(Settings, scope=Scope.APP, cache=True)
+    report = providers.Factory(Report, scope=Scope.REQUEST)
 
 
 app = typer.Typer()
@@ -66,12 +59,9 @@ modern_di_typer.setup_di(app, container)
 @app.command()
 @modern_di_typer.inject
 def status(
-    reporter: typing.Annotated[
-        HealthReporter,
-        modern_di_typer.FromDI(HealthReporter),    # resolve by type
-    ],
+    report: typing.Annotated[Report, modern_di_typer.FromDI(Report)],   # resolve by type
 ) -> None:
-    typer.echo(reporter.report())
+    typer.echo(report.render())
 
 
 if __name__ == "__main__":
@@ -113,6 +103,12 @@ def run_job(
         job = action_container.resolve_provider(AppGroup.job)
         job.run()
 ```
+
+## See also
+
+- [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.
+- [Lifecycle](../providers/lifecycle.md) — finalizers and container teardown.
+- [Scopes](../providers/scopes.md) — the APP → REQUEST lifetime model.
 
 ## API
 

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -357,8 +357,13 @@ Each official integration is its own repository and PyPI package, mirroring the
   family group: Web / Tasks & events / Bots / RPC / CLI / Testing). Follow the
   canonical page shape the existing pages use: a single realistic-but-compact
   example — an APP-scoped `Settings` plus one work-scoped service (two providers,
-  no more) that depends on `Settings` by type and, where the framework exposes a
-  connection/message object, reads one field of it — followed by any
+  no more) that depends on `Settings` by type — built with `validate=True`. Keep
+  the connection/message object **out** of that validated example: its
+  `ContextProvider` is registered by `setup_di` *after* the container is
+  constructed, so a service that requires it by type fails `validate=True` at
+  construction. Demonstrate context injection in a dedicated "Framework Context
+  Objects" section instead (unvalidated, or with an optional `| None = None`
+  parameter as the [gRPC page](grpc.md) does). Follow the example with any
   framework-specific sections, a tailored `## See also` block linking
   [Testing with overrides](../recipes/testing-overrides.md),
   [Lifecycle](../providers/lifecycle.md), [Scopes](../providers/scopes.md), and

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -353,7 +353,16 @@ Each official integration is its own repository and PyPI package, mirroring the
   home. Keep resolution sync-only and add no runtime dependency beyond the
   framework and `modern-di`.
 - **Docs.** Add a `docs/integrations/<framework>.md` usage page **in the
-  `modern-di` repo** and a nav entry for it in `mkdocs.yml`; integrations do not
+  `modern-di` repo** and a nav entry for it in `mkdocs.yml` (under the matching
+  family group: Web / Tasks & events / Bots / RPC / CLI / Testing). Follow the
+  canonical page shape the existing pages use: a single realistic-but-compact
+  example — an APP-scoped `Settings` plus one work-scoped service (two providers,
+  no more) that depends on `Settings` by type and, where the framework exposes a
+  connection/message object, reads one field of it — followed by any
+  framework-specific sections, a tailored `## See also` block linking
+  [Testing with overrides](../recipes/testing-overrides.md),
+  [Lifecycle](../providers/lifecycle.md), [Scopes](../providers/scopes.md), and
+  the most relevant recipe, and the `## API` table last. Integrations do not
   ship their own docs site.
 - **Release.** Tag-driven, mirroring `modern-di`: write release notes and push a
   bare semver tag off green `main`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,18 +170,10 @@ plugins:
           - providers/errors-and-exceptions.md: The ModernDIError exception hierarchy
           - providers/advanced-api.md: Low-level extension points for library authors
         Integrations:
-          - integrations/aiohttp.md: Usage with aiohttp
-          - integrations/fastapi.md: Usage with FastAPI
-          - integrations/flask.md: Usage with Flask
-          - integrations/litestar.md: Usage with Litestar
-          - integrations/starlette.md: Usage with Starlette
-          - integrations/arq.md: Usage with arq
-          - integrations/celery.md: Usage with Celery
-          - integrations/faststream.md: Usage with FastStream
-          - integrations/taskiq.md: Usage with taskiq
-          - integrations/aiogram.md: Usage with aiogram
-          - integrations/grpc.md: Usage with gRPC
-          - integrations/typer.md: Usage with Typer
+          # Bulk-include every integration page so a new one needs no edit here;
+          # the two lines below re-list the pages whose description adds info
+          # beyond the nav label (a glob yields an empty description).
+          - integrations/*.md
           - integrations/pytest.md: Usage with pytest, with and without modern-di-pytest
           - integrations/writing-integrations.md: Specification for building a new framework integration
         Recipes:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,19 +21,25 @@ nav:
       - Errors and exceptions: providers/errors-and-exceptions.md
       - Advanced / low-level API: providers/advanced-api.md
   - Integrations:
-      - aiogram: integrations/aiogram.md
-      - aiohttp: integrations/aiohttp.md
-      - arq: integrations/arq.md
-      - celery: integrations/celery.md
-      - FastAPI: integrations/fastapi.md
-      - FastStream: integrations/faststream.md
-      - Flask: integrations/flask.md
-      - gRPC: integrations/grpc.md
-      - Litestar: integrations/litestar.md
-      - Starlette: integrations/starlette.md
-      - taskiq: integrations/taskiq.md
-      - Typer: integrations/typer.md
-      - Pytest: integrations/pytest.md
+      - Web:
+          - aiohttp: integrations/aiohttp.md
+          - FastAPI: integrations/fastapi.md
+          - Flask: integrations/flask.md
+          - Litestar: integrations/litestar.md
+          - Starlette: integrations/starlette.md
+      - Tasks & events:
+          - arq: integrations/arq.md
+          - Celery: integrations/celery.md
+          - FastStream: integrations/faststream.md
+          - taskiq: integrations/taskiq.md
+      - Bots:
+          - aiogram: integrations/aiogram.md
+      - RPC:
+          - gRPC: integrations/grpc.md
+      - CLI:
+          - Typer: integrations/typer.md
+      - Testing:
+          - Pytest: integrations/pytest.md
       - Writing an integration: integrations/writing-integrations.md
   - Recipes:
       - Async SQLAlchemy: recipes/sqlalchemy.md
@@ -164,17 +170,17 @@ plugins:
           - providers/errors-and-exceptions.md: The ModernDIError exception hierarchy
           - providers/advanced-api.md: Low-level extension points for library authors
         Integrations:
-          - integrations/aiogram.md: Usage with aiogram
           - integrations/aiohttp.md: Usage with aiohttp
-          - integrations/arq.md: Usage with arq
-          - integrations/celery.md: Usage with Celery
           - integrations/fastapi.md: Usage with FastAPI
-          - integrations/faststream.md: Usage with FastStream
           - integrations/flask.md: Usage with Flask
-          - integrations/grpc.md: Usage with gRPC
           - integrations/litestar.md: Usage with Litestar
           - integrations/starlette.md: Usage with Starlette
+          - integrations/arq.md: Usage with arq
+          - integrations/celery.md: Usage with Celery
+          - integrations/faststream.md: Usage with FastStream
           - integrations/taskiq.md: Usage with taskiq
+          - integrations/aiogram.md: Usage with aiogram
+          - integrations/grpc.md: Usage with gRPC
           - integrations/typer.md: Usage with Typer
           - integrations/pytest.md: Usage with pytest, with and without modern-di-pytest
           - integrations/writing-integrations.md: Specification for building a new framework integration

--- a/planning/changes/2026-07-14.04-integration-docs-realistic-examples.md
+++ b/planning/changes/2026-07-14.04-integration-docs-realistic-examples.md
@@ -1,5 +1,5 @@
 ---
-summary: Enrich the 13 integration docs pages with realistic-but-compact examples, tailored See-also blocks, consistent shape, and a categorized nav.
+summary: Enriched all 13 integration docs pages with realistic-but-compact examples and tailored See-also blocks, unified their shape and install tabs, categorized the Integrations nav, and recorded the canonical page shape in writing-integrations.md.
 ---
 
 # Design: Realistic examples for the integration docs pages

--- a/planning/changes/2026-07-14.04-integration-docs-realistic-examples.md
+++ b/planning/changes/2026-07-14.04-integration-docs-realistic-examples.md
@@ -1,0 +1,110 @@
+---
+summary: Enrich the 13 integration docs pages with realistic-but-compact examples, tailored See-also blocks, consistent shape, and a categorized nav.
+---
+
+# Design: Realistic examples for the integration docs pages
+
+## Summary
+
+The 13 `docs/integrations/*.md` pages share good scaffolding but every code
+example is a toy (`datetime.datetime` singleton, or a `Settings`/`Greeter`/
+`greet(name)` trio) and each demonstrates essentially one provider + one handler
++ `FromDI`. This change replaces the toy with one realistic-but-compact example
+per page that naturally shows a small multi-provider graph and one real scope
+crossing, adds a tailored "See also" block that links depth instead of inlining
+it, fixes consistency drift, categorizes the Integrations nav, and records the
+canonical page shape in `writing-integrations.md` so future pages don't regress.
+
+## Motivation
+
+Two concrete gaps, confirmed by reading all 13 pages:
+
+- **Not real.** No page except FastAPI/Litestar (which link the SQLAlchemy
+  templates) shows anything resembling a service. `greeting="hello"` /
+  `datetime.now()` teach the mechanics but not how a real graph is wired.
+- **Too few features.** Each page shows one provider + one handler. Multi-provider
+  graphs, scope interactions beyond the websocket note, lifecycle/finalizers, and
+  testing are only reachable via generic recipes no integration page points to.
+
+Drift compounds it: aiohttp/starlette/flask omit the `poetry` install tab the
+others carry; the example domain flips between `datetime` and `Settings/Greeter`;
+`cache=True` vs `CacheSettings` is used inconsistently. dishka (checked for
+prior art) confirms the direction: it categorizes integrations and keeps depth in
+runnable examples the pages link to, rather than fattening each page.
+
+## Design
+
+**Canonical example shape.** Every page's main example becomes the same *shape*,
+rendered in the framework's idiom:
+
+- `Settings` at `Scope.APP`, cached — real config fields, not `greeting="hello"`.
+- One work-scoped service/repository (`REQUEST`, or the framework's per-unit
+  scope) that depends on `Settings` **by type** — one snippet shows the APP→REQUEST
+  scope crossing *and* type-based auto-wiring.
+- Where the framework has a context object (request/message/update), the service
+  reads one real field from it, folding context injection into the main example.
+- A finalizer only where it reads naturally (a resource that must close).
+
+Two providers and one genuine scope interaction — real, not overloaded. The exact
+recurring domain (leaning toward a small config-backed lookup/report service) is
+locked in spec review before enrichment starts. Task-queue / CLI / RPC pages use
+the same shape with a task/command/servicer-method instead of an HTTP handler.
+
+**Per-page structure.** Intro → How to use (install tabs + enriched example) →
+framework-specific sections as they exist today (websockets, auto-inject, DITask,
+action scope) → **See also** (new) → API table. The "Framework Context Objects"
+implicit/explicit block stays where the framework has one, but shrinks: the main
+example now carries the implicit case.
+
+**See-also block (tailored, not uniform).** A short per-page block linking a
+curated subset of Testing-with-overrides, Lifecycle, Scopes, and the single most
+relevant recipe (SQLAlchemy for web frameworks; not for Typer). Each page links
+only what applies, so it reads as next-steps, not boilerplate.
+
+**Consistency hygiene.** Add the missing `poetry` tab to aiohttp/starlette/flask;
+converge on the Quickstart convention (`CacheSettings` when a finalizer is
+attached, bare `cache=True` for a plain singleton); apply the canonical shape so
+the domain stops flipping.
+
+**Nav categorization.** Regroup the flat `Integrations` nav in `mkdocs.yml` into
+Web (aiohttp, FastAPI, Flask, Litestar, Starlette) / Tasks & events (arq, Celery,
+FastStream, taskiq) / Bots (aiogram) / RPC (gRPC) / CLI (Typer) / Testing
+(pytest), plus "Writing an integration". Mirror the grouping in the `llmstxt`
+plugin section. Nav-only; page files unaffected. Exact category names/order
+confirmed in spec review.
+
+**Template documentation.** Extend the "Docs" bullet in
+`writing-integrations.md` to specify the canonical page shape (realistic example
++ See-also block) so new integration pages hold the bar.
+
+**Rollout.** One Full-lane change, shipped in framework-family batches (web →
+tasks → bots/rpc/cli/testing) so review stays scoped, with hygiene + nav +
+`writing-integrations.md` in a final pass.
+
+## Non-goals
+
+- No single shared app wired across all frameworks — rejected as over-coupling.
+- No new runnable example repos — maintenance cost across separate repos.
+- No fat per-page feature sections (Testing/Lifespan/Multi-scope as standing
+  sections) — fights the "don't overload" constraint; that depth is linked, not
+  inlined.
+- No code or API changes — docs only.
+
+## Testing
+
+`just lint-ci` (validates planning bundles + docs lint) and `just check-planning`
+pass. `mkdocs build --strict` succeeds with no broken cross-links or nav
+warnings. Manual read-through confirms each enriched example is copy-pasteable
+against the current integration APIs.
+
+## Risk
+
+- **Example drift from real APIs** (medium likelihood, medium impact): an
+  enriched snippet could use an integration symbol incorrectly. Mitigation: each
+  example is checked against the integration's documented API table on the same
+  page; batching by family keeps the reviewer's context tight.
+- **Over-enrichment creep** (medium/low): "realistic" tempts toward full apps.
+  Mitigation: the two-provider/one-scope-crossing cap is normative, enforced in
+  review.
+- **Nav churn** (low): category names bikeshed. Mitigation: settled in spec
+  review before any page work.

--- a/planning/changes/2026-07-14.04-integration-docs-realistic-examples.md
+++ b/planning/changes/2026-07-14.04-integration-docs-realistic-examples.md
@@ -41,8 +41,12 @@ rendered in the framework's idiom:
 - One work-scoped service/repository (`REQUEST`, or the framework's per-unit
   scope) that depends on `Settings` **by type** — one snippet shows the APP→REQUEST
   scope crossing *and* type-based auto-wiring.
-- Where the framework has a context object (request/message/update), the service
-  reads one real field from it, folding context injection into the main example.
+- The framework's context object (request/message/update) stays **out** of this
+  validated example: its `ContextProvider` is registered by `setup_di` after the
+  container is constructed, so a service that requires it by type would fail
+  `validate=True` at construction. Context injection is shown in the existing
+  "Framework Context Objects" section instead. (gRPC is the exception — its
+  `ServicerContext | None = None` optional param validates cleanly.)
 - A finalizer only where it reads naturally (a resource that must close).
 
 Two providers and one genuine scope interaction — real, not overloaded. The exact
@@ -53,8 +57,9 @@ the same shape with a task/command/servicer-method instead of an HTTP handler.
 **Per-page structure.** Intro → How to use (install tabs + enriched example) →
 framework-specific sections as they exist today (websockets, auto-inject, DITask,
 action scope) → **See also** (new) → API table. The "Framework Context Objects"
-implicit/explicit block stays where the framework has one, but shrinks: the main
-example now carries the implicit case.
+implicit/explicit block is kept intact where the framework has one — it is the
+correct place to demonstrate context injection (the main example stays
+context-free so it validates at construction).
 
 **See-also block (tailored, not uniform).** A short per-page block linking a
 curated subset of Testing-with-overrides, Lifecycle, Scopes, and the single most


### PR DESCRIPTION
Enriches the 13 integration docs pages so they teach from realistic-but-compact examples instead of toys, and tidies the surrounding structure.

**Rationale & design:** [`planning/changes/2026-07-14.04-integration-docs-realistic-examples.md`](planning/changes/2026-07-14.04-integration-docs-realistic-examples.md).

## What changed
- **Realistic main examples** on every page: an APP-scoped cached `Settings` + one work-scoped service, showing the APP→REQUEST scope crossing and type-based auto-wiring — replacing the `datetime.now()` / `Greeter("hello")` toys.
- **Tailored `## See also` blocks** linking testing-overrides, lifecycle, scopes, and the most relevant recipe per framework (sync pages use sync-correct teardown wording).
- **Consistency hygiene:** added the missing `poetry` install tab to aiohttp/starlette/flask; unified the example shape and `cache=True` usage.
- **Categorized the Integrations nav** in `mkdocs.yml` (Web / Tasks & events / Bots / RPC / CLI / Testing) and reordered the `llmstxt` section to match.
- **Documented the canonical page shape** in `writing-integrations.md` so future pages hold the bar.

## Design note
The main examples keep the framework's context object (Request/Message/Update) **out** of the `validate=True` container — its `ContextProvider` is registered by `setup_di` after construction, so requiring it by type would fail validation. Context injection stays taught in each page's "Framework Context Objects" section; gRPC's `ServicerContext | None = None` is the one validated-with-context exception.

## Verification
- `just lint-ci` (ruff, ty, planning-bundle validation) — green
- `just docs-build` (`mkdocs build --strict`) — clean, no link/nav warnings
- The Settings-only shape was executed against `modern-di` to confirm `validate=True` passes and the REQUEST child resolves.

Docs-only: no `modern_di/` or `tests/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)