### PR TITLE
docs: correct the CLAUDE.md claim about where error messages live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Where the detail lives — read the matching capability file before changing beh
 - `modern_di/suggester.py` — `close_matches`, the shared difflib fuzzy-match used by registry type suggestions and factory kwarg "did you mean"
 - `modern_di/scope.py` — Scope enum
 - `modern_di/group.py` — Group base class for provider namespaces
-- `modern_di/exceptions.py` — exception class hierarchy (`ModernDIError` → `ContainerError`/`ResolutionError`/`RegistrationError` subclasses); each error message is an inline f-string in the class that raises it
+- `modern_di/exceptions.py` — exception class hierarchy (`ModernDIError` → `ContainerError`/`ResolutionError`/`RegistrationError` subclasses). Each error owns its own message: the raise site passes only structured keyword attrs, and the class's `__init__` renders the f-string and stores those attrs. Every concrete class sets a `docs_slug` (its page under `docs/troubleshooting/`, appended by `__str__` as a trailing `See: <url>` line, enforced by `tests/test_docs_slug_census.py`). **Add a message or a class here, not at the raise site.**
 
 ### Testing patterns
 


### PR DESCRIPTION
`CLAUDE.md` described `exceptions.py` as: *"each error message is an inline f-string in the class that raises it."*

That is backwards. #227 (`bfc8fda`, "inline error messages and delete the errors.py seam") moved every message **into the exception class**. A raise site passes only structured keyword attributes; the class's `__init__` stores them and renders the f-string. Nothing about the message is written at the raise site.

Left uncorrected, the line tells a reader to compose messages where they raise, which is the one thing the refactor removed.

The replacement also records the `docs_slug` contract, which is load-bearing and was undocumented here: every concrete class sets one, `__str__` appends it as a trailing `See: <url>` line, and `tests/test_docs_slug_census.py` fails the build if a new concrete error omits it.

Docs only. `just lint-ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)