### PR TITLE
fix: NoneType parameters lose their default and their nullability

### DIFF
--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -69,6 +69,13 @@ map produced at provider-declaration time by `types_parser.parse_creator` — an
    - Otherwise the parameter is recorded in the plan's `unwireable` list as a `(name, SignatureItem)` record — **not** a
      pre-built exception (see Step 5).
 
+   > A bare `None` annotation is the **degenerate nullable** — a union with zero non-`None` members — and takes the
+   > same two branches as `X | None`: `x: None = None` omits (its default applies), and `x: None` injects `None`,
+   > which is the annotation's only legal value. `SignatureItem.from_type` handles `NoneType` in its own branch, since
+   > the union branch would otherwise take it for a plain type and look `NoneType` up in the registry. In the *return*
+   > position (`-> None`, a void creator) the nullability is simply unread: only `.arg_type` is consulted, to derive
+   > `bound_type`.
+
 The plan's buckets — `provider_kwargs` (regular providers, resolved recursively), `static_kwargs` (plain values), and
 `context_kwargs` (`ContextProvider` + its `SignatureItem`, resolved live) — plus the `dependencies` view and the
 `unwireable` records are memoized on the `CacheItem`. The same `WiringPlan.build` backs `validate()`: `get_dependencies`

--- a/modern_di/types_parser.py
+++ b/modern_di/types_parser.py
@@ -19,7 +19,10 @@ class SignatureItem:
     @classmethod
     def from_type(cls, type_: type, default: object = UNSET) -> "SignatureItem":
         if type_ is types.NoneType:
-            return cls()
+            # The degenerate nullable — a union with zero non-None members. Handled here
+            # rather than by the union branch below, which would take it for a plain type
+            # and try to resolve `NoneType` from the registry.
+            return cls(default=default, is_nullable=True)
 
         # typing.Annotated
         if hasattr(type_, "__metadata__"):

--- a/planning/changes/2026-07-14.07-nonetype-param-drops-default.md
+++ b/planning/changes/2026-07-14.07-nonetype-param-drops-default.md
@@ -1,0 +1,78 @@
+---
+summary: `SignatureItem.from_type` discarded both `default` and `is_nullable` for a `None`-annotated parameter, so `x: None = None` raised instead of using its default; treat `NoneType` as the degenerate nullable it is.
+---
+
+# Change: NoneType parameters lose their default and their nullability
+
+**Lane:** lightweight — one branch in `types_parser.py`, plus tests.
+
+## Goal
+
+A creator parameter annotated `None` **with a default** raises
+`ArgumentResolutionError` instead of using that default:
+
+```python
+class Svc:
+    def __init__(self, hook: None = None) -> None: ...   # -> ArgumentResolutionError
+
+class Svc2:
+    def __init__(self, hook: str = "d") -> None: ...     # -> resolves, hook == "d"
+```
+
+`SignatureItem.from_type` (`types_parser.py:20-22`) early-returns a bare `cls()`
+for `types.NoneType`, discarding **both** the `default` it was handed and the
+nullability the annotation implies. Every other branch threads `default` through
+via `result = {"default": default}`. `absent_disposition` then sees
+`default is UNSET` and `is_nullable is False`, and classifies the parameter
+`UNWIRABLE`.
+
+## Approach
+
+Return the degenerate nullable instead of an empty record:
+
+```python
+if type_ is types.NoneType:
+    return cls(default=default, is_nullable=True)
+```
+
+`NoneType` *is* a nullable union with zero non-`None` members, and this is
+exactly what the union branch below would produce for it. (The early return
+still has to exist: without it, `NoneType` falls through to
+`isinstance(type_, type)` and becomes `arg_type=NoneType`, which would then be
+looked up in the registry.)
+
+This aligns `None` with `T | None`, which was already correct:
+
+| creator | before | after |
+|---|---|---|
+| `x: None = None` | UNWIRABLE (raises) | **OMIT** (default applies) |
+| `x: None` | UNWIRABLE (raises) | **NULL** (injects `None`) |
+| `x: str \| None = None` | OMIT | OMIT (unchanged) |
+| `x: str \| None` | NULL | NULL (unchanged) |
+
+The second row is a behavior change beyond the reported defect: a bare
+`x: None` currently errors and will now inject `None`. That is the annotation's
+only legal value, so injecting it is what the type says to do, and erroring was
+a false positive. Rows 1 and 2 are presently *indistinguishable* after parsing —
+the tell that `cls()` was dropping state rather than encoding a decision.
+
+Contract lives in [architecture/resolution.md](../../architecture/resolution.md)
+(step 3, absent-parameter disposition).
+
+## Files
+
+- `modern_di/types_parser.py` — `SignatureItem.from_type`: thread `default`,
+  set `is_nullable` on the `NoneType` branch.
+- `tests/test_types_parser.py` — parse-level: `None`-annotated params keep their
+  default and are nullable.
+- `tests/providers/test_factory.py` — resolution-level: `hook: None = None`
+  resolves to the default; bare `hook: None` injects `None`.
+
+## Verification
+
+- [ ] Failing test first — `just test tests/test_types_parser.py -k nonetype`;
+      expect `default=UNSET, is_nullable=False`.
+- [ ] Apply the change.
+- [ ] Tests pass — same command.
+- [ ] `just test-ci` — full suite, 100% coverage gate.
+- [ ] `just lint-ci` — clean.

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -828,3 +828,33 @@ def test_definition_site_recursion_error_propagates_for_guard_retry() -> None:
     # so the guard's shallower retry gets a fresh computation, not a cached None.
     with pytest.raises(RecursionError):
         _ = factory.definition_site
+
+
+def test_nonetype_param_with_default_uses_the_default() -> None:
+    """A `None`-annotated parameter with a default is OMIT, not UNWIRABLE."""
+
+    class Svc:
+        def __init__(self, hook: None = None) -> None:
+            self.hook = hook
+
+    factory = providers.Factory(scope=Scope.APP, creator=Svc)
+    container = Container()
+    container.providers_registry.add_providers(factory)
+
+    result = container.resolve(Svc)
+    assert result.hook is None
+
+
+def test_nonetype_param_without_default_injects_none() -> None:
+    """A bare `None` annotation is nullable: its only legal value is None, so inject it."""
+
+    class Svc:
+        def __init__(self, hook: None) -> None:
+            self.hook = hook
+
+    factory = providers.Factory(scope=Scope.APP, creator=Svc)
+    container = Container()
+    container.providers_registry.add_providers(factory)
+
+    result = container.resolve(Svc)
+    assert result.hook is None

--- a/tests/test_types_parser.py
+++ b/tests/test_types_parser.py
@@ -30,10 +30,30 @@ if typing.TYPE_CHECKING:
         (list[str] | None, SignatureItem(arg_type=list, is_nullable=True)),
         (GenericClass[str], SignatureItem(raw_annotation=GenericClass[str])),
         (GenericClass[str] | None, SignatureItem(arg_type=GenericClass, is_nullable=True)),
+        # `None` is the degenerate nullable: a union with zero non-None members.
+        (type(None), SignatureItem(is_nullable=True)),
     ],
 )
 def test_signature_item_parser(type_: type, result: SignatureItem) -> None:
     assert SignatureItem.from_type(type_) == result
+
+
+@pytest.mark.parametrize("default", [None, 3, "x"])
+def test_nonetype_threads_its_default(default: object) -> None:
+    """A `None`-annotated parameter keeps its default, like every other annotation.
+
+    Exercised through `from_type` rather than a real creator: only `None` is assignable
+    to a `None`-annotated parameter, so a non-None default cannot be spelled in a signature.
+    """
+    assert SignatureItem.from_type(type(None), default=default) == SignatureItem(default=default, is_nullable=True)
+
+
+def nonetype_func(hook: None = None) -> None: ...
+
+
+def test_nonetype_params_keep_defaults_through_parse_creator() -> None:
+    _ret, params = parse_creator(nonetype_func)
+    assert params["hook"] == SignatureItem(default=None, is_nullable=True)
 
 
 def simple_func(arg1: int, arg2: str | None = None) -> int: ...  # ty: ignore[empty-body]
@@ -87,7 +107,8 @@ class ClassWithWrongAnnotations:
         (
             none_func,
             (
-                SignatureItem(),
+                # `-> None` is nullable; only `.arg_type` (None) is read, to derive bound_type.
+                SignatureItem(is_nullable=True),
                 {
                     "arg1": SignatureItem(arg_type=int),
                     "arg2": SignatureItem(arg_type=str, is_nullable=True, default=None),
@@ -97,14 +118,14 @@ class ClassWithWrongAnnotations:
         (
             args_kwargs_func,
             (
-                SignatureItem(),
+                SignatureItem(is_nullable=True),
                 {},
             ),
         ),
         (
             func_with_str_annotations,
             (
-                SignatureItem(),
+                SignatureItem(is_nullable=True),
                 {
                     "arg1": SignatureItem(arg_type=str),
                     "arg2": SignatureItem(raw_annotation=tuple[int, ...], default=()),


### PR DESCRIPTION
A creator parameter annotated `None` **with a default** raises instead of using it:

```python
class Svc:
    def __init__(self, hook: None = None) -> None: ...   # -> ArgumentResolutionError

class Svc2:
    def __init__(self, hook: str = "d") -> None: ...     # -> resolves, hook == "d"
```

`SignatureItem.from_type` (`types_parser.py:21`) early-returns a bare `cls()` for `types.NoneType`, discarding **both** the `default` it was handed and the nullability the annotation implies. Every other branch threads `default` through via `result = {"default": default}`. `absent_disposition` then sees `default is UNSET` and `is_nullable is False`, and classifies the parameter `UNWIRABLE`.

`x: None = None` and `x: None` were **indistinguishable** after parsing — the tell that `cls()` was dropping state rather than encoding a decision.

## The fix

Return the degenerate nullable instead of an empty record. `NoneType` *is* a union with zero non-`None` members, and this is exactly what the union branch below would produce for it:

```python
if type_ is types.NoneType:
    return cls(default=default, is_nullable=True)
```

The branch still has to exist: without it, `NoneType` falls through to `isinstance(type_, type)` and becomes `arg_type=NoneType`, which would then be looked up in the registry.

## Behavior

`None` now takes the same two branches as `X | None`, which were already correct:

| creator | before | after |
|---|---|---|
| `x: None = None` | UNWIRABLE (raises) | **OMIT** (default applies) |
| `x: None` | UNWIRABLE (raises) | **NULL** (injects `None`) |
| `x: str \| None = None` | OMIT | OMIT (unchanged) |
| `x: str \| None` | NULL | NULL (unchanged) |

Row 2 goes beyond the reported defect: bare `x: None` currently errors and will now inject `None`. That is the annotation's only legal value, so injecting it is what the type says to do and the error was a false positive.

In the **return** position (`-> None`, a void creator) the new nullability is simply unread — `factory.py:75` consults only `.arg_type` to derive `bound_type`, so a void creator still gets `bound_type=None` exactly as before. Three existing `test_parse_creator` expectations are updated for the return-position record; no behavior rides on them.

Design: [`planning/changes/2026-07-14.07-nonetype-param-drops-default.md`](planning/changes/2026-07-14.07-nonetype-param-drops-default.md).

## Not in scope

The card this came from also flagged that `UnsupportedCreatorParameterError` is raised from **two** owners — `types_parser.py` (positional-only) and `factory.py` (parameterized generic) — one policy, two homes. Deliberately left alone: it is churn without a forcing function, and the revisit trigger on [`decisions/2026-07-14-signatureitem-opacity-superseded.md`](planning/decisions/2026-07-14-signatureitem-opacity-superseded.md) (a *new* duplicated raw-field decode idiom) has not fired.

## Testing

TDD, 5 failing tests written first.

- `test_signature_item_parser[NoneType]` — `from_type(None)` is nullable.
- `test_nonetype_threads_its_default` — parametrized over `None`, `3`, `"x"`. Exercised through `from_type` rather than a real creator, because only `None` is assignable to a `None`-annotated parameter, so a non-`None` default cannot be spelled in a signature (`ty` correctly rejects it).
- `test_nonetype_params_keep_defaults_through_parse_creator` — end-to-end through the parser.
- `test_nonetype_param_with_default_uses_the_default` / `..._without_default_injects_none` — resolution-level, the behavior a user actually hits.

`just test-ci`: 386 passed, 100% coverage. `just lint-ci`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)