### PR TITLE
docs: recommend optional context types to keep validate=True

### DIFF
--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -361,9 +361,13 @@ Each official integration is its own repository and PyPI package, mirroring the
   the connection/message object **out** of that validated example: its
   `ContextProvider` is registered by `setup_di` *after* the container is
   constructed, so a service that requires it by type fails `validate=True` at
-  construction. Demonstrate context injection in a dedicated "Framework Context
-  Objects" section instead (unvalidated, or with an optional `| None = None`
-  parameter as the [gRPC page](grpc.md) does). Follow the example with any
+  construction. Demonstrate context injection in a dedicated "Framework
+  Context Objects" section instead. To show it inside a `validate=True` container,
+  make the context parameter optional (`request: FrameworkType | None = None`) so
+  validation skips it while the integration still injects the real value at runtime —
+  the pattern the [gRPC page](grpc.md) uses and
+  [Framework Context Objects](../providers/context.md#framework-context-objects)
+  documents. Follow the example with any
   framework-specific sections, a tailored `## See also` block linking
   [Testing with overrides](../recipes/testing-overrides.md),
   [Lifecycle](../providers/lifecycle.md), [Scopes](../providers/scopes.md), and

--- a/docs/providers/context.md
+++ b/docs/providers/context.md
@@ -152,11 +152,14 @@ runs inside the `Container(...)` call, *before* `setup_di()` registers
 raise [`ArgumentResolutionError`](../troubleshooting/argument-resolution-error.md).
 A defaulted parameter is skipped by that check, and at runtime the integration has
 registered the provider and set the per-request context, so the real `Request` is
-injected. The default is load-bearing only at validation time — in modern-di 3.0 an
-unset context still raises `ContextValueNotSetError` at resolve, so the annotation
-does not hide a missing-context bug. Prefer this to `validate=False`, which silences
-*all* validation; reach for `validate=False` (and validate after `setup_di()`
-instead) only if you'd rather keep the parameter required.
+injected — the parameter is `None` only when resolved with no context set, which the
+integration never does per request. The default is load-bearing only at validation
+time; it does not change runtime behaviour. (A defaulted `Factory` parameter keeps
+its own disposition in modern-di 3.0 — the 3.0 `ContextValueNotSetError` affects only
+a *direct* resolve of an unset context type, not a defaulted parameter, which still
+falls back to its default.) Prefer this to `validate=False`, which silences *all*
+validation; reach for `validate=False` (and validate after `setup_di()` instead)
+only if you'd rather keep the parameter required so a missing context fails loudly.
 
 **Explicit usage (provider-based resolution).** Every integration also exports the underlying
 `ContextProvider` object itself (e.g. `fastapi_request_provider`, `litestar_request_provider`,

--- a/docs/providers/context.md
+++ b/docs/providers/context.md
@@ -120,12 +120,10 @@ import fastapi
 import modern_di_fastapi
 
 
-def create_request_info(request: fastapi.Request) -> dict[str, str]:
-    return {
-        "method": request.method,
-        "url": str(request.url),
-        "timestamp": "2023-01-01T00:00:00Z"
-    }
+def create_request_info(request: fastapi.Request | None = None) -> dict[str, str]:
+    if request is None:  # only at validate() time; the integration always sets it at runtime
+        return {}
+    return {"method": request.method, "url": str(request.url)}
 
 
 class Dependencies(Group):
@@ -138,15 +136,27 @@ class Dependencies(Group):
 
 ALL_GROUPS = [Dependencies]
 app = fastapi.FastAPI()
-# validate=False: request_info depends on fastapi.Request, whose ContextProvider
-# is registered by setup_di() below — validating before that call would raise
-# ArgumentResolutionError for a dependency the integration hasn't wired in yet.
-container = Container(groups=ALL_GROUPS, validate=False)
+# validate=True stays on: the optional `request` parameter (| None = None) lets
+# validation skip it, since fastapi.Request's ContextProvider is only registered
+# by setup_di() below — after the container (and its validate()) is built.
+container = Container(groups=ALL_GROUPS, validate=True)
 modern_di_fastapi.setup_di(app, container)
 # The integration creates a REQUEST-scoped child container per request and
-# automatically injects the fastapi.Request into its context. The factory
-# is resolved from the child container, not the APP-scope container.
+# injects the fastapi.Request into its context, so `request` is the real object
+# at runtime — never None.
 ```
+
+The `| None = None` on `request` is what keeps `validate=True` usable. `validate()`
+runs inside the `Container(...)` call, *before* `setup_di()` registers
+`fastapi.Request`'s `ContextProvider`; a required parameter with no provider would
+raise [`ArgumentResolutionError`](../troubleshooting/argument-resolution-error.md).
+A defaulted parameter is skipped by that check, and at runtime the integration has
+registered the provider and set the per-request context, so the real `Request` is
+injected. The default is load-bearing only at validation time — in modern-di 3.0 an
+unset context still raises `ContextValueNotSetError` at resolve, so the annotation
+does not hide a missing-context bug. Prefer this to `validate=False`, which silences
+*all* validation; reach for `validate=False` (and validate after `setup_di()`
+instead) only if you'd rather keep the parameter required.
 
 **Explicit usage (provider-based resolution).** Every integration also exports the underlying
 `ContextProvider` object itself (e.g. `fastapi_request_provider`, `litestar_request_provider`,

--- a/docs/troubleshooting/argument-resolution-error.md
+++ b/docs/troubleshooting/argument-resolution-error.md
@@ -30,6 +30,14 @@ class Dependencies(Group):
     service2 = providers.Factory(Service, scope=Scope.APP, kwargs={"clock": clock})
 ```
 
+**Integration-supplied context types.** If the missing type is one a framework
+integration provides at runtime (`fastapi.Request`, `taskiq.TaskiqMessage`, …), its
+`ContextProvider` is registered by `setup_di()` — which runs *after* the container
+is built, so `validate=True` (and the modern-di 3.0 validate-by-default) sees no
+provider for it yet. Make the parameter optional (`request: fastapi.Request | None = None`)
+so validation skips it; the integration still injects the real value at runtime. See
+[Framework Context Objects](../providers/context.md#framework-context-objects).
+
 Check `.suggestions` on the caught exception for a "did you mean" hint when a similarly-named type is
 registered instead.
 

--- a/planning/changes/2026-07-14.05-optional-context-types-under-validate.md
+++ b/planning/changes/2026-07-14.05-optional-context-types-under-validate.md
@@ -1,0 +1,101 @@
+---
+summary: Document the optional-type pattern (`FrameworkType | None = None`) as the recommended way to depend on integration-supplied context under validate=True, replacing the validate=False workaround.
+---
+
+# Design: Optional framework types for integration-supplied context under validate=True
+
+## Summary
+
+A `Factory` that depends **by type** on an integration-supplied context object
+(`fastapi.Request`, `taskiq.TaskiqMessage`, …) fails `validate=True` at
+construction, because the integration registers that `ContextProvider` inside
+`setup_di`, which runs *after* the container is built. The current docs remedy
+is `validate=False`. This change documents a better remedy — type the parameter
+as `FrameworkType | None = None` — which keeps `validate=True` on. Docs-only; no
+core behavior changes.
+
+## Motivation
+
+`validate()` flags a `Factory` parameter as unresolvable when no provider for its
+type is registered *and* the parameter has no default. The pure-core case works
+(a user's own `ContextProvider` sits in a `Group`, present at construction), but
+the integration case does not:
+
+```python
+container = Container(groups=[AppGroup], validate=True)  # validate() runs here, graph incomplete → raises
+setup_di(app, container)                                 # ...context provider only registered here
+```
+
+This is not a papercut for long: modern-di 3.0 makes `validate()` run **by
+default** at root construction. Once it lands, every integration user whose group
+has a factory depending on the framework's request/message type breaks by
+default — unless they opt out with `validate=False` and lose validation entirely.
+
+`docs/providers/context.md` currently teaches `validate=False` as the remedy.
+`validate=False` silences *all* validation, not just the one deferred provider —
+the wrong default to teach heading into 3.0.
+
+## Design
+
+Recommend `param: FrameworkType | None = None`. A defaulted parameter is skipped
+by the missing-dependency check, so `validate=True` passes at construction; at
+runtime the integration has registered the provider, so resolution injects the
+**real** object. Verified end to end: construction validates, and a resolve with
+context set returns the real value (not `None`). The `| None = None` is
+load-bearing **only at validation time** — at runtime the registered
+`ContextProvider` governs, returning the real value when context is set and (in
+3.0) raising `ContextValueNotSetError` if it is somehow unset. So the annotation
+does not mask a missing-context bug at runtime under 3.0; it is purely a
+validation-time concession. This is exactly the rationale the gRPC page already
+documents for `grpc.ServicerContext | None = None`, generalized.
+
+Three doc edits:
+
+1. **`docs/providers/context.md`** (primary) — the implicit-usage-with-integration
+   example uses `validate=False`. Rewrite it to `request: fastapi.Request | None = None`
+   with `validate=True`, and a comment explaining why it validates yet still
+   injects the real request at runtime. Keep `validate=False` as a one-line
+   alternative for readers who don't want the annotation.
+
+2. **`docs/troubleshooting/argument-resolution-error.md`** — the page already
+   lists "give the parameter a default" generically. Add the concrete
+   integration-timing case: when the missing type is integration-supplied and you
+   validate before `setup_di` (or under `validate=True` / the 3.0 default), make
+   the parameter optional so validation skips it. Cross-link `context.md`.
+
+3. **`docs/integrations/writing-integrations.md`** — already carries a caveat
+   pointing at gRPC's `| None = None`; tighten it to state the optional-type
+   pattern as *the* way to show context injection in a validated example.
+
+The eight integration pages' "Framework Context Objects" sections are left as-is:
+they already link to `context.md#framework-context-objects`, so the cross-reference
+lands on the new guidance once that section carries it. No per-page edits.
+
+## Non-goals
+
+- **No core code change.** The mechanism already works; this is guidance.
+- **No error-message change.** `ArgumentResolutionError` can't distinguish an
+  integration context type from a genuine typo; the troubleshooting page carries
+  the guidance instead.
+- **Context stays out of the integration main examples.** They remain
+  Settings-only ([2026-07-14.04](2026-07-14.04-integration-docs-realistic-examples.md));
+  the `| None` + guard noise is why context lives in its own section.
+- **No architecture/ promotion.** Behavior is unchanged; the truth home already
+  describes the mechanism (validation skips defaulted params;
+  [validation.md](../../architecture/validation.md) "Missing required dependencies").
+
+## Testing
+
+`just docs-build` (`mkdocs build --strict`) — clean, no broken cross-links.
+`just check-planning` — bundle valid. The recommended snippet is executed against
+`modern-di` to confirm `validate=True` passes at construction and the real
+context value is injected at runtime.
+
+## Risk
+
+- **Snippet correctness** (low): the rewritten context.md example could drift from
+  real behavior. Mitigation: run it against modern-di before shipping (already
+  reproduced in brainstorming).
+- **Two remedies coexisting** (low): context.md will show both optional-type
+  (recommended) and `validate=False` (alternative). Mitigation: lead with the
+  recommended one and mark the other explicitly as the fallback.

--- a/planning/changes/2026-07-14.05-optional-context-types-under-validate.md
+++ b/planning/changes/2026-07-14.05-optional-context-types-under-validate.md
@@ -42,11 +42,13 @@ by the missing-dependency check, so `validate=True` passes at construction; at
 runtime the integration has registered the provider, so resolution injects the
 **real** object. Verified end to end: construction validates, and a resolve with
 context set returns the real value (not `None`). The `| None = None` is
-load-bearing **only at validation time** — at runtime the registered
-`ContextProvider` governs, returning the real value when context is set and (in
-3.0) raising `ContextValueNotSetError` if it is somehow unset. So the annotation
-does not mask a missing-context bug at runtime under 3.0; it is purely a
-validation-time concession. This is exactly the rationale the gRPC page already
+load-bearing **only at validation time**; it does not change runtime behaviour. At
+runtime the integration has registered the provider and set the context, so
+resolution injects the real value. If context is somehow unset, a defaulted
+parameter falls back to its default — its disposition is unchanged in modern-di 3.0
+(the 3.0 `ContextValueNotSetError` affects only a *direct* resolve of an unset
+context type, per [migration to-3.x #5](../../docs/migration/to-3.x.md), not a
+defaulted `Factory` parameter). This is exactly the rationale the gRPC page already
 documents for `grpc.ServicerContext | None = None`, generalized.
 
 Three doc edits:


### PR DESCRIPTION
Documents `param: FrameworkType | None = None` as the recommended way to depend on an integration-supplied context object (`fastapi.Request`, `taskiq.TaskiqMessage`, …) while keeping `validate=True`.

**Rationale & design:** [`planning/changes/2026-07-14.05-optional-context-types-under-validate.md`](planning/changes/2026-07-14.05-optional-context-types-under-validate.md).

## The problem
An integration registers its connection `ContextProvider` inside `setup_di`, which runs *after* the container is built. So a `Factory` that depends **by type** on that context object fails `validate=True` at construction (`ArgumentResolutionError` — no provider yet). This becomes a default footgun once modern-di 3.0 makes `validate()` run by default at construction. The current docs remedy, `validate=False`, silences *all* validation.

## The fix (docs-only)
Type the parameter `FrameworkType | None = None`. A defaulted parameter is skipped by validation's missing-dependency check, so `validate=True` passes; at runtime the integration has registered the provider, so resolution injects the real object. Verified end-to-end.

- `docs/providers/context.md` — implicit-usage example switched from `validate=False` to `validate=True` + optional type, with an explanation; `validate=False` kept as the fallback.
- `docs/troubleshooting/argument-resolution-error.md` — adds the integration-timing case and the optional-type fix.
- `docs/integrations/writing-integrations.md` — tightened to recommend the optional-type pattern for context in a validated example.

## Correctness note
A defaulted `Factory` parameter keeps its own disposition in 3.0 — the 3.0 `ContextValueNotSetError` affects only a *direct* resolve of an unset context type (per [migration to-3.x #5](docs/migration/to-3.x.md)), not a defaulted parameter, which falls back to its default. The docs state this accurately.

## Verification
- `just docs-build` (`mkdocs build --strict`) — clean.
- `just check-planning` — bundle valid.
- The recommended snippet was executed against `modern-di`: `validate=True` passes at construction, and a resolve with context set returns the real object.

No `modern_di/` or `tests/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)