### PR TITLE
perf: memoize wiring plans on the registry, shared tree-wide

### DIFF
--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -34,10 +34,13 @@ immediately. A `Factory` with no `cache_settings` always re-runs the creator.
 ## Step 4 — Wiring plan
 
 If no cached instance is returned, `Factory` builds the **wiring plan**: the partition of the creator's parameters by
-how each is satisfied. `_ensure_plan` memoizes a single `WiringPlan` on the `CacheItem`, stamped with the
-`ProvidersRegistry.version` it was built against; subsequent calls (within the same container lifetime) reuse it while
-that stamp matches the registry's current version, and rebuild it when the registry has changed (i.e. after
-`add_providers`).
+how each is satisfied. `Factory._plan` delegates to `ProvidersRegistry.plan_for`, which memoizes one `WiringPlan` per
+provider on the **registry** — keyed by `provider_id`, stamped with the `ProvidersRegistry.version` it was built
+against. A call reuses the plan while that stamp matches the registry's current version and rebuilds when the registry
+has changed (i.e. after `add_providers`). Because a container and every child share one `providers_registry`, the plan
+is built once per registry version for the whole tree, not once per child container; a `REQUEST`-scoped factory
+resolved across many child containers plans only once. `get_dependencies` and `iter_validation_issues` route through the
+same memo, so `validate()` warms it rather than rebuilding on each graph walk.
 
 `WiringPlan.build` (in `modern_di/wiring.py`) is a **pure function** of `(parsed_kwargs, kwargs, providers_registry,
 owner)` — it reads no cache, scope, or live context, so it runs outside the container lock; the version stamp keeps the

--- a/benchmarks/test_bench_kwargs_split.py
+++ b/benchmarks/test_bench_kwargs_split.py
@@ -16,7 +16,7 @@ import typing
 
 from modern_di import Container, Group, Scope, providers
 from modern_di.providers.abstract import AbstractProvider
-from modern_di.registries.cache_registry import CacheItem
+from modern_di.wiring import WiringPlan
 
 
 # ---------------------------------------------------------------------------
@@ -51,11 +51,8 @@ class BenchGroup(Group):
 # ---------------------------------------------------------------------------
 
 
-def _baseline_resolve_inner(cache_item: CacheItem, container: Container) -> dict[str, typing.Any]:
+def _baseline_resolve_inner(plan: WiringPlan, container: Container) -> dict[str, typing.Any]:
     """Simulate the old resolved_kwargs dict-comp that ran on every resolve()."""
-    plan = cache_item.wiring_plan
-    if plan is None:
-        return {}
     unified = {**plan.provider_kwargs, **plan.static_kwargs}
     return {k: container.resolve_provider(v) if isinstance(v, AbstractProvider) else v for k, v in unified.items()}
 
@@ -74,16 +71,15 @@ def test_uncached_optimized(benchmark):
 def test_uncached_baseline(benchmark):
     """Baseline: unified dict-comp with isinstance on every resolve()."""
     container = Container(scope=Scope.APP, groups=[BenchGroup])
-    # Warm up compilation so kwargs are cached (same as optimized path)
+    # Warm up compilation so the plan is memoized (same as optimized path)
     container.resolve_provider(BenchGroup.svc)
 
     svc_provider = BenchGroup.svc
-    cache_item = container.cache_registry.fetch_cache_item(svc_provider)
 
     def _baseline():
         # replicate what resolve() did before fix #4
         c = container.find_container(svc_provider.scope)
-        resolved = _baseline_resolve_inner(cache_item, c)
+        resolved = _baseline_resolve_inner(svc_provider._plan(c), c)
         return svc_provider._creator(**resolved)
 
     benchmark(_baseline)
@@ -124,7 +120,7 @@ def test_singleton_baseline(benchmark):
     def _baseline():
         c = container.find_container(svc_provider.scope)
         # resolve the unified kwargs (even though cache exists — mimics pre-fix path)
-        _baseline_resolve_inner(cache_item, c)
+        _baseline_resolve_inner(svc_provider._plan(c), c)
         # return cached instance (same as current code does after kwargs loop)
         return cache_item.cache
 

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -13,7 +13,6 @@ from modern_di.wiring import WiringPlan, _Absent, absent_disposition
 
 if typing.TYPE_CHECKING:
     from modern_di import Container
-    from modern_di.registries.cache_registry import CacheItem
     from modern_di.registries.providers_registry import ProvidersRegistry
 
 
@@ -170,21 +169,21 @@ class Factory(AbstractProvider[types.T_co]):
             member_types=item.args,
         )
 
-    def _ensure_plan(self, container: "Container", cache_item: "CacheItem") -> WiringPlan:
-        # Plan runs outside the container lock — safe under the GIL since it's a deterministic
-        # function of the providers registry as of the version it was built against (free-threaded/nogil
-        # caveat: planning/deferred.md). The version stamp on the registry lets a stale memoized plan
-        # (built before a later Container.add_providers call) be detected and rebuilt.
-        current_version = container.providers_registry.version
-        if cache_item.wiring_plan is None or cache_item.wiring_plan_version != current_version:
-            cache_item.wiring_plan = WiringPlan.build(
+    def _plan(self, container: "Container") -> WiringPlan:
+        # The plan is memoized on the providers registry (shared by a container and every child), so a
+        # deeper-scope factory builds it once per registry version, not once per child container. Building
+        # runs outside the container lock — safe under the GIL since it's a deterministic function of the
+        # registry as of the version it was built against (free-threaded/nogil caveat: planning/deferred.md).
+        reg = container.providers_registry
+        return reg.plan_for(
+            self,
+            lambda: WiringPlan.build(
                 parsed_kwargs=self._parsed_kwargs,
                 kwargs=self._kwargs,
-                registry=container.providers_registry,
+                registry=reg,
                 owner=self,
-            )
-            cache_item.wiring_plan_version = current_version
-        return cache_item.wiring_plan
+            ),
+        )
 
     def _resolve_context_value(
         self, container: "Container", arg_name: str, provider: ContextProvider[typing.Any], item: SignatureItem
@@ -213,21 +212,11 @@ class Factory(AbstractProvider[types.T_co]):
         Pure lookup: no scope check, no cache touch, no context-value lookup. Used by
         Container.validate() to traverse the static graph.
         """
-        return WiringPlan.build(
-            parsed_kwargs=self._parsed_kwargs,
-            kwargs=self._kwargs,
-            registry=container.providers_registry,
-            owner=self,
-        ).edges
+        return self._plan(container).edges
 
     def iter_validation_issues(self, container: "Container") -> typing.Iterable[Exception]:
         """Yield ArgumentResolutionError for parameters with no provider, no default, no static kwarg."""
-        plan = WiringPlan.build(
-            parsed_kwargs=self._parsed_kwargs,
-            kwargs=self._kwargs,
-            registry=container.providers_registry,
-            owner=self,
-        )
+        plan = self._plan(container)
         for name, item in plan.unwireable:
             yield self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
 
@@ -243,9 +232,9 @@ class Factory(AbstractProvider[types.T_co]):
             error.prepend_step(self._resolution_step())
             raise error from exc
 
-    def _resolve_kwargs(self, container: "Container", cache_item: "CacheItem") -> dict[str, typing.Any]:
+    def _resolve_kwargs(self, container: "Container") -> dict[str, typing.Any]:
         try:
-            plan = self._ensure_plan(container, cache_item)
+            plan = self._plan(container)
             if plan.unwireable:
                 name, item = plan.unwireable[0]
                 raise self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
@@ -270,14 +259,14 @@ class Factory(AbstractProvider[types.T_co]):
             exc.prepend_step(self._resolution_step())
             raise
         container._warn_and_reopen_if_closed()  # noqa: SLF001
-        cache_item = container.cache_registry.fetch_cache_item(self)
 
         if not self.cache_settings:
-            return self._call_creator(self._resolve_kwargs(container, cache_item))
+            return self._call_creator(self._resolve_kwargs(container))
 
+        cache_item = container.cache_registry.fetch_cache_item(self)
         value, created = cache_item.get_or_create(
             container._lock,  # noqa: SLF001
-            resolve=lambda: self._resolve_kwargs(container, cache_item),
+            resolve=lambda: self._resolve_kwargs(container),
             create=self._call_creator,
         )
         if created:

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -9,8 +9,6 @@ from modern_di.providers import CacheSettings, Factory
 if typing.TYPE_CHECKING:
     import threading
 
-    from modern_di.wiring import WiringPlan
-
 
 _R = typing.TypeVar("_R")
 _V = typing.TypeVar("_V")
@@ -21,9 +19,6 @@ class CacheItem:
     settings: CacheSettings[typing.Any] | None
     cache: typing.Any = types.UNSET
     finalized: bool = False
-    wiring_plan: "WiringPlan | None" = None
-    # `ProvidersRegistry.version` the memoized `wiring_plan` was built against; see `Factory._ensure_plan`.
-    wiring_plan_version: int | None = None
 
     def _clear(self) -> None:
         if self.settings and self.settings.clear_cache:

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -6,6 +6,10 @@ from modern_di import exceptions, suggester, types
 from modern_di.providers.abstract import AbstractProvider
 
 
+if typing.TYPE_CHECKING:
+    from modern_di.wiring import WiringPlan
+
+
 _MAX_SUGGESTIONS = 3
 
 
@@ -26,11 +30,12 @@ def _hierarchy_hint(requested_type: type, provider: AbstractProvider[typing.Any]
 
 
 class ProvidersRegistry:
-    __slots__ = ("_lock", "_providers", "_version", "validated_version")
+    __slots__ = ("_lock", "_plans", "_providers", "_version", "validated_version")
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._providers: dict[type, AbstractProvider[typing.Any]] = {}
+        self._plans: dict[int, tuple[int, WiringPlan]] = {}
         self._version = 0
         self.validated_version: int | None = None
 
@@ -44,13 +49,37 @@ class ProvidersRegistry:
     def version(self) -> int:
         """Monotonically increasing counter, bumped on every mutation.
 
-        Lets memoized `WiringPlan`s (see `Factory._ensure_plan`) detect that the registry
-        changed underneath them and rebuild instead of resolving against a stale plan.
+        Stamps the memoized `WiringPlan`s held in `_plans` (see `plan_for`) so a plan built
+        against an older registry is rebuilt instead of resolving against a stale one.
         """
         return self._version
 
     def find_provider(self, dependency_type: type[types.T]) -> AbstractProvider[types.T] | None:
         return self._providers.get(dependency_type)
+
+    def plan_for(
+        self,
+        provider: AbstractProvider[typing.Any],
+        build: "typing.Callable[[], WiringPlan]",
+    ) -> "WiringPlan":
+        """Return `provider`'s memoized wiring plan, building and stamping it on a miss.
+
+        A plan is a pure function of the provider and this registry's contents, so it is
+        memoized per `provider_id` and stamped with the `version` it was built against; a
+        stamp mismatch (the registry mutated since) rebuilds. The version is snapshotted
+        *before* `build` runs, so a plan built against a since-mutated registry carries the
+        old stamp and is never served as current. Shared tree-wide: a container and every
+        child share one registry, so a deeper-scope provider builds its plan once, not once
+        per child container.
+        """
+        provider_id = provider.provider_id
+        version = self._version
+        cached = self._plans.get(provider_id)
+        if cached is not None and cached[0] == version:
+            return cached[1]
+        plan = build()
+        self._plans[provider_id] = (version, plan)
+        return plan
 
     def register(self, provider_type: type, provider: AbstractProvider[typing.Any]) -> None:
         with self._lock:

--- a/planning/changes/2026-07-15.01-wiring-plan-registry-memo.md
+++ b/planning/changes/2026-07-15.01-wiring-plan-registry-memo.md
@@ -1,0 +1,119 @@
+---
+summary: The WiringPlan memo moves off the per-container CacheItem onto ProvidersRegistry (plan_for, version-stamped dict shared tree-wide); a REQUEST-scoped Factory now builds its plan once per registry version instead of once per child container, get_dependencies/iter_validation_issues share the memo, uncached factories skip fetch_cache_item, and CacheItem loses two fields. No public-API or behaviour change.
+---
+
+# Design: ProvidersRegistry owns the wiring-plan memo
+
+## Summary
+
+`Factory` memoizes its `WiringPlan` on `CacheItem`, which is per-container. A
+`REQUEST`-scoped factory therefore rebuilds an identical plan on every request,
+and the two validation paths (`get_dependencies`, `iter_validation_issues`)
+rebuild it unmemoized on every graph walk. This change moves the memo onto
+`ProvidersRegistry` — the object the plan is actually keyed to — behind a single
+`plan_for(provider, build)` accessor. The plan is shared tree-wide (root plus
+every child share one registry), so it builds once per registry version. Public
+API and behaviour are unchanged; this is Candidate 1 from the 2026-07-15
+architecture review.
+
+## Motivation
+
+`WiringPlan.build` is a pure function of `(Factory._parsed_kwargs,
+Factory._kwargs, providers_registry)`. The first two are fixed at construction,
+so the plan varies **only** with the registry. But `_ensure_plan` stamps the
+memo onto `CacheItem`, and every container owns a fresh `CacheRegistry`
+(`container.py`), so children never see the parent's plan. Measured: 100 child
+containers resolving one `REQUEST`-scoped factory call `WiringPlan.build` **101
+times** where 1 is correct. Separately, `get_dependencies` and
+`iter_validation_issues` (`factory.py:210,223`) call `WiringPlan.build` inline
+with no memo, so each `validate()` walk rebuilds every plan.
+
+The memo lives on the wrong object. It is keyed to the registry but stored on a
+per-container cache item, which forces the version stamp to poll a *foreign*
+object's version from a distance. Moving it onto the registry puts the memo with
+the data it derives from and the invalidation where mutation already happens.
+
+## Design
+
+**`ProvidersRegistry`** gains a private `_plans: dict[int, tuple[int,
+WiringPlan]]` (provider_id → (version, plan)) and one accessor:
+
+```python
+def plan_for(self, provider, build):
+    pid = provider.provider_id
+    version = self._version            # snapshot BEFORE build
+    hit = self._plans.get(pid)
+    if hit is not None and hit[0] == version:
+        return hit[1]
+    plan = build()
+    self._plans[pid] = (version, plan)
+    return plan
+```
+
+`WiringPlan` is a `TYPE_CHECKING`-only import (the registry stores and returns
+it opaquely; it never builds one), so no runtime coupling and no import cycle.
+The single get-or-build shape encapsulates the snapshot-before-build ordering in
+one place — a passive get/store pair would leak that ordering to the call site,
+where stamping with the post-build version silently serves a stale plan.
+
+**`Factory`** replaces `_ensure_plan` and the two inline `WiringPlan.build`
+calls with one private accessor that all three callers share, so validation now
+warms the same memo instead of rebuilding:
+
+```python
+def _plan(self, container):
+    reg = container.providers_registry
+    return reg.plan_for(self, lambda: WiringPlan.build(
+        parsed_kwargs=self._parsed_kwargs, kwargs=self._kwargs,
+        registry=reg, owner=self))
+```
+
+**Invalidation** is the version-stamped read-side check, relocated verbatim from
+today's `CacheItem` logic (`factory.py:179`): snapshot before build, trust only
+a matching stamp. This preserves the exact resolve-vs-`add_providers`
+concurrency property — a plan built against a since-mutated registry carries a
+stale stamp and is rebuilt, never served. No new lock: plan-building is a pure
+lockless lookup, GIL-assuming, consistent with the committed stance in
+`deferred.md` A-1.
+
+**Two consequences fall out.** `CacheItem` loses `wiring_plan` and
+`wiring_plan_version` (5 fields → 3). And an *uncached* factory fetches a
+`CacheItem` today only to hold its plan; once the plan lives on the registry,
+`resolve()` fetches a `CacheItem` only on the cached path, removing a per-resolve
+`setdefault` allocation.
+
+## Non-goals
+
+- `WiringPlan.build` and its partitioning logic (`wiring.py`) — untouched; only
+  where the result is memoized changes.
+- The singleton double-checked-lock half of `CacheItem` (`get_or_create`,
+  finalizers) — unchanged (that was 2026-07-14.02).
+- The nogil publication barrier — still deferred; A-1 is *repointed*, not fixed.
+- Candidates 2–5 from the review — separate changes.
+
+## Testing
+
+- `just test-ci` — 100% line coverage, the gate.
+- RED-first regression: a `REQUEST`-scoped `Factory` resolved across N child
+  containers, spying `WiringPlan.build`, asserts one build per provider (fails
+  at 101 today, passes after). Replaces the weaker single-container count test
+  at `test_factory.py:430`.
+- Correctness guard (no mock): the same `Factory` instance registered into two
+  independent registries with different provider sets wires differently
+  (`dep`→provider in one, `None` in the other) — guards against a naive
+  Factory-keyed memo that a version-only stamp would alias.
+- `test_add_providers_rebuilds_stale_wiring_plan_for_{optional,required}_dependency`
+  (`test_container.py:836,859`) stay green as invalidation guards.
+- `architecture/resolution.md` Step 4 + the `ProvidersRegistry.version`
+  docstring + `deferred.md` A-1 promoted in the same PR.
+
+## Risk
+
+- **Cross-registry aliasing** (low likelihood × high impact — silent wrong
+  wiring). This is the sharp edge the whole design turns on; keyed by
+  `(registry, version)` and covered by the two-tree correctness guard.
+- **Concurrency regression** vs `add_providers` (low × medium — stale plan). The
+  read-side stamp with pre-build snapshot is a verbatim port of today's logic;
+  guarded by the rebuild-stale-plan tests.
+- **A coverage branch drops** after removing the `CacheItem` fields / uncached
+  path (low × low — the 100% gate fails loudly).

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -4,22 +4,25 @@ Items intentionally not actioned in the current work, kept here so they aren't l
 
 ## Free-threaded (nogil) safety of wiring-plan compilation — from 2026-06-14 audit (A-1)
 
-`Factory._ensure_plan` builds the `WiringPlan` outside the container lock and publishes it to
-`cache_item.wiring_plan` (`modern_di/providers/factory.py`). Under the GIL this is safe: the plan is a
-deterministic function of the providers registry's state as of the version it was built against (a
-`ProvidersRegistry.version` stamp, bumped on every `register`/`add_providers`/removal, is memoized
-alongside the plan so a later registration invalidates it), so two threads that both see the same
-`wiring_plan_version` build identical plans — at worst the work is repeated once — and the GIL ensures a
-thread seeing a non-`None` `wiring_plan` also sees the fully-built (frozen) object.
+`Factory._plan` builds the `WiringPlan` outside any lock and publishes it via
+`ProvidersRegistry.plan_for`, which stores it in the registry's `_plans` dict keyed by `provider_id`
+(`modern_di/registries/providers_registry.py`). Under the GIL this is safe: the plan is a deterministic
+function of the providers registry's state as of the version it was built against (a
+`ProvidersRegistry.version` stamp, bumped on every `register`/`add_providers`/removal, is stored
+alongside the plan and snapshotted *before* the build so a later registration invalidates it), so two
+threads that both see the same stamp build identical plans — at worst the work is repeated once — and the
+GIL ensures a thread seeing a stored `(version, plan)` entry also sees the fully-built (frozen) object.
 
-Under free-threaded CPython that publication guarantee is lost: without a memory barrier a reader could
-observe the non-`None` reference before the `WiringPlan`'s fields are visible and resolve against a
-partially-constructed plan. (The WiringPlan refactor narrowed the window — one immutable-object publish
-replaced the old set-`kwargs_compiled`-after-the-bucket-fields sequence — but did not add a barrier.)
+Under free-threaded CPython that guarantee is lost on two counts: concurrent `dict.__setitem__` on the
+shared `_plans` dict is itself a data race (a resize can corrupt it), and without a memory barrier a
+reader could observe the stored reference before the `WiringPlan`'s fields are visible and resolve
+against a partially-constructed plan.
 
 **Revisit trigger:** if/when free-threading (PEP 703 / `--disable-gil`) support becomes a goal. Fix
-options: build and publish `wiring_plan` under the existing container lock, or publish the reference
-behind an explicit barrier/atomic. Until then, document modern-di as GIL-assuming for plan compilation.
+options: build and publish under the registry's own `_lock` (co-located with the `_providers`/`_version`
+mutations the plan reads, and deadlock-safe since plan-building is pure lookup that never re-enters
+`register`), or publish the reference behind an explicit barrier/atomic. Until then, document modern-di
+as GIL-assuming for plan compilation.
 See [2026-06-14 audit A-1](audits/2026-06-14-deep-audit-report.md).
 
 ## Opt-in DEBUG resolution tracing (ERR-8) — from 2026-07-05 3.0 UX research

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -427,22 +427,52 @@ def test_provider_instances_have_no_dict() -> None:
         factory.some_unexpected_attr = 1
 
 
-def test_compile_kwargs_is_memoized_across_resolves() -> None:
-    # Pins the compile-once invariant: kwargs compilation (type lookups + partitioning) runs
-    # exactly once per provider per container, not on every resolve. A regression that moved it
-    # back onto the per-resolve path would leave correctness tests green but silently slow.
+def test_wiring_plan_is_memoized_across_child_containers() -> None:
+    # The wiring plan is a pure function of (provider, providers registry); the registry is shared by a
+    # container and every child, so each provider builds its plan once for the whole tree — across
+    # validation and every resolve — not once per child container. Before the registry-owned memo the plan
+    # lived on the per-container CacheItem, so svc was rebuilt in every one of the N REQUEST children.
     class _MemoGroup(Group):
         leaf = providers.Factory(scope=Scope.APP, creator=SimpleCreator, kwargs={"dep1": "x"})
-        svc = providers.Factory(scope=Scope.APP, creator=DependentCreator)
+        svc = providers.Factory(scope=Scope.REQUEST, creator=DependentCreator)
 
-    container = Container(groups=[_MemoGroup])
     real_build = wiring_mod.WiringPlan.build
     with unittest.mock.patch.object(wiring_mod.WiringPlan, "build", autospec=True, side_effect=real_build) as build_spy:
-        container.resolve(DependentCreator)
-        container.resolve(DependentCreator)
-    # svc + leaf each build their plan once on the first resolve; the second reuses the memo (else this is 4).
+        app_container = Container(scope=Scope.APP, groups=[_MemoGroup], validate=True)
+        for _ in range(50):
+            with app_container.build_child_container(scope=Scope.REQUEST) as request_container:
+                request_container.resolve(DependentCreator)
+    # leaf + svc each build their plan exactly once for the whole tree; validation and every child reuse it.
     expected_build_calls = 2
     assert build_spy.call_count == expected_build_calls
+
+
+def test_shared_factory_wires_independently_per_registry() -> None:
+    # One Factory instance registered into two independent registries must wire from each registry's own
+    # providers. The plan memo is keyed per registry, so the two never alias — even though both roots sit at
+    # the same version. A memo shared across registries (keyed by version alone) would serve the first root's
+    # plan to the second, injecting a SimpleCreator where None is correct.
+    class OptionalDepSvc:
+        def __init__(self, dep: SimpleCreator | None = None) -> None:
+            self.dep = dep
+
+    svc_factory = providers.Factory(scope=Scope.APP, creator=OptionalDepSvc)
+    leaf_factory = providers.Factory(scope=Scope.APP, creator=SimpleCreator, kwargs={"dep1": "x"})
+
+    class WithLeaf(Group):
+        leaf = leaf_factory
+        svc = svc_factory
+
+    class WithoutLeaf(Group):
+        svc = svc_factory
+
+    with_leaf = Container(scope=Scope.APP, groups=[WithLeaf], validate=True)
+    without_leaf = Container(scope=Scope.APP, groups=[WithoutLeaf], validate=True)
+
+    assert with_leaf.providers_registry.find_provider(OptionalDepSvc) is svc_factory
+    assert without_leaf.providers_registry.find_provider(OptionalDepSvc) is svc_factory
+    assert isinstance(with_leaf.resolve(OptionalDepSvc).dep, SimpleCreator)
+    assert without_leaf.resolve(OptionalDepSvc).dep is None
 
 
 # Q-1 / G-3 — optional (X | None) params inject None when no provider is registered


### PR DESCRIPTION
The `WiringPlan` memo lived on `CacheItem`, which is per-container, so a `REQUEST`-scoped `Factory` rebuilt an identical plan on every child container (**measured: 101 `WiringPlan.build` calls across 100 request containers** where 1 is correct), and `validate()`'s `get_dependencies`/`iter_validation_issues` rebuilt it unmemoized on every graph walk.

This moves the memo onto `ProvidersRegistry` — the object the plan is actually keyed to — behind a single `plan_for(provider, build)` accessor, keyed by `provider_id` and stamped with the registry version. Design rationale and the alternatives weighed live in the change bundle: [`planning/changes/2026-07-15.01-wiring-plan-registry-memo.md`](../blob/wiring-plan-registry-memo/planning/changes/2026-07-15.01-wiring-plan-registry-memo.md).

## What changes
- `ProvidersRegistry.plan_for` — version-stamped, snapshot-before-build memo shared tree-wide (a container and every child share one registry), so a deeper-scope factory plans once per registry version, not once per child container. Distinct roots keep separate memos, so the same `Factory` in two registries with different provider sets wires independently.
- `Factory._plan` replaces `_ensure_plan`; the resolve path plus `get_dependencies`/`iter_validation_issues` all route through it, so `validate()` warms the memo instead of rebuilding on each walk.
- `CacheItem` loses `wiring_plan`/`wiring_plan_version` (5 fields → 3); uncached factories skip `fetch_cache_item` entirely.
- Invalidation is the version-stamped read-side check ported verbatim from `CacheItem`, preserving the resolve-vs-`add_providers` concurrency guarantee. No new lock — GIL-assuming, consistent with `deferred.md` A-1 (repointed to the registry location in this PR).

Behaviour and public API are unchanged.

## Tests
- **RED-first perf guard**: a `REQUEST`-scoped `Factory` across 50 child containers asserts one build per provider (fails at 55 on old code, passes at 2). Replaces the weaker single-container count test.
- **Correctness guard**: same `Factory`, two registries, different provider sets → wires differently. Verified to fail under a naive version-only shared memo.
- Existing `add_providers`-rebuilds-stale-plan tests stay green as invalidation guards.

`just test-ci` (400 passed, 100% coverage), `just lint-ci`, and `just bench` (22 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)