### PR TITLE
refactor: exceptions own every glyph; raise sites carry facts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,10 @@ Where the detail lives — read the matching capability file before changing beh
 - `modern_di/providers/context_provider.py` — ContextProvider for runtime-injected values
 - `modern_di/providers/container_provider.py` — auto-registered provider that resolves to the Container itself
 - `modern_di/types_parser.py` — Signature introspection engine (parses type hints for DI wiring)
-- `modern_di/suggester.py` — `close_matches`, the shared difflib fuzzy-match used by registry type suggestions and factory kwarg "did you mean"
+- `modern_di/suggester.py` — what a suggestion *is* (the `Suggestion` record) and how to *find* one (`close_matches`, the shared difflib fuzzy-match). Carries no formatting
 - `modern_di/scope.py` — Scope enum
 - `modern_di/group.py` — Group base class for provider namespaces
-- `modern_di/exceptions.py` — exception class hierarchy (`ModernDIError` → `ContainerError`/`ResolutionError`/`RegistrationError` subclasses). Each error owns its own message: the raise site passes only structured keyword attrs, and the class's `__init__` renders the f-string and stores those attrs. Every concrete class sets a `docs_slug` (its page under `docs/troubleshooting/`, appended by `__str__` as a trailing `See: <url>` line, enforced by `tests/test_docs_slug_census.py`). **Add a message or a class here, not at the raise site.**
+- `modern_di/exceptions.py` — exception class hierarchy (`ModernDIError` → `ContainerError`/`ResolutionError`/`RegistrationError` subclasses). Each error owns its own message: the raise site passes only structured keyword attrs, and the class's `__init__` renders the f-string and stores those attrs. Every concrete class sets a `docs_slug` (its page under `docs/troubleshooting/`, appended by `__str__` as a trailing `See: <url>` line, enforced by `tests/test_docs_slug_census.py`). This file owns **every glyph**: `_render_chain` (the arrow tree, shared by breadcrumbs and cycles) and `_render_suggestions` (the "did you mean" block). Callers pass facts, never formatting. **Add a message, a glyph, or a class here — never at the raise site.**
 
 ### Testing patterns
 

--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -121,6 +121,34 @@ inspection, and anything without an inspectable source (C callables, `functools.
 like) yields no site rather than raising. `Alias` steps never carry a definition site, since an
 alias has no creator of its own to anchor.
 
+### One renderer
+
+Every glyph in every message lives in `exceptions.py`, and nowhere else. Two private drawers own the
+formatting the errors share:
+
+- `_render_chain(steps)` draws a `list[ResolutionStep]` as the indented arrow tree with an aligned
+  scope column. It is the single home of the chain glyphs, used by both `DependencyPathMixin`
+  (a resolution breadcrumb) and `CircularDependencyError` (a cycle) — which is why the two read
+  identically and cannot drift.
+- `_render_suggestions(items)` draws the `Did you mean:` block from `list[suggester.Suggestion]`.
+  It is the single home of the suggestion glyphs, used by `ProviderNotRegisteredError`,
+  `ArgumentResolutionError`, and `UnknownFactoryKwargError`.
+
+What crosses into an error is **facts, never formatting**. `ProvidersRegistry.build_suggestions`
+returns `Suggestion` records — `(name, reason, scope)` — not rendered bullets, so `.suggestions` on a
+caught exception is data a caller can act on rather than glyphs it would have to parse back apart.
+An error also derives whatever it can from what it was already handed: `InvalidChildScopeError`
+computes `.allowed_scopes` from `parent_scope`, and `UnknownFactoryKwargError` runs its own
+`close_matches` over the `unknown_keys`/`known_keys` it receives. Neither is computed at a raise site.
+
+`suggester` owns what a suggestion *is* (the `Suggestion` record) and how to *find* one
+(`close_matches`); `exceptions` owns how everything *looks*. The messages themselves stay inline
+f-strings in the class that raises them — only the shared glyph logic is factored out, not the
+message catalog (see [2026-06-23.02-inline-error-messages](../planning/changes/2026-06-23.02-inline-error-messages.md)).
+
+Rendered error text is diagnostic, not a public contract; the structured attributes and the class
+hierarchy are. See [2026-07-14-error-text-is-not-a-contract](../planning/decisions/2026-07-14-error-text-is-not-a-contract.md).
+
 ## Step 6 — Creator call and caching
 
 `Factory` calls the creator with `resolved_kwargs`. With no `cache_settings`, the instance is returned immediately.

--- a/architecture/validation.md
+++ b/architecture/validation.md
@@ -71,18 +71,20 @@ graph clean for every container in the tree.
 When the walk follows an edge to a provider still on the active path (tracked in the walk's internal
 `visiting` set), it emits a `Cycle` event whose `providers` list closes the loop by repeating the first
 node last (e.g., `[A, B, A]`). `validate()` maps that event to a `CircularDependencyError` (built via
-`dependency_graph.build_cycle_error`) whose `.cycle_path` is the list of type names showing the loop
-(e.g., `["A", "B", "A"]`). The walk does **not** descend into the cycle, but the rest of the graph
-continues to be checked. `CircularDependencyError.__str__` renders `.cycle_path` as a multi-line arrow
-chain, not an inline `A -> B -> A` string — see `CircularDependencyError` in `exceptions.py`.
+`dependency_graph.build_cycle_error`), which carries the loop as `.steps` — one `ResolutionStep`
+(scope, name, optional definition site) per node. The walk does **not** descend into the cycle, but the
+rest of the graph continues to be checked. `CircularDependencyError.__str__` renders those steps as a
+multi-line arrow chain, not an inline `A -> B -> A` string.
 
-Each node in that chain may also carry an optional definition site — the creator's declaration
-point — rendered as a trailing `module:line` anchor alongside the provider name, using the same
-lazy, memoized, best-effort capture described for breadcrumb steps in
-[resolution.md](resolution.md#breadcrumb-definition-sites). The public `.cycle_path` stays the bare
-list of type names; the parallel locations live on a separate `.cycle_locations` attribute. Both
-`validate()` and the runtime guard build the error through the one `dependency_graph.build_cycle_error`
-helper, so the two attributes stay in sync by construction rather than by parallel edit.
+`.cycle_path` (the bare list of type names, e.g. `["A", "B", "A"]`) and `.cycle_locations` (the parallel
+`module:line` anchors) are **views derived from `.steps`**, so they cannot fall out of step with each
+other or with what is rendered — the equal-length invariant is structural rather than enforced at render
+time. Definition sites use the same lazy, memoized, best-effort capture described for breadcrumb steps in
+[resolution.md](resolution.md#breadcrumb-definition-sites).
+
+Because a `ResolutionStep` carries its provider's scope, the cycle renders through the *same* chain drawer
+as a resolution breadcrumb — including the aligned scope column — so a cycle and a failed resolution path
+read identically. See [resolution.md](resolution.md#one-renderer) for that drawer.
 
 > **Runtime resolution has a cycle guard too — but `validate()` remains the way to see all errors up front.**
 > `Container.resolve_provider` wraps the final `provider.resolve(self)` in `try/except RecursionError`. The

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -88,11 +88,7 @@ class Container:
         if not isinstance(scope, enum.IntEnum):
             raise exceptions.InvalidScopeTypeError(scope_value=scope)
         if parent_container is not None and scope <= parent_container.scope:
-            raise exceptions.InvalidChildScopeError(
-                parent_scope=parent_container.scope,
-                child_scope=scope,
-                allowed_scopes=[x.name for x in type(parent_container.scope) if x > parent_container.scope],
-            )
+            raise exceptions.InvalidChildScopeError(parent_scope=parent_container.scope, child_scope=scope)
         self._lock = threading.RLock() if use_lock else None
         self._validated = False
         self.closed = False
@@ -139,11 +135,7 @@ class Container:
         self._warn_and_reopen_if_closed()
 
         if scope is not None and scope <= self.scope:
-            raise exceptions.InvalidChildScopeError(
-                parent_scope=self.scope,
-                child_scope=scope,
-                allowed_scopes=[x.name for x in type(self.scope) if x > self.scope],
-            )
+            raise exceptions.InvalidChildScopeError(parent_scope=self.scope, child_scope=scope)
 
         if scope is None:
             # Derive the next scope as the smallest member deeper than the current one, so

--- a/modern_di/dependency_graph.py
+++ b/modern_di/dependency_graph.py
@@ -61,8 +61,9 @@ def build_cycle_error(
 ) -> "exceptions.CircularDependencyError":
     """Build a ``CircularDependencyError`` from a cycle's providers (first node repeated last)."""
     return exceptions.CircularDependencyError(
-        cycle_path=[p.display_name for p in providers],
-        cycle_locations=[p.definition_site for p in providers],
+        steps=[
+            exceptions.ResolutionStep(scope=p.scope, name=p.display_name, location=p.definition_site) for p in providers
+        ]
     )
 
 

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -2,6 +2,8 @@ import dataclasses
 import enum
 import typing
 
+from modern_di import suggester
+
 
 SUGGESTION_HEADER = "Did you mean:"
 _TROUBLESHOOTING_BASE_URL = "https://modern-di.modern-python.org/troubleshooting"
@@ -13,10 +15,13 @@ if typing.TYPE_CHECKING:
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class ResolutionStep:
-    """One entry in a :class:`ResolutionError`'s ``dependency_path``.
+    """One entry in a chain-shaped error: a provider, as this module needs to draw it.
+
+    Used both for a :class:`ResolutionError`'s ``dependency_path`` and for a
+    :class:`CircularDependencyError`'s cycle, so both render through ``_render_chain``.
 
     Attributes:
-        scope: the scope of the provider at this step of the resolution chain.
+        scope: the scope of the provider at this step of the chain.
         name: the provider's display name (bound type or creator name).
         location: the provider's declaration site as ``module:line``, when known.
 
@@ -25,6 +30,42 @@ class ResolutionStep:
     scope: enum.IntEnum
     name: str
     location: str | None = None
+
+
+def _render_chain(steps: "list[ResolutionStep]") -> list[str]:
+    """Draw a provider chain as an indented arrow tree, one line per step.
+
+    The single home of the chain glyphs — used by every chain-shaped error, so a
+    resolution path and a dependency cycle cannot drift apart in how they read.
+    """
+    scope_width = max(len(step.scope.name) for step in steps)
+    lines = []
+    for i, step in enumerate(steps):
+        prefix = "" if i == 0 else "    " * (i - 1) + "└─> "
+        label = f"{step.name} ({step.location})" if step.location else step.name
+        lines.append(f"  {step.scope.name:<{scope_width}}  {prefix}{label}")
+    return lines
+
+
+def _render_suggestion_lines(suggestions: "list[suggester.Suggestion]") -> list[str]:
+    """Draw each suggestion as a bullet. The single home of the suggestion glyphs."""
+    lines = []
+    for suggestion in suggestions:
+        details = [x for x in (suggestion.reason, _scope_detail(suggestion.scope)) if x]
+        suffix = f" ({', '.join(details)})" if details else ""
+        lines.append(f"  - {suggestion.name}{suffix}")
+    return lines
+
+
+def _scope_detail(scope: enum.IntEnum | None) -> str | None:
+    return None if scope is None else f"scope={scope.name}"
+
+
+def _render_suggestions(suggestions: "list[suggester.Suggestion]") -> str:
+    """Render the full ``Did you mean:`` block, or an empty string when there is nothing to suggest."""
+    if not suggestions:
+        return ""
+    return "\n".join([SUGGESTION_HEADER, *_render_suggestion_lines(suggestions)])
 
 
 class ModernDIError(RuntimeError):
@@ -83,13 +124,11 @@ class DependencyPathMixin:
         if not self.dependency_path:
             return self._base_message
 
-        scope_width = max(len(step.scope.name) for step in self.dependency_path)
-        lines = ["Cannot resolve dependency chain:"]
-        for i, step in enumerate(self.dependency_path):
-            prefix = "" if i == 0 else "    " * (i - 1) + "└─> "
-            label = f"{step.name} ({step.location})" if step.location else step.name
-            lines.append(f"  {step.scope.name:<{scope_width}}  {prefix}{label}")
-        lines.append(f"  caused by: {self._base_message}")
+        lines = [
+            "Cannot resolve dependency chain:",
+            *_render_chain(self.dependency_path),
+            f"  caused by: {self._base_message}",
+        ]
         return "\n".join(lines)
 
 
@@ -106,14 +145,17 @@ class InvalidChildScopeError(ContainerError):
 
     __slots__ = ("allowed_scopes", "child_scope", "parent_scope")
 
-    def __init__(self, *, parent_scope: enum.IntEnum, child_scope: enum.IntEnum, allowed_scopes: list[str]) -> None:
+    def __init__(self, *, parent_scope: enum.IntEnum, child_scope: enum.IntEnum) -> None:
         self.parent_scope = parent_scope
         self.child_scope = child_scope
-        self.allowed_scopes = allowed_scopes
+        # Derived, not handed over: the allowed scopes are a pure function of the parent's own
+        # enum class, so a raise site has nothing to add. Drawn from type(parent_scope) so a
+        # custom IntEnum reports its own members.
+        self.allowed_scopes = [x.name for x in type(parent_scope) if x > parent_scope]
         super().__init__(
             f"Scope of child container cannot be {child_scope.name} if parent scope is {parent_scope.name} "
             f"(child scope value must be strictly greater than parent scope value). "
-            f"Possible scopes are {allowed_scopes}."
+            f"Possible scopes are {self.allowed_scopes}."
         )
 
 
@@ -249,13 +291,13 @@ class ProviderNotRegisteredError(ResolutionError):
         self,
         *,
         provider_type: type,
-        suggestions: list[str] | None = None,
+        suggestions: "list[suggester.Suggestion] | None" = None,
     ) -> None:
         self.provider_type = provider_type
         self.suggestions = suggestions or []
         message = f"Provider of type {provider_type} is not registered in providers registry."
-        if self.suggestions:
-            message += "\n" + SUGGESTION_HEADER + "\n" + "\n".join(self.suggestions)
+        if block := _render_suggestions(self.suggestions):
+            message += "\n" + block
         super().__init__(message)
 
 
@@ -287,7 +329,7 @@ class ArgumentResolutionError(ResolutionError):
         arg_name: str,
         arg_type: typing.Any,  # noqa: ANN401
         bound_type: typing.Any,  # noqa: ANN401
-        suggestions: list[str] | None = None,
+        suggestions: "list[suggester.Suggestion] | None" = None,
         member_types: list[type] | None = None,
     ) -> None:
         self.arg_name = arg_name
@@ -308,8 +350,8 @@ class ArgumentResolutionError(ResolutionError):
                 f"Argument {arg_name} has no usable type annotation, so it cannot be resolved by type. "
                 f"Pass it via the kwargs parameter or add a type annotation. Trying to build dependency {bound_type}."
             )
-        if self.suggestions:
-            message += "\n" + SUGGESTION_HEADER + "\n" + "\n".join(self.suggestions)
+        if block := _render_suggestions(self.suggestions):
+            message += "\n" + block
         super().__init__(message)
 
 
@@ -332,25 +374,29 @@ class CreatorCallError(ResolutionError):
 class CircularDependencyError(ResolutionError):
     """A dependency cycle was detected by ``validate()`` or the runtime resolve guard.
 
-    Inspect ``.cycle_path`` (the loop as type names) and ``.cycle_locations`` (parallel
-    ``module:line`` anchors, when known). When raised at resolve time, ``__cause__`` carries
-    the original ``RecursionError``.
+    Inspect ``.steps`` (the loop, first provider repeated last), or the ``.cycle_path`` /
+    ``.cycle_locations`` views derived from it. When raised at resolve time, ``__cause__``
+    carries the original ``RecursionError``.
     """
 
     docs_slug = "circular-dependency"
 
-    __slots__ = ("cycle_locations", "cycle_path")
+    __slots__ = ("steps",)
 
-    def __init__(self, *, cycle_path: list[str], cycle_locations: list[str | None] | None = None) -> None:
-        self.cycle_path = cycle_path
-        self.cycle_locations = cycle_locations
-        locations = cycle_locations if cycle_locations is not None else [None] * len(cycle_path)
-        lines = []
-        for i, (name, location) in enumerate(zip(cycle_path, locations, strict=True)):
-            label = f"{name} ({location})" if location else name
-            lines.append(f"  {'    ' * (i - 1)}└─> {label}" if i else f"  {label}")
-        rendered = "\n".join(lines)
+    def __init__(self, *, steps: list[ResolutionStep]) -> None:
+        self.steps = steps
+        rendered = "\n".join(_render_chain(steps))
         super().__init__(f"Circular dependency detected:\n{rendered}\nCheck your provider graph for unintended cycles.")
+
+    @property
+    def cycle_path(self) -> list[str]:
+        """The cycle as provider names."""
+        return [step.name for step in self.steps]
+
+    @property
+    def cycle_locations(self) -> list[str | None]:
+        """The cycle's ``module:line`` anchors, positionally parallel to ``cycle_path``."""
+        return [step.location for step in self.steps]
 
 
 class ContextValueNotSetError(ResolutionError):
@@ -467,21 +513,27 @@ class UnknownFactoryKwargError(RegistrationError):
         creator: typing.Any,  # noqa: ANN401
         unknown_keys: list[str],
         known_keys: list[str],
-        suggestions: dict[str, str] | None = None,
     ) -> None:
         self.creator = creator
         self.unknown_keys = unknown_keys
         self.known_keys = known_keys
-        self.suggestions = suggestions or {}
+        # Derived, not handed over: matching the unknown keys against the known ones needs
+        # nothing the error was not already given. A kwarg has no provider, so no scope.
+        self.suggestions = [
+            suggester.Suggestion(
+                name=repr(key),
+                reason=f"did you mean {matches[0]!r}?"
+                if (matches := suggester.close_matches(key, known_keys, n=1))
+                else None,
+            )
+            for key in unknown_keys
+        ]
         creator_name = getattr(creator, "__name__", repr(creator))
-        parts = [f"Factory kwargs contain unknown key(s) not in {creator_name} signature:"]
-        for key in unknown_keys:
-            sug = self.suggestions.get(key)
-            line = f"  - {key!r}"
-            if sug:
-                line += f" (did you mean {sug!r}?)"
-            parts.append(line)
-        parts.append(f"Known parameters: {known_keys}")
+        parts = [
+            f"Factory kwargs contain unknown key(s) not in {creator_name} signature:",
+            *_render_suggestion_lines(self.suggestions),
+            f"Known parameters: {known_keys}",
+        ]
         super().__init__("\n".join(parts))
 
 

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -4,7 +4,7 @@ import inspect
 import typing
 import warnings
 
-from modern_di import exceptions, suggester, types
+from modern_di import exceptions, types
 from modern_di.providers.abstract import AbstractProvider
 from modern_di.providers.context_provider import ContextProvider
 from modern_di.types_parser import SignatureItem, parse_creator
@@ -110,16 +110,10 @@ class Factory(AbstractProvider[types.T_co]):
         unknown = sorted(set(kwargs) - known)
         if not unknown:
             return
-        suggestions: dict[str, str] = {}
-        for bad in unknown:
-            matches = suggester.close_matches(bad, known, n=1)
-            if matches:
-                suggestions[bad] = matches[0]
         raise exceptions.UnknownFactoryKwargError(
             creator=creator,
             unknown_keys=unknown,
             known_keys=sorted(known),
-            suggestions=suggestions,
         )
 
     def __repr__(self) -> str:

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -9,18 +9,20 @@ from modern_di.providers.abstract import AbstractProvider
 _MAX_SUGGESTIONS = 3
 
 
-def _hierarchy_hint(requested_type: type, provider: AbstractProvider[typing.Any]) -> str | None:
+def _hierarchy_hint(requested_type: type, provider: AbstractProvider[typing.Any]) -> "suggester.Suggestion | None":
     registered = provider.bound_type
     if registered is None or not inspect.isclass(registered):
         return None
     try:
         if issubclass(registered, requested_type):
-            return f"  - {registered.__name__} (registered subclass, scope={provider.scope.name})"
-        if issubclass(requested_type, registered):
-            return f"  - {registered.__name__} (registered base class, scope={provider.scope.name})"
+            reason = "registered subclass"
+        elif issubclass(requested_type, registered):
+            reason = "registered base class"
+        else:
+            return None
     except TypeError:
         return None
-    return None
+    return suggester.Suggestion(name=registered.__name__, reason=reason, scope=provider.scope)
 
 
 class ProvidersRegistry:
@@ -83,11 +85,12 @@ class ProvidersRegistry:
             self._version += 1
             self.validated_version = None
 
-    def build_suggestions(self, requested_type: type) -> list[str]:
+    def build_suggestions(self, requested_type: type) -> "list[suggester.Suggestion]":
+        """Candidates the caller may have meant, as data — rendering belongs to ``exceptions``."""
         requested_is_class = inspect.isclass(requested_type)
         requested_name = getattr(requested_type, "__name__", str(requested_type))
 
-        hierarchy_hints: list[str] = []
+        hierarchy_hints: list[suggester.Suggestion] = []
         name_to_provider: dict[str, AbstractProvider[typing.Any]] = {}
 
         for provider in list(self._providers.values()):
@@ -108,7 +111,7 @@ class ProvidersRegistry:
 
         remaining = _MAX_SUGGESTIONS - len(hierarchy_hints)
         typo_hints = [
-            f"  - {name} (similar name, scope={name_to_provider[name].scope.name})"
+            suggester.Suggestion(name=name, reason="similar name", scope=name_to_provider[name].scope)
             for name in suggester.close_matches(requested_name, name_to_provider.keys(), n=remaining)
         ]
         return hierarchy_hints + typo_hints

--- a/modern_di/suggester.py
+++ b/modern_di/suggester.py
@@ -1,5 +1,22 @@
+import dataclasses
 import difflib
+import enum
 import typing
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Suggestion:
+    """A candidate the caller probably meant, as data.
+
+    Carries no formatting: rendering a suggestion to a bullet is ``exceptions``' job, so
+    one module owns the glyphs. ``scope`` is None when the suggestion names something with
+    no provider behind it (a creator's keyword argument); ``reason`` is None when there is
+    nothing to say beyond the name.
+    """
+
+    name: str
+    reason: str | None = None
+    scope: enum.IntEnum | None = None
 
 
 def close_matches(target: str, candidates: typing.Iterable[str], *, n: int, cutoff: float = 0.6) -> list[str]:

--- a/planning/changes/2026-07-14.08-one-error-renderer.md
+++ b/planning/changes/2026-07-14.08-one-error-renderer.md
@@ -1,0 +1,166 @@
+---
+summary: Shipped. Exceptions own every glyph — one chain drawer replaces two, one suggestion format replaces three, and three raise sites stopped computing what the error derives itself. `build_suggestions` returns `Suggestion` records instead of rendered bullets; `CircularDependencyError` carries `ResolutionStep`s (with `.cycle_path`/`.cycle_locations` as derived views), so cycles now render with the same aligned scope column as a resolution breadcrumb. No glyph remains outside `exceptions.py`. 397 tests, 100% coverage.
+---
+
+# Design: One error renderer; raise sites carry facts, not formatting
+
+## Summary
+
+`exceptions.py` renders messages, but it does not own rendering. The chain drawer
+is written twice inside it, the "did you mean" block is rendered in three places in
+two incompatible formats — half of it in `providers_registry.py` — and three raise
+sites compute data the exception already has enough information to derive. This
+change makes the exception classes the single home of every glyph: callers hand over
+*facts*, exceptions render them. No message text moves out of the class that raises
+it; the messages stay inline f-strings, as
+[2026-06-23.02-inline-error-messages](2026-06-23.02-inline-error-messages.md) (PR #227)
+established.
+
+## Motivation
+
+Four concrete observations on HEAD:
+
+1. **The chain drawer is written twice.** `DependencyPathMixin._render_body`
+   (`exceptions.py:89`) and `CircularDependencyError.__init__` (`exceptions.py:351`)
+   each build their own `└─>` indent-and-arrow lines and their own
+   `f"{name} ({location})"` labels. Two copies, one already drifted: the first prints
+   an aligned scope column, the second prints none.
+
+2. **The suggestion format is split across modules.**
+   `ProvidersRegistry.build_suggestions` returns *pre-rendered bullet lines*
+   (`"  - Repository (similar name, scope=APP)"`), and the exception concatenates
+   them under a header it owns. So the registry owns half the message format. This
+   is the split PR #227 explicitly preserved and named as someone else's job.
+
+3. **`.suggestions` is a public attribute holding glyphs.**
+   `ProviderNotRegisteredError` documents *"Inspect `.provider_type` and
+   `.suggestions`"*, and `tests/test_suggestions.py:73` pins
+   `exc.suggestions == ["  - Repository (similar name, scope=APP)"]`. A caller who
+   wants to *act* on a suggestion has to parse the indent and the parenthetical back
+   out. A third format — `UnknownFactoryKwargError`'s `- 'key' (did you mean 'x'?)` —
+   shares none of this and carries no header.
+
+4. **Raise sites compute what the error could derive.**
+   - `container.py:94` and `container.py:145` both build
+     `allowed_scopes=[x.name for x in type(parent_scope) if x > parent_scope]` — a
+     pure function of `parent_scope`, which the exception already receives. Written
+     out twice.
+   - `factory.py:113-117` runs `suggester.close_matches` to build
+     `UnknownFactoryKwargError`'s did-you-mean map, though the exception already
+     receives both `unknown_keys` and `known_keys` and could match them itself.
+   - `dependency_graph.py:63-66` decomposes a cycle's providers into two parallel
+     string lists (`cycle_path`, `cycle_locations`) whose equal length is an
+     invariant enforced only at render time, by `zip(..., strict=True)`.
+
+The interface a raise site must learn today therefore includes "pre-render your
+suggestion bullets", "derive the allowed scopes", and "there are two ways to draw a
+chain". That is a wide interface for the leverage it returns.
+
+## Design
+
+Three modules, three jobs, no overlap.
+
+```
+suggester.py            — what a suggestion IS, and how to find one
+  close_matches(...)                       (unchanged)
+  @dataclass(frozen=True, slots=True) Suggestion:
+      name: str                            "Repository"
+      reason: str                          "similar name" | "registered base class"
+      scope: enum.IntEnum | None
+
+exceptions.py           — how everything LOOKS. every glyph, one home.
+  _render_chain(steps: list[ResolutionStep]) -> str
+  _render_suggestions(items: list[Suggestion]) -> str
+  ModernDIError.__str__ -> body + "See: <url>"      (unchanged)
+
+providers_registry.py   — data only
+  build_suggestions(t) -> list[Suggestion]
+
+container.py / factory.py / dependency_graph.py — raise only
+  no close_matches, no allowed_scopes, no parallel lists
+```
+
+`exceptions` gains an import of `suggester`, which is safe: `suggester` imports only
+`difflib` and `typing`, and `providers_registry` already imports both modules. No
+cycle is possible.
+
+### One chain drawer
+
+`CircularDependencyError` carries `steps: list[ResolutionStep]` — the record
+`DependencyPathMixin` already uses, and which `Factory._resolution_step()`
+(`factory.py:161`) already builds from a provider. `dependency_graph.build_cycle_error`
+maps providers straight to it, so the parallel-list invariant disappears rather than
+being re-enforced.
+
+`.cycle_path` and `.cycle_locations` survive as derived properties over `steps`, so
+nothing a caller catches on changes:
+
+```python
+@property
+def cycle_path(self) -> list[str]:
+    return [s.name for s in self.steps]
+```
+
+Because every `ResolutionStep` carries a scope, the cycle message now renders with the
+same aligned scope column as a resolution chain. That is a user-visible message change,
+licensed by [2026-07-14-error-text-is-not-a-contract](../decisions/2026-07-14-error-text-is-not-a-contract.md):
+the rendered text is diagnostic, the attributes are the contract. It is what lets the
+shared drawer exist with no `show_scope` flag.
+
+### One suggestion format
+
+`build_suggestions` returns `Suggestion` records; `_render_suggestions` is the only
+code that knows a suggestion is a two-space bullet with a parenthetical.
+`UnknownFactoryKwargError` joins the same shape (`Suggestion(name="'kwarg'",
+reason="did you mean 'kwargs'?")`) and derives its own matches from the
+`unknown_keys`/`known_keys` it is already handed.
+
+**Public-API change:** `.suggestions` becomes `list[Suggestion]` rather than
+`list[str]`. Accepted as a clean break in a 2.x minor: what it held before was
+unparsed glyphs, so a programmatic consumer could not have been relying on it in any
+way this does not improve.
+
+## Non-goals
+
+- **Moving message text out of the exception classes.** Ruled out; #227 deleted
+  exactly that seam. Every message stays an inline f-string in the `__init__` that
+  raises it. Only *shared glyph logic* is extracted, and it stays inside
+  `exceptions.py`.
+- **Keeping the cycle message byte-identical.** See the decision above.
+- **Making `exceptions.py` smaller.** It is the largest file in the project (602
+  lines), but ~240 of those are docstrings. Size is not the defect; duplication and a
+  leaked format are.
+- **Touching `docs_slug` / the `See:` trailer.** Unrelated and already correct.
+
+## Testing
+
+Each defect gets a test that fails first.
+
+- `_render_chain` and `_render_suggestions` are pure functions of their inputs, so
+  they are tested directly in `tests/test_error_rendering.py` — the drawer is now
+  exercisable without constructing a container or a cycle.
+- `tests/test_suggestions.py:73` inverts: `.suggestions` must hold
+  `Suggestion(name="Repository", reason="similar name", scope=Scope.APP)`, not a
+  bullet string. Its `str(exc)` assertions stay, proving the rendered block is
+  unchanged.
+- A cycle message test asserts the scope column is present (the one intended
+  user-visible change).
+- `UnknownFactoryKwargError` is constructed with no `suggestions=` argument and must
+  still render "did you mean".
+- `InvalidChildScopeError` is constructed with no `allowed_scopes=` argument and must
+  still list them; the two `container.py` call sites lose the comprehension.
+- `just test-ci` — full suite, 100% line coverage gate.
+- `just lint-ci` — clean.
+
+## Risk
+
+- **A message regresses silently.** Likeliest failure, low impact. The existing
+  `match=`-style assertions across `test_suggestions.py`, `test_error_rendering.py`,
+  `test_dependency_path.py` and `test_runtime_cycle_guard.py` already pin the rendered
+  text of every error that has one; they must pass unchanged except for the cycle
+  scope column. Any other diff in rendered output is a bug in this change.
+- **`.suggestions` break reaches someone.** Low likelihood, low impact — the attribute
+  previously exposed formatting, so it had no clean programmatic use. Called out in
+  the release notes.
+- **`exceptions → suggester` import.** No cycle is possible (`suggester` is
+  stdlib-only), verified before writing this. Mechanical.

--- a/planning/decisions/2026-07-14-error-text-is-not-a-contract.md
+++ b/planning/decisions/2026-07-14-error-text-is-not-a-contract.md
@@ -1,0 +1,54 @@
+---
+status: accepted
+summary: Rendered error text is diagnostic, not a public contract — the structured attributes are; a change may reformat a message without a deprecation cycle.
+supersedes: null
+superseded_by: null
+---
+
+# Rendered error text is not a public contract
+
+**Decision:** The *rendered* text of a `ModernDIError` is diagnostic output and
+may change in any release. The **structured attributes** each error carries
+(`.provider_type`, `.cycle_path`, `.suggestions`, `.dependency_path`, …) and the
+**class hierarchy** callers catch on are the public contract, and those change
+only with the usual care.
+
+## Context
+
+Came up while designing
+[2026-07-14.08-one-error-renderer](../changes/2026-07-14.08-one-error-renderer.md).
+Unifying the two chain drawers means `CircularDependencyError` renders through the
+same code path as `DependencyPathMixin`, which prints an aligned scope column.
+Either the cycle message gains that column (a user-visible change), or the shared
+drawer carries a `show_scope` flag forever to preserve byte-identical output.
+
+The same question sits under the suggestion work: `.suggestions` currently holds
+pre-rendered bullet strings, and making it hold structured `Suggestion` records
+changes what a caller reading that attribute sees.
+
+## Decision & rationale
+
+Error text is for a human reading a traceback. Freezing its bytes buys nothing
+real and costs compounding: every renderer grows a compatibility flag, and the
+formatting can never be improved. So the cycle message gains the scope column,
+and the drawer needs no flag.
+
+The attributes are a different matter, and the distinction is the point of the
+split: a caller who wants to *act* on an error should read `.cycle_path`, not
+regex the message. Pre-rendering suggestions into `.suggestions` violated that —
+it forced a programmatic consumer to parse glyphs back out. Structured records
+fix the contract rather than break it.
+
+This does not license churn. It licenses a message *improving* without a
+deprecation cycle, and it means message-text assertions in tests are pinning an
+implementation detail, not a promise.
+
+Rejected: freezing the rendered text. It would have preserved output nobody
+depends on, at the price of a permanent flag in the one drawer this change exists
+to unify.
+
+## Revisit trigger
+
+A downstream consumer (an integration, or a user in an issue) is found parsing
+`str(exc)` to recover structured facts. That means the attribute surface is
+missing something — add the attribute, and keep this decision.

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -8,7 +8,7 @@ import warnings
 
 import pytest
 
-from modern_di import Container, Group, Scope, exceptions, providers
+from modern_di import Container, Group, Scope, exceptions, providers, suggester
 from modern_di.exceptions import (
     ArgumentResolutionError,
     ChildContainerRegistrationError,
@@ -961,7 +961,9 @@ def test_resolve_dependency_with_unregistered_type_raises_with_suggestion() -> N
 
     exc = exc_info.value
     assert exc.provider_type is Database
-    assert exc.suggestions == ["  - PostgresDatabase (registered subclass, scope=APP)"]
+    assert exc.suggestions == [
+        suggester.Suggestion(name="PostgresDatabase", reason="registered subclass", scope=Scope.APP)
+    ]
 
 
 def test_resolve_dependency_works_on_child_container_for_both_arms() -> None:

--- a/tests/test_error_rendering.py
+++ b/tests/test_error_rendering.py
@@ -1,4 +1,10 @@
-from modern_di import exceptions
+import pytest
+
+from modern_di import Scope, exceptions, suggester
+
+
+def _step(name: str, scope: Scope = Scope.APP, location: str | None = None) -> exceptions.ResolutionStep:
+    return exceptions.ResolutionStep(scope=scope, name=name, location=location)
 
 
 def test_error_without_docs_slug_renders_body_unchanged() -> None:
@@ -9,11 +15,65 @@ def test_error_without_docs_slug_renders_body_unchanged() -> None:
     assert str(error) == "boom"
 
 
+def test_render_chain_is_a_pure_function_of_its_steps() -> None:
+    # The drawer is exercisable without a container, a cycle, or a raise — it is the
+    # single home of the indent-and-arrow glyphs, shared by every chain-shaped error.
+    assert exceptions._render_chain([_step("A"), _step("B", location="app:31"), _step("A")]) == [  # noqa: SLF001
+        "  APP  A",
+        "  APP  └─> B (app:31)",
+        "  APP      └─> A",
+    ]
+
+
+def test_render_chain_aligns_the_scope_column_to_the_widest_name() -> None:
+    lines = exceptions._render_chain([_step("A"), _step("B", scope=Scope.REQUEST)])  # noqa: SLF001
+    assert lines == ["  APP      A", "  REQUEST  └─> B"]
+
+
+@pytest.mark.parametrize(
+    ("suggestion", "expected"),
+    [
+        (
+            suggester.Suggestion(name="PostgresDatabase", reason="registered subclass", scope=Scope.APP),
+            "  - PostgresDatabase (registered subclass, scope=APP)",
+        ),
+        (
+            suggester.Suggestion(name="Repository", reason="similar name", scope=Scope.REQUEST),
+            "  - Repository (similar name, scope=REQUEST)",
+        ),
+        # A kwarg suggestion carries no scope: a parameter name has no provider behind it.
+        (suggester.Suggestion(name="'kwargs'", reason="did you mean 'kwarg'?"), "  - 'kwargs' (did you mean 'kwarg'?)"),
+        # ...and an unknown kwarg with no near match has nothing to say beyond its own name.
+        (suggester.Suggestion(name="'zzz'"), "  - 'zzz'"),
+    ],
+)
+def test_render_suggestion_lines_covers_every_format(suggestion: suggester.Suggestion, expected: str) -> None:
+    # One bullet format for all three suggestion kinds — the registry no longer owns half of it.
+    assert exceptions._render_suggestion_lines([suggestion]) == [expected]  # noqa: SLF001
+
+
+def test_render_suggestions_prepends_the_header_and_is_empty_when_there_is_nothing_to_say() -> None:
+    assert exceptions._render_suggestions([]) == ""  # noqa: SLF001
+    assert (
+        exceptions._render_suggestions(  # noqa: SLF001
+            [suggester.Suggestion(name="Repository", reason="similar name", scope=Scope.APP)]
+        )
+        == "Did you mean:\n  - Repository (similar name, scope=APP)"
+    )
+
+
 def test_circular_dependency_error_renders_cycle_as_arrow_chain() -> None:
-    error = exceptions.CircularDependencyError(cycle_path=["A", "B", "A"])
+    error = exceptions.CircularDependencyError(steps=[_step("A"), _step("B"), _step("A")])
+    # cycle_path / cycle_locations survive as views derived from the one list of steps,
+    # so the two-parallel-lists invariant (equal length) is structural, not enforced at render.
     assert error.cycle_path == ["A", "B", "A"]
+    assert error.cycle_locations == [None, None, None]
     assert str(error) == (
-        "Circular dependency detected:\n  A\n  └─> B\n      └─> A\nCheck your provider graph for unintended cycles.\n"
+        "Circular dependency detected:\n"
+        "  APP  A\n"
+        "  APP  └─> B\n"
+        "  APP      └─> A\n"
+        "Check your provider graph for unintended cycles.\n"
         "See: https://modern-di.modern-python.org/troubleshooting/circular-dependency/"
     )
 
@@ -24,7 +84,7 @@ def test_validation_failed_error_groups_by_kind_and_indents_multiline() -> None:
     # carries a trailer, and it is the report's own final line. Repeating each sub-error's
     # "See: ..." line would be noise (same URL N times for N errors of one kind) and would
     # break "one trailer, always last line."
-    cycle = exceptions.CircularDependencyError(cycle_path=["A", "B", "A"])
+    cycle = exceptions.CircularDependencyError(steps=[_step("A"), _step("B"), _step("A")])
     boom = RuntimeError("boom")
     error = exceptions.ValidationFailedError(errors=[boom, cycle])
     assert error.errors == [boom, cycle]  # list content preserved, order as given
@@ -33,9 +93,9 @@ def test_validation_failed_error_groups_by_kind_and_indents_multiline() -> None:
         "\n"
         "CircularDependencyError (1):\n"
         "  - Circular dependency detected:\n"
-        "      A\n"
-        "      └─> B\n"
-        "          └─> A\n"
+        "      APP  A\n"
+        "      APP  └─> B\n"
+        "      APP      └─> A\n"
         "    Check your provider graph for unintended cycles.\n"
         "\n"
         "RuntimeError (1):\n"
@@ -61,6 +121,38 @@ def test_duplicate_provider_type_error_url_unchanged_by_mechanism() -> None:
     assert "https://modern-di.modern-python.org/troubleshooting/duplicate-type-error/" in rendered
     assert rendered.endswith("See: https://modern-di.modern-python.org/troubleshooting/duplicate-type-error/")
     assert rendered.count("https://modern-di.modern-python.org/troubleshooting/duplicate-type-error/") == 1
+
+
+def test_invalid_child_scope_error_derives_the_allowed_scopes() -> None:
+    # allowed_scopes is a pure function of parent_scope, so the error derives it rather than
+    # being handed it — the same comprehension used to be written out at two raise sites.
+    error = exceptions.InvalidChildScopeError(parent_scope=Scope.REQUEST, child_scope=Scope.APP)
+    assert error.allowed_scopes == ["ACTION", "STEP"]
+    assert "Possible scopes are ['ACTION', 'STEP']." in str(error)
+
+
+def test_unknown_factory_kwarg_error_derives_its_own_suggestions() -> None:
+    # The error already receives unknown_keys and known_keys; it can run the match itself
+    # instead of the raise site pre-computing a did-you-mean map for it.
+    def creator(timeout: int, retries: int) -> int:
+        return timeout + retries
+
+    assert creator(1, retries=2) == creator(2, retries=1)  # exercise the body; only __name__ is read below
+
+    error = exceptions.UnknownFactoryKwargError(
+        creator=creator, unknown_keys=["timout", "zzz"], known_keys=["retries", "timeout"]
+    )
+    assert error.suggestions == [
+        suggester.Suggestion(name="'timout'", reason="did you mean 'timeout'?"),
+        suggester.Suggestion(name="'zzz'"),
+    ]
+    assert str(error) == (
+        "Factory kwargs contain unknown key(s) not in creator signature:\n"
+        "  - 'timout' (did you mean 'timeout'?)\n"
+        "  - 'zzz'\n"
+        "Known parameters: ['retries', 'timeout']\n"
+        "See: https://modern-di.modern-python.org/troubleshooting/unknown-factory-kwarg-error/"
+    )
 
 
 def test_context_value_not_set_error_message_and_hierarchy() -> None:

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -3,7 +3,7 @@ import typing
 
 import pytest
 
-from modern_di import Container, Group, Scope, providers
+from modern_di import Container, Group, Scope, providers, suggester
 from modern_di.exceptions import ArgumentResolutionError, ProviderNotRegisteredError
 from modern_di.registries.providers_registry import _hierarchy_hint
 
@@ -70,7 +70,8 @@ def test_typo_suggestion() -> None:
     # which would otherwise embed the brittle `<locals>.Repostory` repr (couples to this test's name).
     exc = exc_info.value
     assert exc.provider_type is Repostory
-    assert exc.suggestions == ["  - Repository (similar name, scope=APP)"]
+    # .suggestions is data, not glyphs: a caller can act on it without parsing a bullet back apart.
+    assert exc.suggestions == [suggester.Suggestion(name="Repository", reason="similar name", scope=Scope.APP)]
     rendered = str(exc)
     assert "is not registered in providers registry" in rendered
     assert "Did you mean:" in rendered
@@ -175,7 +176,9 @@ def test_argument_resolution_subclass_suggestion() -> None:
     rendered = str(exc_info.value)
     assert "Did you mean:" in rendered
     assert "PostgresDatabase (registered subclass, scope=APP)" in rendered
-    assert exc_info.value.suggestions == ["  - PostgresDatabase (registered subclass, scope=APP)"]
+    assert exc_info.value.suggestions == [
+        suggester.Suggestion(name="PostgresDatabase", reason="registered subclass", scope=Scope.APP)
+    ]
 
 
 def test_argument_resolution_baseclass_suggestion() -> None:


### PR DESCRIPTION
Review candidate 2, scoped down after it turned out to bundle a revert.

Design: [planning/changes/2026-07-14.08-one-error-renderer.md](planning/changes/2026-07-14.08-one-error-renderer.md)
Decision: [planning/decisions/2026-07-14-error-text-is-not-a-contract.md](planning/decisions/2026-07-14-error-text-is-not-a-contract.md)

## Scope note

The candidate as originally written proposed splitting the message catalog out of `exceptions.py`. That is the **inverse of #227** (`bfc8fda`), which deleted `errors.py` precisely so messages would live with the class that raises them. That part was dropped: every message stays an inline f-string in its own `__init__`. Only *shared glyph logic* is factored out, and it stays inside `exceptions.py`.

## What was wrong

- **The chain drawer was written twice**, in the same file: `DependencyPathMixin._render_body` and `CircularDependencyError.__init__` each built their own `└─>` arrow tree. They had already drifted — one printed an aligned scope column, the other none.
- **The suggestion format was split across modules.** `build_suggestions` returned *pre-rendered bullet lines*, so the registry owned half the message format. `.suggestions` — a documented public attribute — held glyphs, meaning a caller who wanted to *act* on a suggestion had to parse the indent and parenthetical back out. `UnknownFactoryKwargError` used a third, unrelated format.
- **Three raise sites computed what the error could derive.** `allowed_scopes` was built by the identical comprehension at `container.py:94` and `:145`; `factory.py` ran `close_matches` to hand `UnknownFactoryKwargError` a did-you-mean map it could have built itself; `dependency_graph` decomposed a cycle into two parallel lists whose equal length was enforced only by `zip(strict=True)` at render time.

## What changed

`suggester` owns what a suggestion *is* (`Suggestion(name, reason, scope)`) and how to *find* one. `exceptions` owns how everything *looks* — `_render_chain` and `_render_suggestions` are the only code that knows a glyph. Registries and raise sites pass facts.

`CircularDependencyError` now carries `list[ResolutionStep]`; `.cycle_path` and `.cycle_locations` survive as derived views, so nothing a caller catches on breaks and the parallel-list invariant becomes structural.

**One user-visible change:** because a `ResolutionStep` carries its scope, cycles render with the same aligned scope column as a resolution breadcrumb. Licensed by the decision above — rendered error text is diagnostic; the structured attributes are the contract.

**One API change:** `.suggestions` is `list[Suggestion]`, not `list[str]`. What it held before was unparsed glyphs, so no programmatic consumer could have depended on it in a way this does not improve.

## Verification

Test-first, one failing test per defect. `_render_chain` / `_render_suggestions` are pure functions, so they are now exercisable without building a container or a cycle. `test_custom_scope.py` already asserted `allowed_scopes == ["BACKGROUND_JOB"]` for a custom enum, which became a free proof the derivation is right.

397 tests, 100% coverage, `just lint-ci` clean. Verified no glyph survives outside `exceptions.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)