### PR TITLE
test: pin compiled-resolver positional-path selection

### DIFF
--- a/planning/changes/2026-07-17.01-resolver-compiler-test-surface.md
+++ b/planning/changes/2026-07-17.01-resolver-compiler-test-surface.md
@@ -1,0 +1,107 @@
+---
+summary: Pin the compiled-resolver positional-path selection with a direct test surface — the provider_kwargs ordering invariant and _positional_names' full contract.
+---
+
+# Design: A direct test surface for compiled-resolver path selection
+
+## Summary
+
+Add `tests/test_resolver_compiler.py` covering the two things the existing
+black-box differential-harness suite (`tests/providers/test_factory.py:907+`)
+leaves unguarded: the argument-ordering invariant the positional fast path
+silently depends on, and `_positional_names`' full contract (four exclusion
+rules plus the positive case) called directly. Plus one structural assert in
+`test_wiring.py`. Test-only; no production change.
+
+## Motivation
+
+The single-path compiled resolver (`2026-07-16.02`) made resolve fast by
+selecting a positional `creator(*args)` call when `_positional_names` proves
+every creator parameter is a provider dependency in signature order. The
+differential-harness suite characterizes each compiled path black-box through
+`resolve_provider`, but two real gaps remain:
+
+- **The ordering agreement is unpinned.** `_positional_names` validates
+  `tuple(plan.provider_kwargs) == tuple(parsed_kwargs)`, then the caller
+  *discards* that result and rebuilds `pos` from `plan.provider_kwargs.items()`.
+  The two orders agree only because they share `plan.provider_kwargs` as their
+  source — nothing pins it. A future refactor that re-sources `pos` diverges
+  silently, binding positional args to the wrong parameters.
+- **The invariant is asserted nowhere.** `grep` for any assertion on
+  `provider_kwargs` order returns zero hits. Existing positional tests resolve a
+  single dep or same-typed deps, so argument *misordering* is invisible to them.
+
+## Design
+
+Three tests, each homed by the module it guards.
+
+**1. Behavioral ordering** (new file). A creator with three distinct-typed
+params, resolved via the positional path, asserting each value lands in the
+right slot. Self-guard first, so the test cannot pass vacuously via the kwargs
+path (a pure-provider factory is correct under *both* call conventions):
+
+```python
+def test_positional_path_binds_args_in_signature_order() -> None:
+    class G(Group):
+        a = providers.Factory(creator=_A, scope=Scope.APP)
+        b = providers.Factory(creator=_B, scope=Scope.APP)
+        c = providers.Factory(creator=_C, scope=Scope.APP)
+        ordered = providers.Factory(creator=_make, scope=Scope.APP)  # (a, b, c) -> _Ordered
+    container = Container(groups=[G], validate=False)
+    reg = container.providers_registry
+    plan = reg.plan_for(G.ordered, G.ordered._parsed_kwargs, G.ordered._kwargs)  # noqa: SLF001
+    assert _positional_names(G.ordered, plan) is not None  # self-guard: selector chose positional
+    result = container.resolve(_Ordered)
+    assert isinstance(result.a, _A) and isinstance(result.b, _B) and isinstance(result.c, _C)
+```
+
+**2. `_positional_names` contract** (new file). Five named tests — one per rule,
+house style with a one-line rule comment — building a real `Factory` and its
+plan via `registry.plan_for`, then calling the predicate directly:
+
+- rule 1 — a static or context kwarg present (`not pure_provider`) → `None`
+- rule 2a — a param with a default and no provider (omitted) → `None`
+- rule 2b — a `kwargs={...}` overlay appends an extra provider → `None`
+- rule 3 — a keyword-only param → `None`
+- rule 4 — a positional-only creator param → `None` (direct-predicate companion
+  to the existing behavioral `test_positional_only_with_default_stays_on_kwargs_path`)
+- positive — all params are provider deps in order → returns the exact
+  `("a", "b", "c")` tuple
+
+**3. Structural invariant** (`test_wiring.py`). One assert on a pure-provider
+factory's plan: `tuple(plan.provider_kwargs) == tuple(parsed_kwargs)` — pins the
+`wiring.py` build order the gate depends on. Catches a build-order regression
+that would silently *de-select* the positional path (invisible to any behavioral
+test, since the kwargs path still returns the correct result).
+
+## Non-goals
+
+- **No direct `compile_resolver`/`resolver_for` seam harness** (observing
+  `r.__name__ == "resolve_positional"`). The differential-harness suite already
+  characterizes every compiled path; a parallel seam harness duplicates it for
+  little marginal value. Residual gap — proving the runtime closure honored the
+  selector — is accepted.
+- **No production change.** The three duplicated creator-call error copies are a
+  separate candidate, out of scope here.
+- **Not a coverage fix.** `resolver_compiler.py` is already at 100% line
+  coverage via the black-box suite; the value here is characterization and
+  regression, not closing a gap.
+
+## Testing
+
+`just test-ci` — green, 100% coverage held. During development, one mutation
+sanity check: scramble the `pos` tuple order in `resolver_compiler.py`, confirm
+`test_positional_path_binds_args_in_signature_order` goes red, revert. This
+proves the behavioral test actually bites.
+
+## Risk
+
+Low — test-only. The one real risk is a vacuously-passing behavioral test
+(pure-provider factories resolve correctly under both call conventions);
+mitigated by the `_positional_names(...) is not None` self-guard and the mutation
+check. Calling module-private `_positional_names` and reading `f._parsed_kwargs`
+(`SLF001`) mirrors the established `test_wiring.py` pattern.
+
+Promotion: no behavior changes, so no `architecture/` capability edit is
+required. Optionally note in `architecture/resolution.md` that the positional
+path's ordering invariant is now test-pinned.

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -1,0 +1,172 @@
+"""Direct tests for compiled-resolver path selection.
+
+The differential-harness suite in ``tests/providers/test_factory.py`` characterizes each
+compiled path black-box through ``resolve_provider``. These pin the two things it leaves
+unguarded: the argument-ordering invariant the positional fast path silently depends on,
+and ``_positional_names``' full contract (four exclusion rules plus the positive case),
+called directly.
+"""
+
+import dataclasses
+
+from modern_di import Container, Group, Scope, providers
+from modern_di.providers import ContextProvider
+from modern_di.registries.providers_registry import ProvidersRegistry
+from modern_di.resolver_compiler import _positional_names
+from modern_di.wiring import WiringPlan
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+class _A:
+    pass
+
+
+class _B:
+    pass
+
+
+class _C:
+    pass
+
+
+class _Req:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class _Ordered:
+    a: _A
+    b: _B
+    c: _C
+
+
+def _make(a: _A, b: _B, c: _C) -> _Ordered:
+    return _Ordered(a=a, b=b, c=c)
+
+
+def _plan(registry: ProvidersRegistry, owner: "providers.Factory[object]") -> WiringPlan:
+    """Build ``owner``'s wiring plan the way production does (via the registry memo)."""
+    return registry.plan_for(owner, owner._parsed_kwargs, owner._kwargs)  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Ordering invariant — the positional fast path binds args in signature order
+# ---------------------------------------------------------------------------
+
+
+def test_positional_path_binds_args_in_signature_order() -> None:
+    # A pure-provider factory is correct under BOTH call conventions, so a behavioral test
+    # cannot see which path ran. The self-guard below asserts the selector chose positional;
+    # the distinct-typed args then make a misordered `pos` observable (a _A would land in .b).
+    class G(Group):
+        a = providers.Factory(creator=_A, scope=Scope.APP)
+        b = providers.Factory(creator=_B, scope=Scope.APP)
+        c = providers.Factory(creator=_C, scope=Scope.APP)
+        ordered = providers.Factory(creator=_make, scope=Scope.APP)
+
+    container = Container(groups=[G], validate=False)
+    plan = _plan(container.providers_registry, G.ordered)
+    assert _positional_names(G.ordered, plan) is not None  # self-guard: positional path selected
+
+    result = container.resolve(_Ordered)
+    assert isinstance(result.a, _A)
+    assert isinstance(result.b, _B)
+    assert isinstance(result.c, _C)
+
+
+# ---------------------------------------------------------------------------
+# _positional_names — the full predicate contract, called directly
+# ---------------------------------------------------------------------------
+
+
+def test_positional_names_returns_ordered_names() -> None:
+    # positive: every param is a provider dep in signature order -> the ordered names tuple.
+    registry = ProvidersRegistry()
+    registry.add_providers(
+        providers.Factory(creator=_A, scope=Scope.APP),
+        providers.Factory(creator=_B, scope=Scope.APP),
+        providers.Factory(creator=_C, scope=Scope.APP),
+    )
+    owner = providers.Factory(creator=_make, scope=Scope.APP)
+    registry.add_providers(owner)
+
+    assert _positional_names(owner, _plan(registry, owner)) == ("a", "b", "c")
+
+
+def test_positional_names_rejects_static_or_context_kwarg() -> None:
+    # rule 1: a context param makes the plan non-pure, so kwargs folding must run.
+    def creator(dep: _A, req: _Req) -> _Ordered:
+        raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
+
+    registry = ProvidersRegistry()
+    registry.add_providers(
+        providers.Factory(creator=_A, scope=Scope.APP),
+        ContextProvider(context_type=_Req, scope=Scope.APP),
+    )
+    owner = providers.Factory(creator=creator, scope=Scope.APP)
+    registry.add_providers(owner)
+
+    assert _positional_names(owner, _plan(registry, owner)) is None
+
+
+def test_positional_names_rejects_defaulted_omitted_param() -> None:
+    # rule 2a: `opt` has a default and no provider, so it is omitted -> provider_kwargs is a
+    # strict prefix of the signature, not the whole of it.
+    def creator(dep: _A, opt: int = 5) -> _Ordered:
+        raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
+
+    registry = ProvidersRegistry()
+    registry.add_providers(providers.Factory(creator=_A, scope=Scope.APP))
+    owner = providers.Factory(creator=creator, scope=Scope.APP)
+    registry.add_providers(owner)
+
+    assert _positional_names(owner, _plan(registry, owner)) is None
+
+
+def test_positional_names_rejects_kwargs_overlay_reorder() -> None:
+    # rule 2b: supplying `a` via the kwargs overlay defers it to the end of provider_kwargs,
+    # so the binding order (b, a) no longer matches the signature (a, b).
+    def creator(a: _A, b: _B) -> _Ordered:
+        raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
+
+    registry = ProvidersRegistry()
+    factory_a = providers.Factory(creator=_A, scope=Scope.APP)
+    registry.add_providers(factory_a, providers.Factory(creator=_B, scope=Scope.APP))
+    owner = providers.Factory(creator=creator, scope=Scope.APP, kwargs={"a": factory_a})
+    registry.add_providers(owner)
+
+    plan = _plan(registry, owner)
+    assert tuple(plan.provider_kwargs) == ("b", "a")  # overlay put `a` last
+    assert _positional_names(owner, plan) is None
+
+
+def test_positional_names_rejects_keyword_only_param() -> None:
+    # rule 3: a keyword-only dep can never be passed positionally.
+    def creator(*, dep: _A) -> _Ordered:
+        raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
+
+    registry = ProvidersRegistry()
+    registry.add_providers(providers.Factory(creator=_A, scope=Scope.APP))
+    owner = providers.Factory(creator=creator, scope=Scope.APP)
+    registry.add_providers(owner)
+
+    assert _positional_names(owner, _plan(registry, owner)) is None
+
+
+def test_positional_names_rejects_positional_only_param() -> None:
+    # rule 4: `prefix` is positional-only WITH a default, dropped from parsed_kwargs so the
+    # remaining names look like a clean prefix ("dep",) -- but a positional call would bind
+    # `dep` to the `prefix` slot. The raw-signature scan must reject it.
+    def creator(prefix: str = "P", /, dep: _A = None) -> _Ordered:  # ty: ignore[invalid-parameter-default]
+        raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
+
+    registry = ProvidersRegistry()
+    registry.add_providers(providers.Factory(creator=_A, scope=Scope.APP))
+    owner = providers.Factory(creator=creator, scope=Scope.APP)
+    registry.add_providers(owner)
+
+    assert _positional_names(owner, _plan(registry, owner)) is None

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -276,3 +276,34 @@ def test_find_dep_provider_union_args_skips_owner() -> None:
     item = SignatureItem(arg_type=None, args=[_UnionTypeA])
     result = find_dep_provider(registry, factory_a, item)
     assert result is None
+
+
+class _OrderedDeps:
+    def __init__(self, first: _ServiceA, second: _ServiceB, third: _Request) -> None:
+        pass  # pragma: no cover
+
+
+def test_provider_kwargs_preserves_signature_order() -> None:
+    """provider_kwargs iterates in signature order — the invariant the positional fast path depends on.
+
+    _positional_names gates on tuple(provider_kwargs) == tuple(parsed_kwargs), then the resolver
+    builds its positional tuple from provider_kwargs. If build stopped preserving order, the gate
+    would silently de-select the positional path.
+    """
+    registry = ProvidersRegistry()
+    registry.add_providers(
+        providers.Factory(scope=Scope.APP, creator=_ServiceA),
+        providers.Factory(scope=Scope.APP, creator=_ServiceB),
+        providers.Factory(scope=Scope.APP, creator=_Request),
+    )
+    owner = providers.Factory(scope=Scope.APP, creator=_OrderedDeps)
+
+    plan = WiringPlan.build(
+        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
+        kwargs=owner._kwargs,  # noqa: SLF001
+        registry=registry,
+        owner=owner,
+    )
+
+    assert tuple(plan.provider_kwargs) == ("first", "second", "third")
+    assert tuple(plan.provider_kwargs) == tuple(owner._parsed_kwargs)  # noqa: SLF001


### PR DESCRIPTION
Adds a direct test surface for compiled-resolver path selection, covering the two things the existing black-box differential-harness suite (`tests/providers/test_factory.py:907+`) leaves unguarded.

## What
- **New `tests/test_resolver_compiler.py`** — a behavioral ordering test plus `_positional_names`' full contract (four exclusion rules + the positive exact-tuple case), called directly.
- **`tests/test_wiring.py`** — one structural assert that `provider_kwargs` iterates in signature order.

## Why
The positional fast path binds args from a `pos` tuple re-derived from `plan.provider_kwargs`. It agrees with the signature order that the `_positional_names` gate validated *only because both read the same collection* — nothing pinned that agreement. A future refactor re-sourcing `pos` would misbind positional args silently.

- The behavioral test uses three distinct-typed deps (so misordering is observable) and self-guards on `_positional_names(...) is not None`, so it cannot pass vacuously via the kwargs path (a pure-provider factory is correct under both call conventions).
- The structural assert catches the complementary regression — a `wiring.py` build-order change that silently *de-selects* the positional path, invisible to any behavioral test.

## Scope / non-goals
- Test-only; no production change. 100% coverage held (`just test-ci`: 419 passed).
- No direct `compile_resolver`/`resolver_for` seam harness — the black-box suite already characterizes every compiled path; a parallel harness would duplicate it. Residual gap (proving the runtime closure honored the selector) is accepted and recorded in the spec.

## Verification
- `just test-ci` — green, 100% coverage.
- Mutation sanity check: reversing the `pos` tuple order in `resolver_compiler.py` turns the behavioral test red (a `_C` lands in slot `.a`); reverted.

Spec: `planning/changes/2026-07-17.01-resolver-compiler-test-surface.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)