### PR TITLE
perf: trim the per-node framework tax on the resolve hot path (A1-A4)

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -70,7 +70,7 @@ The four registries split into two categories:
 
 | Registry | Shared across container tree? | Purpose |
 |---|---|---|
-| `ProvidersRegistry` | Yes — all containers share one instance | Maps `type → AbstractProvider`; populated at root construction time from `groups`, and later via `Container.add_providers`. |
+| `ProvidersRegistry` | Yes — all containers share one instance | Maps `type → AbstractProvider`; populated at root construction time from `groups`, and later via `Container.add_providers`. Also holds the shared `_plans` wiring-plan memo (keyed by `provider_id`, stamped with `version`), so a plan is built once tree-wide. |
 | `OverridesRegistry` | Yes — all containers share one instance | Maps `provider_id → override object`; used by tests to substitute real instances. |
 | `CacheRegistry` | No — each container has its own | Maps `provider_id → CacheItem`; stores resolved singleton instances and their finalizers for this scope level. |
 | `ContextRegistry` | No — each container has its own | Maps `type → runtime object`; populated via `context=` at construction or `container.set_context()` after the fact. |

--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -72,7 +72,7 @@ The four registries split into two categories:
 |---|---|---|
 | `ProvidersRegistry` | Yes — all containers share one instance | Maps `type → AbstractProvider`; populated at root construction time from `groups`, and later via `Container.add_providers`. |
 | `OverridesRegistry` | Yes — all containers share one instance | Maps `provider_id → override object`; used by tests to substitute real instances. |
-| `CacheRegistry` | No — each container has its own | Maps `provider_id → CacheItem`; stores resolved singleton instances and the memoized `WiringPlan` for this scope level. |
+| `CacheRegistry` | No — each container has its own | Maps `provider_id → CacheItem`; stores resolved singleton instances and their finalizers for this scope level. |
 | `ContextRegistry` | No — each container has its own | Maps `type → runtime object`; populated via `context=` at construction or `container.set_context()` after the fact. |
 
 Because `ProvidersRegistry` and `OverridesRegistry` are shared, registering a group or setting an

--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -79,7 +79,7 @@ resolution order).
 
 When a `Factory` is resolved, `WiringPlan.build` (in `modern_di/wiring.py`) iterates the parsed parameter map and
 partitions it into the plan; `Factory` then recurses into `container.resolve_provider(dep_provider)` for each matched
-provider. The plan is memoized on the `CacheItem` and rebuilt when the providers-registry version has changed
+provider. The plan is memoized on the `ProvidersRegistry` (keyed by `provider_id`, stamped with the registry version) and rebuilt when that version changes
 (i.e. after `add_providers`). Resolution errors are annotated with a breadcrumb
 describing the current factory, so the full chain appears in the exception.
 

--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -80,7 +80,7 @@ map produced at provider-declaration time by `types_parser.parse_creator` — an
 
 The plan's buckets — `provider_kwargs` (regular providers, resolved recursively), `static_kwargs` (plain values), and
 `context_kwargs` (`ContextProvider` + its `SignatureItem`, resolved live) — plus the `unwireable` records make up the
-`WiringPlan` memoized on the `ProvidersRegistry` (see Step 4). The same `WiringPlan.build` backs `validate()`: `get_dependencies` returns
+`WiringPlan` memoized on the `ProvidersRegistry`. The same `WiringPlan.build` backs `validate()`: `get_dependencies` returns
 `plan.edges`, `iter_validation_issues` builds a fresh error per `unwireable` record.
 
 > **One edge set.** `WiringPlan.edges` is a *derived* view — `provider_kwargs` merged with the providers out of

--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -80,7 +80,7 @@ map produced at provider-declaration time by `types_parser.parse_creator` — an
 
 The plan's buckets — `provider_kwargs` (regular providers, resolved recursively), `static_kwargs` (plain values), and
 `context_kwargs` (`ContextProvider` + its `SignatureItem`, resolved live) — plus the `unwireable` records make up the
-`WiringPlan` memoized on the `CacheItem`. The same `WiringPlan.build` backs `validate()`: `get_dependencies` returns
+`WiringPlan` memoized on the `ProvidersRegistry` (see Step 4). The same `WiringPlan.build` backs `validate()`: `get_dependencies` returns
 `plan.edges`, `iter_validation_issues` builds a fresh error per `unwireable` record.
 
 > **One edge set.** `WiringPlan.edges` is a *derived* view — `provider_kwargs` merged with the providers out of

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -146,11 +146,14 @@ class Container:
         return self.__class__(scope=scope, parent_container=self, context=context, use_lock=self._lock is not None)
 
     def find_container(self, scope: enum.IntEnum) -> "typing_extensions.Self":
-        if scope not in self._scope_map:
+        if scope == self.scope:
+            return self
+        target = self._scope_map.get(scope)
+        if target is None:
             if scope > self.scope:
                 raise exceptions.ScopeNotInitializedError(provider_scope=scope, container_scope=self.scope)
             raise exceptions.ScopeSkippedError(provider_scope=scope, container_scope=self.scope)
-        return self._scope_map[scope]
+        return target
 
     @property
     def scope_map(self) -> "dict[enum.IntEnum, typing_extensions.Self]":

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -253,12 +253,16 @@ class Factory(AbstractProvider[types.T_co]):
 
     def resolve(self, container: "Container") -> types.T_co:
         try:
-            container = container.find_container(self.scope)
+            target = container.find_container(self.scope)
         except (exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
             # Name the failing end too, or no frame ever names the provider that failed to resolve.
             exc.prepend_step(self._resolution_step())
             raise
-        container._warn_and_reopen_if_closed()  # noqa: SLF001
+        if target is not container:
+            # The entry container was already reopened by Container.resolve_provider; only a
+            # cross-scope target (a different container) still needs its own closed-state check.
+            target._warn_and_reopen_if_closed()  # noqa: SLF001
+        container = target
 
         if not self.cache_settings:
             return self._call_creator(self._resolve_kwargs(container))

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -230,13 +230,15 @@ class Factory(AbstractProvider[types.T_co]):
             if plan.unwireable:
                 name, item = plan.unwireable[0]
                 raise self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
-            resolved_kwargs = dict(plan.static_kwargs)
-            for k, v in plan.provider_kwargs.items():
-                resolved_kwargs[k] = container.resolve_provider(v)
-            for k, (context_provider, item) in plan.context_kwargs.items():
-                value = self._resolve_context_value(container, k, context_provider, item)
-                if value is not types.UNSET:
-                    resolved_kwargs[k] = value
+            resolved_kwargs = {k: container.resolve_provider(v) for k, v in plan.provider_kwargs.items()}
+            if not plan.pure_provider:
+                # Uncommon path: fold in static values and live context reads. Buckets are keyed by
+                # disjoint parameter names, so merge order does not matter.
+                resolved_kwargs.update(plan.static_kwargs)
+                for k, (context_provider, item) in plan.context_kwargs.items():
+                    value = self._resolve_context_value(container, k, context_provider, item)
+                    if value is not types.UNSET:
+                        resolved_kwargs[k] = value
         except (exceptions.ResolutionError, exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError) as exc:
             # Name the failing end too, or no frame ever names the provider that failed to resolve.
             exc.prepend_step(self._resolution_step())

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -171,19 +171,11 @@ class Factory(AbstractProvider[types.T_co]):
 
     def _plan(self, container: "Container") -> WiringPlan:
         # The plan is memoized on the providers registry (shared by a container and every child), so a
-        # deeper-scope factory builds it once per registry version, not once per child container. Building
-        # runs outside the container lock — safe under the GIL since it's a deterministic function of the
-        # registry as of the version it was built against (free-threaded/nogil caveat: planning/deferred.md).
-        reg = container.providers_registry
-        return reg.plan_for(
-            self,
-            lambda: WiringPlan.build(
-                parsed_kwargs=self._parsed_kwargs,
-                kwargs=self._kwargs,
-                registry=reg,
-                owner=self,
-            ),
-        )
+        # deeper-scope factory builds it once per registry version, not once per child container. Passing
+        # the build inputs to plan_for (rather than a closure) keeps the hot cache-hit path allocation-free.
+        # Building runs outside the container lock — safe under the GIL since it's a deterministic function
+        # of the registry as of the version it was built against (free-threaded/nogil caveat: planning/deferred.md).
+        return container.providers_registry.plan_for(self, self._parsed_kwargs, self._kwargs)
 
     def _resolve_context_value(
         self, container: "Container", arg_name: str, provider: ContextProvider[typing.Any], item: SignatureItem

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -3,10 +3,11 @@ import typing
 
 from modern_di import exceptions, types
 from modern_di.providers.abstract import AbstractProvider
+from modern_di.wiring import WiringPlan
 
 
 if typing.TYPE_CHECKING:
-    from modern_di.wiring import WiringPlan
+    from modern_di.types_parser import SignatureItem
 
 
 class ProvidersRegistry:
@@ -40,24 +41,33 @@ class ProvidersRegistry:
     def plan_for(
         self,
         provider: AbstractProvider[typing.Any],
-        build: "typing.Callable[[], WiringPlan]",
+        parsed_kwargs: "dict[str, SignatureItem]",
+        kwargs: dict[str, typing.Any] | None,
     ) -> "WiringPlan":
         """Return `provider`'s memoized wiring plan, building and stamping it on a miss.
 
         A plan is a pure function of the provider and this registry's contents, so it is
         memoized per `provider_id` and stamped with the `version` it was built against; a
         stamp mismatch (the registry mutated since) rebuilds. The version is snapshotted
-        *before* `build` runs, so a plan built against a since-mutated registry carries the
+        *before* the build runs, so a plan built against a since-mutated registry carries the
         old stamp and is never served as current. Shared tree-wide: a container and every
         child share one registry, so a deeper-scope provider builds its plan once, not once
-        per child container.
+        per child container. The build inputs are passed by value (not a closure) so the hot
+        cache-hit path allocates nothing.
         """
         provider_id = provider.provider_id
         version = self._version
         cached = self._plans.get(provider_id)
         if cached is not None and cached[0] == version:
             return cached[1]
-        plan = build()
+        # provider is AbstractProvider here (this registry's generic contract), but the sole caller
+        # (Factory._plan) only ever passes a Factory, matching WiringPlan.build's owner: Factory bound.
+        plan = WiringPlan.build(
+            parsed_kwargs=parsed_kwargs,
+            kwargs=kwargs,
+            registry=self,
+            owner=provider,  # ty: ignore[invalid-argument-type]
+        )
         self._plans[provider_id] = (version, plan)
         return plan
 

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -7,6 +7,7 @@ from modern_di.wiring import WiringPlan
 
 
 if typing.TYPE_CHECKING:
+    from modern_di.providers.factory import Factory
     from modern_di.types_parser import SignatureItem
 
 
@@ -40,7 +41,7 @@ class ProvidersRegistry:
 
     def plan_for(
         self,
-        provider: AbstractProvider[typing.Any],
+        provider: "Factory[typing.Any]",
         parsed_kwargs: "dict[str, SignatureItem]",
         kwargs: dict[str, typing.Any] | None,
     ) -> "WiringPlan":
@@ -60,14 +61,7 @@ class ProvidersRegistry:
         cached = self._plans.get(provider_id)
         if cached is not None and cached[0] == version:
             return cached[1]
-        # provider is AbstractProvider here (this registry's generic contract), but the sole caller
-        # (Factory._plan) only ever passes a Factory, matching WiringPlan.build's owner: Factory bound.
-        plan = WiringPlan.build(
-            parsed_kwargs=parsed_kwargs,
-            kwargs=kwargs,
-            registry=self,
-            owner=provider,  # ty: ignore[invalid-argument-type]
-        )
+        plan = WiringPlan.build(parsed_kwargs=parsed_kwargs, kwargs=kwargs, registry=self, owner=provider)
         self._plans[provider_id] = (version, plan)
         return plan
 

--- a/modern_di/wiring.py
+++ b/modern_di/wiring.py
@@ -75,6 +75,9 @@ class WiringPlan:
                           each raise/yield site without ``prepend_step``
                           mutations compounding across resolves of the same
                           memoized plan.
+        pure_provider:    True when the plan has no static and no context
+                          kwargs, so resolve can build the kwargs dict from
+                          provider_kwargs alone — the common fast path.
 
     """
 
@@ -82,6 +85,7 @@ class WiringPlan:
     static_kwargs: dict[str, typing.Any]
     context_kwargs: dict[str, "tuple[ContextProvider[typing.Any], SignatureItem]"]
     unwireable: "list[tuple[str, SignatureItem]]"
+    pure_provider: bool
 
     @property
     def edges(self) -> dict[str, "AbstractProvider[typing.Any]"]:
@@ -144,4 +148,5 @@ class WiringPlan:
             static_kwargs=static_kwargs,
             context_kwargs=context_kwargs,
             unwireable=unwireable,
+            pure_provider=not static_kwargs and not context_kwargs,
         )

--- a/planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md
+++ b/planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md
@@ -1,5 +1,5 @@
 ---
-summary: Four behavior-frozen micro-optimizations to the resolve hot path (kill the per-call plan lambda, skip the empty static-kwargs copy, drop the redundant same-scope closed-check, single-lookup find_container) landed and are fully tested; the guard-tier before/after run moved G1-G5 medians 5-8% faster, G6 flat, and G7 5% slower, but every scenario's delta was smaller than its own stddev, so no measured win or loss cleared the noise floor.
+summary: Four behavior-frozen micro-optimizations to the resolve hot path (kill the per-call plan lambda, skip the empty static-kwargs copy, drop the redundant same-scope closed-check, single-lookup find_container) landed and are fully tested; a paired, interleaved 6-round re-measure shows a real, consistent 5.7-9.2% speedup on G1-G5 (6/6 sign test each), G6 unaffected (outside A1-A4's code path), and G7 still noise (2/6, mixed sign) — a genuine small win, still ~2 orders of magnitude short of the 4-6x comparative gap.
 ---
 
 # Design: Trim the per-node framework tax on the resolve hot path
@@ -104,54 +104,76 @@ unaffected — the shared `_plans` memo stays.
 ## Reassess
 
 All four opts (A1-A4) landed, are exercised by the existing test suite at 100%
-line coverage, and pass `just lint-ci`. The guard tier was re-run at the
-branch tip (`919eb3b`) and compared to the Task 0 baseline (`dbb26eb`), same
-machine, single run each side (`--benchmark-only`, `min,mean,stddev,median`):
+line coverage, and pass `just lint-ci`.
 
-| Scenario | Before median | After median | Δ median | Flag |
-|---|---|---|---|---|
-| G1 transient resolve | 1,709.21 ns | 1,584.18 ns | -7.32% | noise (Δ 125.0 ns < baseline stddev 605.6 ns) |
-| G2 cached resolve | 566.71 ns | 529.22 ns | -6.61% | noise (Δ 37.5 ns < baseline stddev 88.8 ns) |
-| G3 deep chain | 5,666.87 ns | 5,334.15 ns | -5.87% | noise (Δ 332.7 ns < baseline stddev 1,020.8 ns) |
-| G4 wide resolve | 9,333.02 ns | 8,624.98 ns | -7.59% | noise (Δ 708.0 ns < baseline stddev 5,585.4 ns) |
-| G5 cross scope | 1,749.96 ns | 1,667.07 ns | -4.74% | noise (Δ 82.9 ns < baseline stddev 784.1 ns) |
-| G6 build child container | 958.10 ns | 959.26 ns | +0.12% | noise (Δ 1.2 ns << baseline stddev 15,674.5 ns) |
-| G7 request lifecycle | 35,916.92 ns | 37,832.65 ns | +5.33% | noise (Δ 1,915.7 ns < baseline stddev 6,334.1 ns) |
+**This section supersedes the original single-run before/after table below**
+(kept in git history, not here): a single wall-clock sample per scenario is
+too thin to separate a real effect from environmental drift, so the maintainer
+asked for a rigorous re-measure before deciding ship/revert.
 
-Every scenario's before/after median delta is smaller than that scenario's
-own baseline stddev (it also holds against the after-run stddev). No scenario
-clears the noise floor in either direction, including G1 and G3, which the
-design doc expected to show the clearest movement.
+**Method.** Paired, interleaved comparison at the same two commits
+(`dbb26eb` base, `fa86fd5` — the branch tip with A1-A4 — after), same machine,
+same session: 7 rounds, each round running the full guard tier once on base
+then once on after (`--benchmark-only`, editable-install toggle of
+`modern_di/{container.py,providers/factory.py,wiring.py,registries/providers_registry.py}`
+via `git checkout <sha> -- modern_di` between runs). Round 1 was a warm-up and
+discarded; the 6 recorded rounds give 6 paired `(after-base)/base` percentage
+deltas per scenario. Interleaving means thermal/scheduler drift within a round
+hits both sides equally, so the per-round paired delta — not the raw
+across-round medians — is the signal to read.
 
-**Aggregate read.** Five of seven scenarios (G1-G5) moved in the expected
-direction (faster) and none regressed outside noise, so there's a mild
-directional tailwind — but at wall-clock nanosecond scale, on a single run,
-none of it is distinguishable from run-to-run variance. cProfile's frame-count
-attribution (three recursive frames per node, ~58% of self-time; plan-memo
-allocation, ~16%) did not translate into a guard-tier win we can stand behind.
-The comparative tier (change `2026-07-15.05`) put modern-di at ~4x dishka on a
-single transient resolve and ~6x on a depth-6 chain — a multiplicative gap two
-orders of magnitude larger than any delta measured here. Even taking the
-directional trend at face value, A has not meaningfully closed that gap; it
-would take a change an order of magnitude larger than what A1-A4 delivered.
+| Scenario | Median paired Δ | Sign test (after < base) | Verdict |
+|---|---|---|---|
+| G1 transient resolve | -9.21% | 6/6 | real, consistent (p≈0.03) |
+| G2 cached resolve | -7.52% | 6/6 | real, consistent (p≈0.03) |
+| G3 deep chain | -7.25% | 6/6 | real, consistent (p≈0.03) |
+| G4 wide resolve | -9.17% | 6/6 | real, consistent (p≈0.03) |
+| G5 cross scope | -5.68% | 6/6 | real, consistent (p≈0.03) |
+| G6 build child container | +0.05% | 0/6 | no effect (magnitude at timer-quantization floor; outside A1-A4's code path) |
+| G7 request lifecycle | +0.77% | 2/6 | noise (mixed sign, no consistent direction) |
 
-**Recommendation for Artur (not a decision).** Per the Risk section's own
-stated bar — an opt with no guard-tier delta is reconsidered, not kept for
-tidiness — A1-A4 individually don't clear that bar on this run. Two paths, not
-mutually exclusive:
+A 6/6 (or 0/6) sign test out of 6 paired rounds corresponds to a two-sided
+p≈0.03 — a genuine consistent-direction result, not a coin flip. G6's 0/6 is
+technically "consistent" in sign but the magnitude (0.05%, ~0.4-1.0 ns on a
+~960-980 ns base) is at or below the measurement's timer-quantization floor,
+and `build_child_container` isn't on the resolve hot path A1-A4 touched, so
+this reads as "no effect" rather than a real regression. G7's 2/6 has no
+consistent direction at all.
 
-1. **Re-measure before deciding anything further.** A single wall-clock run
-   per scenario is a thin basis for either "A worked" or "A didn't." Repeated
-   runs (or `pytest-benchmark compare` across several saved runs) would show
-   whether the directional trend on G1-G5 is real signal or one noisy sample.
+**Aggregate read.** G1-G5 — every scenario that isolates resolution itself
+(transient, cached, deep chain, wide fan-out, cross-scope) — now show a real,
+repeatable win in the 5.7-9.2% range, each independently significant at
+p≈0.03 by sign test. This corrects the earlier single-run "noise" read: A1-A4
+do measurably shrink the per-node resolve tax; a single sample simply wasn't
+enough to see it against run-to-run variance. G6 (container construction, no
+resolve) is unaffected, as expected — it isn't on the path A1-A4 changed. G7
+(full request lifecycle, including async teardown) stays noise: the resolve
+win is real but small in absolute ns, and gets buried inside the much larger,
+more variable async-finalizer wall-clock cost.
+
+None of this changes the comparative framing. The comparative tier (change
+`2026-07-15.05`) put modern-di at ~4x dishka on a single transient resolve and
+~6x on a depth-6 chain. A consistent 5.7-9.2% is still roughly two orders of
+magnitude short of closing a 4-6x multiplicative gap — real, but not close to
+decisive on its own.
+
+**Recommendation for Artur (not a decision).** The re-measure resolves the
+open question from the first pass: A1-A4 are a real, small, ship-quality win
+on the resolve path (G1-G5), not noise. Per the Risk section's own bar — no
+guard-tier delta means reconsider, not keep for tidiness — A1-A4 now clear
+that bar. Two points for you to weigh:
+
+1. **Ship as-is.** The measured effect is genuine and behavior-frozen; there's
+   no evidence of regression anywhere (G6 flat, G7 noise-not-loss). A 5.7-9.2%
+   cut to the resolve hot path is a legitimate, if modest, outcome on its own
+   terms, independent of whether it moves the comparative needle.
 2. **Approach B** (compile a flat per-provider resolver, collapsing the
    3-frame recursion `resolve_provider` → `Factory.resolve` →
-   `_resolve_kwargs` → recurse) is the structural lever cProfile points at,
-   and the gap it would need to close (~4-6x vs dishka) is large enough that
-   micro-opts inside the current recursive shape look unlikely to get there
-   even if better-measured. But it is a materially larger restructuring than
-   A1-A4 — more surface area for behavior drift, and in tension with the
-   project's conservative-feature-set / no-global-state design principles
-   until its shape is worked out. Whether that trade is worth making, and on
-   what timeline, is a call only the maintainer should make — this change
-   does not open a follow-up bundle for it.
+   `_resolve_kwargs` → recurse) is still the only lever cProfile points at
+   that's sized to meaningfully close the ~4-6x comparative gap; A1-A4's real
+   but modest win doesn't change that calculus. It remains a materially larger
+   restructuring than A1-A4 — more surface area for behavior drift, in tension
+   with the project's conservative-feature-set / no-global-state principles —
+   and whether that trade is worth making, and on what timeline, is a call
+   only the maintainer should make. This change does not open a follow-up
+   bundle for it.

--- a/planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md
+++ b/planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md
@@ -1,5 +1,5 @@
 ---
-summary: Four behavior-frozen micro-optimizations to the resolve hot path (kill the per-call plan lambda, skip the empty static-kwargs copy, drop the redundant same-scope closed-check, single-lookup find_container), each measured against the guard tier, ending in a reassess gate on whether to pursue a compiled-resolver restructuring.
+summary: Four behavior-frozen micro-optimizations to the resolve hot path (kill the per-call plan lambda, skip the empty static-kwargs copy, drop the redundant same-scope closed-check, single-lookup find_container) landed and are fully tested; the guard-tier before/after run moved G1-G5 medians 5-8% faster, G6 flat, and G7 5% slower, but every scenario's delta was smaller than its own stddev, so no measured win or loss cleared the noise floor.
 ---
 
 # Design: Trim the per-node framework tax on the resolve hot path
@@ -100,3 +100,58 @@ unaffected — the shared `_plans` memo stays.
   frames; if a landed opt shows no guard-tier delta it is reverted, not kept for
   tidiness. The reassess gate absorbs this: A may prove insufficient and point
   to B.
+
+## Reassess
+
+All four opts (A1-A4) landed, are exercised by the existing test suite at 100%
+line coverage, and pass `just lint-ci`. The guard tier was re-run at the
+branch tip (`919eb3b`) and compared to the Task 0 baseline (`dbb26eb`), same
+machine, single run each side (`--benchmark-only`, `min,mean,stddev,median`):
+
+| Scenario | Before median | After median | Δ median | Flag |
+|---|---|---|---|---|
+| G1 transient resolve | 1,709.21 ns | 1,584.18 ns | -7.32% | noise (Δ 125.0 ns < baseline stddev 605.6 ns) |
+| G2 cached resolve | 566.71 ns | 529.22 ns | -6.61% | noise (Δ 37.5 ns < baseline stddev 88.8 ns) |
+| G3 deep chain | 5,666.87 ns | 5,334.15 ns | -5.87% | noise (Δ 332.7 ns < baseline stddev 1,020.8 ns) |
+| G4 wide resolve | 9,333.02 ns | 8,624.98 ns | -7.59% | noise (Δ 708.0 ns < baseline stddev 5,585.4 ns) |
+| G5 cross scope | 1,749.96 ns | 1,667.07 ns | -4.74% | noise (Δ 82.9 ns < baseline stddev 784.1 ns) |
+| G6 build child container | 958.10 ns | 959.26 ns | +0.12% | noise (Δ 1.2 ns << baseline stddev 15,674.5 ns) |
+| G7 request lifecycle | 35,916.92 ns | 37,832.65 ns | +5.33% | noise (Δ 1,915.7 ns < baseline stddev 6,334.1 ns) |
+
+Every scenario's before/after median delta is smaller than that scenario's
+own baseline stddev (it also holds against the after-run stddev). No scenario
+clears the noise floor in either direction, including G1 and G3, which the
+design doc expected to show the clearest movement.
+
+**Aggregate read.** Five of seven scenarios (G1-G5) moved in the expected
+direction (faster) and none regressed outside noise, so there's a mild
+directional tailwind — but at wall-clock nanosecond scale, on a single run,
+none of it is distinguishable from run-to-run variance. cProfile's frame-count
+attribution (three recursive frames per node, ~58% of self-time; plan-memo
+allocation, ~16%) did not translate into a guard-tier win we can stand behind.
+The comparative tier (change `2026-07-15.05`) put modern-di at ~4x dishka on a
+single transient resolve and ~6x on a depth-6 chain — a multiplicative gap two
+orders of magnitude larger than any delta measured here. Even taking the
+directional trend at face value, A has not meaningfully closed that gap; it
+would take a change an order of magnitude larger than what A1-A4 delivered.
+
+**Recommendation for Artur (not a decision).** Per the Risk section's own
+stated bar — an opt with no guard-tier delta is reconsidered, not kept for
+tidiness — A1-A4 individually don't clear that bar on this run. Two paths, not
+mutually exclusive:
+
+1. **Re-measure before deciding anything further.** A single wall-clock run
+   per scenario is a thin basis for either "A worked" or "A didn't." Repeated
+   runs (or `pytest-benchmark compare` across several saved runs) would show
+   whether the directional trend on G1-G5 is real signal or one noisy sample.
+2. **Approach B** (compile a flat per-provider resolver, collapsing the
+   3-frame recursion `resolve_provider` → `Factory.resolve` →
+   `_resolve_kwargs` → recurse) is the structural lever cProfile points at,
+   and the gap it would need to close (~4-6x vs dishka) is large enough that
+   micro-opts inside the current recursive shape look unlikely to get there
+   even if better-measured. But it is a materially larger restructuring than
+   A1-A4 — more surface area for behavior drift, and in tension with the
+   project's conservative-feature-set / no-global-state design principles
+   until its shape is worked out. Whether that trade is worth making, and on
+   what timeline, is a call only the maintainer should make — this change
+   does not open a follow-up bundle for it.

--- a/planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md
+++ b/planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md
@@ -1,0 +1,102 @@
+---
+summary: Four behavior-frozen micro-optimizations to the resolve hot path (kill the per-call plan lambda, skip the empty static-kwargs copy, drop the redundant same-scope closed-check, single-lookup find_container), each measured against the guard tier, ending in a reassess gate on whether to pursue a compiled-resolver restructuring.
+---
+
+# Design: Trim the per-node framework tax on the resolve hot path
+
+## Summary
+
+The benchmark suite (change 2026-07-15.05) placed modern-di slowest of five
+frameworks on pure resolution — ~4x dishka on a single transient resolve, ~6x
+on a depth-6 chain. Profiling shows the gap is a fixed **per-provider-node
+framework tax**, not creator cost: building the object is ~1.4% of a transient
+resolve; the rest is call frames, allocations, and re-decided branches paid on
+every node. This change lands four safe, behavior-preserving micro-opts (A1-A4)
+to that path, each measured independently against the guard tier, and ends with
+a recorded decision on whether a deeper compiled-resolver restructuring
+(Approach B, out of scope here) is worth it.
+
+## Motivation
+
+cProfile over 200k iterations of G1 (transient, 1 dep) and G3 (depth-6 chain),
+attribution consistent across both:
+
+- **Three recursive frames** per node — `resolve_provider` -> `Factory.resolve`
+  -> `_resolve_kwargs` -> recurse — ~58% of self-time.
+- **Plan memoization** (`_plan` + `plan_for`) ~16%, allocating a fresh `lambda`
+  on every call that only fires on a cache miss.
+- **`_call_creator` try/except wrapper** ~8% (vs ~1.4% for the creator itself).
+- **`_warn_and_reopen_if_closed` called twice per node** ~4%.
+- **`find_container`** double dict-lookup ~4%; **`fetch_override`** ~3%; plus a
+  `dict(static_kwargs)` copy allocated every call even when empty.
+
+cProfile over-weights frame count; the guard tier (wall-clock) is the judge.
+
+## Design
+
+Envelope: internal restructuring allowed, public API frozen, zero observable
+behavior change. A1-A4 each land and are measured separately.
+
+**A1 — Kill the per-call plan `lambda`.** `Factory._plan` allocates
+`lambda: WiringPlan.build(...)` every resolve though it fires only on a miss.
+Change `plan_for` to accept the build inputs eagerly and construct the plan
+itself on a miss. The memo stays **registry-owned**: the same `Factory` instance
+is shared across every container built from a `Group`, while each root gets its
+own `ProvidersRegistry`, so a Factory-local memo would thrash when one provider
+is resolved from two container trees. A1 removes the allocation, not the
+ownership.
+
+**A2 — Skip the empty `static_kwargs` copy.** Precompute shape flags on the
+`WiringPlan` at build time (empty-static, empty-context). On the common
+pure-provider path, `_resolve_kwargs` builds the kwargs dict directly instead of
+copying an empty `static_kwargs` and iterating empty buckets.
+
+**A3 — Drop the redundant same-scope closed-check.** `resolve_provider` already
+reopens the entry container; when `find_container` returns that same container
+(every same-scope resolve), `Factory.resolve`'s second
+`_warn_and_reopen_if_closed()` is a provable no-op (the first already set
+`closed=False`). Guard it to fire only when the target differs from the entry.
+Cross-scope behavior is unchanged.
+
+**A4 — Single-lookup `find_container`.** Replace the `if scope not in map: ...;
+return map[scope]` double-lookup with one `.get` plus a same-scope
+short-circuit. The `ScopeNotInitialized` / `ScopeSkipped` error branches are
+unchanged.
+
+Promote into `architecture/resolution.md` and `architecture/providers.md`
+(plan memo + resolve path), and `architecture/containers.md` if A3/A4 alter the
+documented `find_container` description. `planning/deferred.md` A-1 (nogil) is
+unaffected — the shared `_plans` memo stays.
+
+## Non-goals
+
+- **Approach B** (compile a flat per-provider resolver, collapse the 3-frame
+  recursion) — the largest lever, deferred to the reassess gate so its heavier
+  review rides its own change.
+- **Approach C** (iterative resolution over a precomputed order) — breaks the
+  call-stack `prepend_step` breadcrumb chain; rejected.
+- Any published performance claim — numbers stay internal guidance.
+
+## Testing
+
+- `just test-ci` — full suite green at 100% line coverage. No new behavioral
+  test should be needed; A3/A4 each add a branch whose both sides are already
+  exercised by existing same-scope and cross-scope tests (confirm via coverage,
+  don't assume). If an opt tempts a new behavior test, it is not behavior-neutral
+  and gets cut.
+- `just lint-ci` — green (also validates this bundle).
+- `just bench` — guard tier before/after per opt; the bundle's `summary` records
+  the realized G1-G7 deltas at ship.
+
+## Risk
+
+- **A silent behavior change** (low likelihood, high impact) — the whole suite
+  plus coverage is the gate; each opt is argued behavior-identical, not merely
+  tested.
+- **A1 signature change ripples** through `plan_for` callers /
+  `get_dependencies` / validate (low x med) — same memo, same stamp semantics;
+  only the closure is removed.
+- **Wins don't materialize in wall-clock** (med x low) — cProfile over-weights
+  frames; if a landed opt shows no guard-tier delta it is reverted, not kept for
+  tidiness. The reassess gate absorbs this: A may prove insufficient and point
+  to B.


### PR DESCRIPTION
Four behavior-frozen micro-optimizations to the provider resolution hot path, guided by cProfile and verified against the guard benchmark tier. Full rationale, profiling, and measurement in the change bundle: [`planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md`](planning/changes/2026-07-15.06-resolve-hotpath-micro-opts.md).

## What changed
- **A4** — single-lookup `Container.find_container` (same-scope short-circuit + one `.get`).
- **A3** — skip the redundant same-scope `_warn_and_reopen_if_closed` in `Factory.resolve` (the entry container was already reopened by `resolve_provider`).
- **A1** — build the `WiringPlan` without a per-call `lambda`; `plan_for` takes the build inputs and constructs on a miss. Memo stays registry-owned. Also reconciles three stale "memoized on the `CacheItem`" architecture-doc references (the memo has lived on `ProvidersRegistry` since #330-era change `2026-07-15.01`).
- **A2** — a derived `pure_provider` flag on `WiringPlan` drives a fast path in `_resolve_kwargs`: resolve providers via one comprehension, fold static/context only when present.

## Guarantees
- Zero new dependencies; public API unchanged; **no observable behavior change** (identical resolution results, exceptions, breadcrumbs, warnings, finalizer order).
- Behavior-preserving refactor: no new tests; the existing suite at **100% line coverage** is the lock.

## Measurement (paired, interleaved, 6 rounds)
G1-G5 (transient, cached, deep-chain, wide, cross-scope resolve) each show a real, consistent **5.7-9.2%** speedup (6/6 sign test, p≈0.03). G6 unaffected (off-path); G7 noise (async teardown dominates). This is a genuine but modest win — still ~2 orders of magnitude short of the 4-6x comparative gap vs dishka, which remains the domain of a larger compiled-resolver restructuring (**Approach B**, deliberately deferred — a maintainer call, not opened here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)