### PR TITLE
refactor: give Scope its own algebra

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -51,9 +51,12 @@ child = container.build_child_container(scope=Scope.REQUEST, context={MyRequest:
 `build_child_container` creates a new `Container` whose `parent_container` is the current one.
 Rules:
 
-- The child's scope must be strictly greater (deeper) than the parent's scope. Passing `scope=None`
-  auto-increments to the next `IntEnum` value; if the parent is already at the maximum scope,
-  `MaxScopeReachedError` is raised.
+- The child's scope must be strictly greater (deeper) than the parent's scope; `Container.__init__` is the
+  guard, so passing a too-shallow scope to `build_child_container` raises `InvalidChildScopeError` from there.
+  Passing `scope=None` derives the next scope via `scope._next_deeper` — the shallowest *member* deeper than
+  the parent, **not** `value + 1`, so non-contiguous custom enums (`TENANT=6, JOB=10`) work; if the parent is
+  already at the deepest member, `MaxScopeReachedError` is raised. See
+  [scopes.md](scopes.md#the-scope-algebra).
 - Building a child from a closed container is transitional until modern-di 3.0: it emits
   `ContainerClosedWarning` and self-reopens the container instead of raising `ContainerClosedError`
   (see [Lifecycle: close and reopen](#lifecycle-close-and-reopen) below).

--- a/architecture/scopes.md
+++ b/architecture/scopes.md
@@ -55,6 +55,31 @@ parent-chain traversal during resolution.
 more levels (or different names) can define their own `IntEnum` and use it throughout. The same integer-ordering
 rules apply. Passing a non-`IntEnum` value raises `InvalidScopeTypeError`.
 
+A custom scope is a **standalone** `IntEnum`, never a subclass of `Scope` — Python forbids extending an enum
+that has members (`class MyScope(Scope)` raises `TypeError: cannot extend enumeration 'Scope'`).
+
+## The scope algebra
+
+The one rule that is not just an integer comparison — *"which members of my enum are deeper than me"* — lives in
+`scope.py`, next to the concept it belongs to:
+
+- `_deeper_members(scope)` — the members of `scope`'s own enum deeper than it, shallowest first.
+- `_next_deeper(scope)` — the shallowest of those, or `None` at the deepest member.
+
+Both take **any** `IntEnum`, which the custom-scope contract forces: since a custom scope cannot subclass
+`Scope`, an algebra expressed as methods on `Scope` would silently apply to the five built-in members and to
+nothing else. Free functions apply uniformly, so custom scopes get the rule for free.
+
+`scope.py` imports only `enum` and stays that way by necessity: `exceptions.py` imports `_deeper_members` (to
+derive `InvalidChildScopeError.allowed_scopes`), so `_next_deeper` returns `None` at the deepest member rather
+than raising `MaxScopeReachedError` itself — raising it here would make `scope` import `exceptions` and the two
+would cycle. `Container.build_child_container` owns that raise.
+
+Both consumers read the rule from this one home: `build_child_container` derives an omitted child scope with
+`_next_deeper`, and `InvalidChildScopeError` reports the valid choices with `_deeper_members`. The plain
+ordering checks (`scope <= parent.scope`, `scope > self.scope`) stay as they are — `IntEnum` already gives
+comparison for free, and wrapping it would add an interface without adding a rule.
+
 ## See also
 
 - [docs/providers/scopes.md](../docs/providers/scopes.md) for a worked, user-facing walk-through of

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -19,7 +19,7 @@ from modern_di.registries.cache_registry import CacheRegistry
 from modern_di.registries.context_registry import ContextRegistry
 from modern_di.registries.overrides_registry import OverrideHandle, OverridesRegistry
 from modern_di.registries.providers_registry import ProvidersRegistry
-from modern_di.scope import Scope
+from modern_di.scope import Scope, _next_deeper
 
 
 if typing.TYPE_CHECKING:
@@ -134,17 +134,15 @@ class Container:
     ) -> "typing_extensions.Self":
         self._warn_and_reopen_if_closed()
 
-        if scope is not None and scope <= self.scope:
-            raise exceptions.InvalidChildScopeError(parent_scope=self.scope, child_scope=scope)
-
         if scope is None:
-            # Derive the next scope as the smallest member deeper than the current one, so
-            # non-contiguous custom enums (e.g. TENANT=6, JOB=10) work, not just `value + 1`.
-            deeper_scopes = [member for member in type(self.scope) if member > self.scope]
-            if not deeper_scopes:
+            # `_next_deeper` is the smallest member deeper than this one, so non-contiguous
+            # custom enums (e.g. TENANT=6, JOB=10) work, not just `value + 1`.
+            scope = _next_deeper(self.scope)
+            if scope is None:
                 raise exceptions.MaxScopeReachedError(parent_scope=self.scope)
-            scope = min(deeper_scopes)
 
+        # An explicitly-passed scope is not checked here: __init__ rejects a scope that is not
+        # deeper than its parent's, raising an identical InvalidChildScopeError.
         return self.__class__(scope=scope, parent_container=self, context=context, use_lock=self._lock is not None)
 
     def find_container(self, scope: enum.IntEnum) -> "typing_extensions.Self":

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -3,6 +3,7 @@ import enum
 import typing
 
 from modern_di import suggester
+from modern_di.scope import _deeper_members
 
 
 SUGGESTION_HEADER = "Did you mean:"
@@ -148,10 +149,9 @@ class InvalidChildScopeError(ContainerError):
     def __init__(self, *, parent_scope: enum.IntEnum, child_scope: enum.IntEnum) -> None:
         self.parent_scope = parent_scope
         self.child_scope = child_scope
-        # Derived, not handed over: the allowed scopes are a pure function of the parent's own
-        # enum class, so a raise site has nothing to add. Drawn from type(parent_scope) so a
-        # custom IntEnum reports its own members.
-        self.allowed_scopes = [x.name for x in type(parent_scope) if x > parent_scope]
+        # Derived, not handed over: the allowed scopes are a pure function of the parent's
+        # own enum class, so a raise site has nothing to add.
+        self.allowed_scopes = [member.name for member in _deeper_members(parent_scope)]
         super().__init__(
             f"Scope of child container cannot be {child_scope.name} if parent scope is {parent_scope.name} "
             f"(child scope value must be strictly greater than parent scope value). "

--- a/modern_di/scope.py
+++ b/modern_di/scope.py
@@ -15,3 +15,23 @@ class Scope(enum.IntEnum):
     REQUEST = 3
     ACTION = 4
     STEP = 5
+
+
+def _deeper_members(scope: enum.IntEnum) -> list[enum.IntEnum]:
+    """Members of ``scope``'s own enum that are deeper than it, shallowest first.
+
+    Takes any ``IntEnum``, not just :class:`Scope`: Python forbids extending an enum that
+    has members, so a custom scope is a standalone ``IntEnum`` and this rule could never
+    reach it as a method.
+    """
+    return sorted(member for member in type(scope) if member > scope)
+
+
+def _next_deeper(scope: enum.IntEnum) -> enum.IntEnum | None:
+    """Return the next deeper member, or None when ``scope`` is the deepest.
+
+    Returns None rather than raising ``MaxScopeReachedError`` so this module stays
+    dependency-free: ``exceptions`` imports it, so importing ``exceptions`` back would cycle.
+    """
+    members = _deeper_members(scope)
+    return members[0] if members else None

--- a/planning/changes/2026-07-14.09-scope-algebra.md
+++ b/planning/changes/2026-07-14.09-scope-algebra.md
@@ -1,0 +1,105 @@
+---
+summary: Shipped. `_deeper_members` / `_next_deeper` give the "members of my enum deeper than me" rule one home in a dependency-free `scope.py`, replacing a comprehension written in two modules; the redundant child-scope guard in `build_child_container` is gone (`__init__` was already raising an identical error). Private, not exported — no user computes this. 399 tests, 100% coverage.
+---
+
+# Design: Scope owns its own algebra
+
+## Summary
+
+`Scope` is the module that *is* the scope concept, and it knows none of the scope
+rules. "Which members of my enum are deeper than me" is written twice, in two
+different modules, and the child-scope guard is checked twice on every child
+container. Two private helpers in a dependency-free `scope.py` give the rule one
+home, and one redundant guard is deleted.
+
+## Motivation
+
+Two live duplications on HEAD.
+
+**The deeper-members comprehension, written twice in two modules:**
+
+```python
+container.py:143   [member for member in type(self.scope) if member > self.scope]
+exceptions.py:154  [x.name  for x in type(parent_scope) if x > parent_scope]
+```
+
+The second was introduced yesterday by
+[2026-07-14.08-one-error-renderer](2026-07-14.08-one-error-renderer.md) (PR #324),
+which made `InvalidChildScopeError` derive `allowed_scopes` instead of being handed
+it — correct, but it moved the rule rather than homing it. This is the same shape
+as the defect #324 existed to remove (one drawer written twice, already drifted),
+one layer down.
+
+**The child-scope guard, checked twice per child.** `build_child_container`
+(`container.py:137`) rejects a too-shallow scope, then calls `__init__`
+(`container.py:90`), which rejects it again. Verified: both paths raise an
+*identical* `InvalidChildScopeError` — same `.parent_scope`, `.child_scope`, and
+`.allowed_scopes` — differing only in the line that raises. Deleting the
+`build_child_container` check changes no behavior; `__init__` remains the real guard
+(it must, since `Container(scope=..., parent_container=...)` is constructible
+directly).
+
+## Design
+
+Two private helpers in `scope.py`:
+
+```python
+def _deeper_members(scope: enum.IntEnum) -> list[enum.IntEnum]:
+    """Members of `scope`'s own enum that are deeper than it, shallowest first."""
+    return sorted(member for member in type(scope) if member > scope)
+
+
+def _next_deeper(scope: enum.IntEnum) -> enum.IntEnum | None:
+    """The next deeper member, or None when `scope` is the deepest."""
+    members = _deeper_members(scope)
+    return members[0] if members else None
+```
+
+They take **any** `enum.IntEnum`, which is forced by the domain: a custom scope is a
+standalone `IntEnum` (`test_custom_scope.py:15` — `class MyScope(enum.IntEnum)`), and
+Python **cannot** extend an enum that has members (`class MyScope(Scope)` raises
+`TypeError: cannot extend enumeration 'Scope'`). So the algebra can never be methods
+on `Scope` without silently applying to the five built-in members and nothing else.
+Free functions apply uniformly; custom scopes get the rule for free.
+
+`scope.py` stays **dependency-free** (it imports only `enum`). That is also forced:
+`exceptions.py` needs `_deeper_members` for `allowed_scopes`, so the edge runs
+`exceptions → scope`. If `_next_deeper` raised `MaxScopeReachedError` itself, `scope`
+would have to import `exceptions` and the two would cycle. So `_next_deeper` returns
+`None` and `Container` keeps the raise.
+
+Private, not public: a user with a custom scope never computes this. They pass
+`MyScope.TENANT` explicitly, or omit `scope=` and let the container derive the next
+deeper scope on their behalf. Nothing in `docs/` or `tests/` computes deeper members
+at user level, so a public API here would be a seam with no caller.
+
+## Non-goals
+
+- **Moving the resolution rule (`container.scope >= provider.scope`) or
+  `find_container`'s error choice.** Those need the container's `_scope_map`, not just
+  scope algebra. They stay in `Container`.
+- **Exporting the algebra.** See above — no demonstrated caller.
+- **Touching `Scope`'s members or the custom-scope contract.** Any `IntEnum` still works,
+  unchanged.
+
+## Testing
+
+- `test_next_deeper_and_deeper_members_over_a_custom_enum` — non-contiguous custom
+  enum (`TENANT=6, BACKGROUND_JOB=7`) resolves correctly, and `_next_deeper` returns
+  `None` at the deepest member. This is the property that made the original
+  comprehension use `min(...)` over `value + 1`.
+- `test_custom_scope.py` already asserts `allowed_scopes == ["BACKGROUND_JOB"]` for a
+  custom enum and that `build_child_container()` auto-derives; both must stay green,
+  proving the extracted rule behaves identically.
+- A `build_child_container(scope=<too shallow>)` test must still raise
+  `InvalidChildScopeError` with the same attributes after the redundant guard is gone.
+- `just test-ci` (100% coverage gate) and `just lint-ci`.
+
+## Risk
+
+- **The redundant-guard deletion changes which line raises.** Low impact; verified the
+  error is attribute-identical from either path. A test asserting on a traceback line
+  number would break, and none does.
+- **`sorted()` on enum members.** `IntEnum` members order by value, so `sorted` and
+  `min` agree with the current `min(deeper_scopes)`. Covered by the non-contiguous
+  custom-enum test.

--- a/tests/test_custom_scope.py
+++ b/tests/test_custom_scope.py
@@ -10,6 +10,7 @@ from modern_di.exceptions import (
     ScopeNotInitializedError,
     ScopeSkippedError,
 )
+from modern_di.scope import _deeper_members, _next_deeper
 
 
 class MyScope(enum.IntEnum):
@@ -85,6 +86,26 @@ def test_invalid_child_scope_with_conflicting_value() -> None:
         app_container.build_child_container(scope=ConflictingScope.SAME_AS_APP)
     assert exc.value.parent_scope is Scope.APP
     assert exc.value.child_scope is ConflictingScope.SAME_AS_APP
+
+
+def test_scope_algebra_answers_deeper_members_for_any_int_enum() -> None:
+    # The rule has one home and takes ANY IntEnum: Python forbids extending an enum that
+    # has members (`class MyScope(Scope)` -> TypeError), so a custom scope is a standalone
+    # IntEnum and the algebra cannot be methods on Scope without silently skipping it.
+    assert _deeper_members(MyScope.TENANT) == [MyScope.BACKGROUND_JOB]
+    assert _deeper_members(MyScope.BACKGROUND_JOB) == []
+    assert _deeper_members(Scope.ACTION) == [Scope.STEP]
+
+
+def test_scope_algebra_next_deeper_is_the_shallowest_deeper_member() -> None:
+    # Non-contiguous values: the next scope is the smallest member greater than the current
+    # one, never current.value + 1 (which need not be a member at all).
+    assert _next_deeper(GappedScope.TENANT) is GappedScope.BACKGROUND_JOB
+    assert _next_deeper(Scope.APP) is Scope.SESSION
+    # None at the deepest member: `scope.py` stays dependency-free, so raising
+    # MaxScopeReachedError here would cycle (exceptions imports scope for allowed_scopes).
+    assert _next_deeper(GappedScope.BACKGROUND_JOB) is None
+    assert _next_deeper(Scope.STEP) is None
 
 
 def test_caching_isolated_across_tenant_containers() -> None:


### PR DESCRIPTION
Review candidate 5, re-scoped after checking its premises against HEAD.

Design: [planning/changes/2026-07-14.09-scope-algebra.md](planning/changes/2026-07-14.09-scope-algebra.md)

## Two corrections to the candidate as filed

The review claimed the "scopes deeper than me" comprehension appeared **three times in `container.py`**. #324 deleted two of them. What actually remained was two sites in *two modules* — and the second one, in `exceptions.py`, was **introduced by #324 itself**, which made `InvalidChildScopeError` derive `allowed_scopes` rather than be handed it. That was right, but it homed the rule's caller without homing the rule.

The review also proposed moving the rules **onto `Scope`**, so "custom scope enums get them for free." That is impossible. Python forbids extending an enum that has members:

```
class MyScope(Scope): ...  ->  TypeError: MyScope: cannot extend enumeration 'Scope'
```

Custom scopes are standalone `IntEnum`s (`test_custom_scope.py:16`), so methods on `Scope` would apply to the five built-in members and to nothing else — exactly the asymmetry that breeds bugs. The algebra has to be free functions over `enum.IntEnum`, and then custom scopes really do get it for free.

## What changed

`_deeper_members` and `_next_deeper` in `scope.py`, next to the concept they belong to. `scope.py` imports only `enum`, and must stay that way: `exceptions.py` imports `_deeper_members`, so `_next_deeper` returns `None` at the deepest member rather than raising `MaxScopeReachedError` itself — raising it there would cycle. `Container` keeps that raise.

**Also deletes a redundant guard.** `build_child_container` rejected a too-shallow scope, then called `__init__`, which rejected it again. Verified both paths raise an attribute-identical `InvalidChildScopeError` (same `.parent_scope`, `.child_scope`, `.allowed_scopes`) differing only in the raising line, so every child container was checked twice. `__init__` remains the real guard — it must, since `Container(scope=..., parent_container=...)` is directly constructible.

Private, not exported: no user computes deeper members. They pass a scope explicitly, or omit it and let the container derive it on their behalf. A public API here would be a seam with no caller.

## Verification

Test-first. The existing custom-scope suite is the proof the extraction is faithful: `allowed_scopes == ["BACKGROUND_JOB"]` for a custom enum, auto-derive across a *gapped* enum (`TENANT=6, JOB=10`), and `MaxScopeReachedError` at the deepest member all stay green untouched. Every existing too-shallow-scope rejection test also stays green, now raising from `__init__`.

399 tests, 100% coverage, `just lint-ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)