### PR TITLE
docs(glossary): add 11 curated core terms, fix the preamble

### DIFF
--- a/architecture/glossary.md
+++ b/architecture/glossary.md
@@ -1,9 +1,75 @@
 # Glossary
 
-The project's ubiquitous language — the domain terms that code, specs, and
-capability pages share. Living prose, no frontmatter, dated by git. Each entry is
-a term, what it *is* (not what it does), and the synonyms to avoid. No
-implementation detail; this is a glossary, not a spec.
+The project's ubiquitous language — the domain terms worth pinning down: those
+with a synonym to reject, or a meaning subtle enough that code, specs, and
+capability pages must agree on it. Not an exhaustive dictionary of every class
+name; a term earns a place when there is something to disambiguate, and entries
+are authored lazily as that need arises. Living prose, no frontmatter, dated by
+git. Each entry says what a term *is* (not what it does) and links to the
+capability page that owns the behaviour; an _Avoid_ line names the synonyms to
+reject. No implementation detail; this is a glossary, not a spec.
+
+**Container**:
+The central object: it owns the provider registries and resolves dependencies
+within a scope. Containers form a parent→child hierarchy, one per scope band. See
+[containers.md](containers.md).
+_Avoid_: injector
+
+**Provider**:
+A declaration of *how to produce* a dependency — the recipe, not the value.
+`Factory`, `Alias`, and `ContextProvider` are the concrete kinds. See
+[providers.md](providers.md).
+_Avoid_: service, dependency (those name the produced value, not its recipe)
+
+**Scope**:
+One band in the container hierarchy (`APP → SESSION → REQUEST → ACTION → STEP`),
+ordered shallow to deep; a provider resolves only from a container at the same or
+a deeper band. See [scopes.md](scopes.md).
+_Avoid_: lifetime, layer
+
+**Group**:
+A non-instantiable namespace class whose class attributes declare providers. See
+[providers.md](providers.md).
+_Avoid_: module
+
+**Resolution**:
+The act of producing a dependency's value from its provider, wiring the
+provider's own dependencies from their type hints. Sync-only (async resolution
+was removed in 2.x). See [resolution.md](resolution.md).
+_Avoid_: injection (reserve that for the integration act of passing a resolved
+value into a handler)
+
+**Validation**:
+A static check of the provider graph — cycles plus scope ordering — run before
+resolution, without calling any creator. See [validation.md](validation.md).
+
+**Override**:
+A test-time replacement of a provider's resolved value with a supplied object,
+short-circuiting its creator. See
+[testing-and-overrides.md](testing-and-overrides.md).
+_Avoid_: mock, patch (an override supplies a concrete value; it does not wrap or spy)
+
+**Child container**:
+A container built at a deeper scope from a parent. It shares the parent's
+providers and overrides registries but owns its own cache and context. See
+[containers.md](containers.md).
+
+**Bound type**:
+The type a provider is registered under and resolvable by — taken from the
+creator's return annotation unless set explicitly. See
+[resolution.md](resolution.md).
+_Avoid_: registered type, return type
+
+**Wiring plan**:
+The partition of a creator's parameters by how each is satisfied — a provider, a
+static value, a context lookup, or unwireable. A pure function of the provider
+and the registry's contents. See [resolution.md](resolution.md).
+_Avoid_: compiled kwargs
+
+**Finalizer**:
+A cleanup callback bound to a cached provider, run when the container closes
+(LIFO); may be sync or async. See [containers.md](containers.md).
+_Avoid_: teardown, destructor
 
 **Connection**:
 The framework-specific object a unit of work carries — an HTTP request, a

--- a/planning/changes/2026-07-15.03-glossary-core-terms.md
+++ b/planning/changes/2026-07-15.03-glossary-core-terms.md
@@ -1,0 +1,57 @@
+---
+summary: Grow architecture/glossary.md from 3 integration-only terms to add 11 curated core terms (Container, Provider, Scope, Group, Resolution, Validation, Override, Child container, Bound type, Wiring plan, Finalizer) and rewrite the over-claiming preamble to describe a lazily-authored map of terms worth pinning, not an exhaustive dictionary.
+---
+
+# Change: Curated core terms for the glossary
+
+**Lane:** lightweight — one file (`architecture/glossary.md`), docs-only, no
+code, no public-API change.
+
+## Goal
+
+`architecture/glossary.md` defined only 3 integration terms (`Connection`,
+`Connection match`, `Integration kit`) while its preamble claimed to be "the
+domain terms that code, specs, and capability pages share." The entire core
+domain — `Container`, `Provider`, `Scope`, resolution, validation, override — was
+absent. Close that gap for the terms worth pinning, and make the preamble honest.
+Candidate 4 from the 2026-07-15 architecture review.
+
+## Approach
+
+Curated growth, not exhaustive. A term earns an entry only when it meets the
+convention's "worth pinning down" bar — a synonym to reject, or a subtle /
+cross-cutting meaning. That admits 11 core terms and excludes the self-evident
+(the individual provider subtypes live in `providers.md`) and the narrow
+(`Suggestion`, `Definition site`). Retitling to an integration-only glossary was
+rejected: the `planning/README.md` convention intends a project-wide ubiquitous
+language.
+
+Each entry says what a term *is* (1–2 sentences), carries an `_Avoid_` line where
+a synonym must be rejected, and links out with `See: <capability>.md` — matching
+the existing 3 entries. Drift is prevented by the is/does split: the glossary
+never restates mechanism, so there is nothing to drift from the capability files;
+no reverse links are added (a possible follow-up, out of scope here). Ordering is
+conceptual — foundational nouns, then the acts, then mechanism terms, then the
+existing integration cluster.
+
+The 11: `Container` (avoid: injector), `Provider` (avoid: service, dependency),
+`Scope` (avoid: lifetime, layer), `Group` (avoid: module), `Resolution`
+(sync-only; avoid: injection), `Validation` (no creators run), `Override` (avoid:
+mock, patch), `Child container` (shared vs owned registries), `Bound type` (avoid:
+registered type), `Wiring plan` (avoid: compiled kwargs), `Finalizer` (avoid:
+teardown, destructor).
+
+## Files
+
+- `architecture/glossary.md` — preamble rewritten; 11 core entries added ahead of
+  the integration cluster.
+- `planning/changes/2026-07-15.03-glossary-core-terms.md` — this bundle.
+
+## Verification
+
+- [x] Definitions cross-checked against code (child-container registry sharing in
+  `container.py`, scope order in `scope.py`, sync-only resolution,
+  validation-without-creators, the wiring-plan partition in `wiring.py`).
+- [x] Every `See:` target exists under `architecture/`.
+- [x] `just lint-ci` — clean (includes `just check-planning`).
+- [x] No code touched → `just test` unaffected.


### PR DESCRIPTION
**Candidate 4** from the 2026-07-15 architecture review. `architecture/glossary.md` defined only 3 integration terms (`Connection`, `Connection match`, `Integration kit`) while its preamble claimed to hold "the domain terms that code, specs, and capability pages share" — the entire core domain was absent.

Rationale bundle: [`planning/changes/2026-07-15.03-glossary-core-terms.md`](../blob/glossary-core-terms/planning/changes/2026-07-15.03-glossary-core-terms.md).

## What changes
- **Preamble rewritten** to honestly describe a lazily-authored map of terms *worth pinning* (a synonym to reject, or a subtle/cross-cutting meaning), not an exhaustive dictionary. (Retitling to an integration-only glossary was rejected — the convention intends a project-wide ubiquitous language.)
- **11 curated core terms added** ahead of the integration cluster, in conceptual order: `Container` (avoid: injector), `Provider` (avoid: service/dependency), `Scope` (avoid: lifetime/layer), `Group` (avoid: module), `Resolution` (sync-only; avoid: injection), `Validation` (no creators run), `Override` (avoid: mock/patch), `Child container` (shared vs owned registries), `Bound type` (avoid: registered type), `Wiring plan` (avoid: compiled kwargs), `Finalizer` (avoid: teardown/destructor).
- Each entry: 1-line "what it *is*", an `_Avoid_` line where a synonym must be rejected, and a `See: <capability>.md` link. Definitions cross-checked against the code.

Curated, not exhaustive — provider subtypes stay in `providers.md`; narrow terms (`Suggestion`, `Definition site`) are left out. Drift is prevented by the is/does split, so no reverse links are added (a possible follow-up).

Docs-only, no code touched. `just lint-ci` (incl. `check-planning`) clean; every `See:` target resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)