### PR TITLE
test: drift-lock the four inlined creator-call error copies

### DIFF
--- a/planning/changes/2026-07-17.02-creator-call-error-drift-lock.md
+++ b/planning/changes/2026-07-17.02-creator-call-error-drift-lock.md
@@ -1,0 +1,93 @@
+---
+summary: Lock the four inlined copies of the creator-call tb_next rule with a cross-path equivalence test, and fill the one untested matrix cell.
+---
+
+# Design: A drift lock for the creator-call error rule
+
+## Summary
+
+The rule "a binding `TypeError` becomes `CreatorCallError` (with a prepended
+resolution step); a `TypeError` from inside the creator body propagates
+unchanged" is inlined in four places. Their per-path behavior is well tested,
+but nothing asserts the copies *agree*. Add one cross-path equivalence test that
+pins them together, plus the single per-path cell the matrix left uncovered.
+Test-only; no production change.
+
+## Motivation
+
+The single-path compiled resolver (`2026-07-16.02`) inlines the creator call to
+avoid a per-node frame, so the `tb_next` discriminator now lives in four copies:
+
+- `factory.py:221` — `_call_creator` (kwargs), canonical; reused by the cached-kwargs path
+- `resolver_compiler.py:114` — transient positional
+- `resolver_compiler.py:146` — transient kwargs
+- `resolver_compiler.py:188` — cached positional
+
+Existing coverage of the two behaviors, per copy:
+
+| Copy | binding → wraps | body → propagates |
+|---|---|---|
+| `_call_creator` (cached-kwargs) | ✓ | ✓ |
+| transient-positional | **gap** | ✓ |
+| transient-kwargs | ✓ | ✓ |
+| cached-positional | ✓ | ✓ |
+
+Body-propagation is 4/4, binding-wrap 3/4. But every test checks *one* path in
+isolation — a copy that drifts its message, drops `prepend_step`, or changes the
+docs slug leaves all existing tests green. That silent divergence is the exact
+failure mode four-way duplication creates, and nothing guards it.
+
+## Design
+
+Do **not** extract a shared helper — that reintroduces the frame the inlining
+removed. Pin the copies with tests.
+
+**1. Cross-path equivalence (drift lock).** `CreatorCallError`'s rendered
+`str()` is a function of the creator, the underlying `TypeError`, and the
+prepended step. For a fixed creator + scope, a re-inlined copy must render
+*byte-identically* to its reused/canonical sibling within the same call
+convention:
+
+- positional pair: `resolve_positional` (transient) vs `create_positional` (cached)
+- kwargs pair: transient `resolve`/`build_kwargs` vs `Factory._call_creator` (cached)
+
+```python
+transient_pos = _resolve_creator_call_error(Factory(_cov_needs_one_arg, ..., skip_creator_parsing=True), R)
+cached_pos    = _resolve_creator_call_error(Factory(_cov_needs_one_arg, ..., skip_creator_parsing=True, cache=True), R)
+assert str(transient_pos) == str(cached_pos)   # positional copies agree
+# ... same for the kwargs pair ...
+for error in (transient_pos, cached_pos, transient_kw, cached_kw):
+    assert "Failed to call creator" in str(error)              # the wrap happened
+    assert "Cannot resolve dependency chain:" in str(error)    # a step was prepended
+    assert "creator-call-error" in str(error)                  # docs slug intact
+```
+
+Byte-identity across positional vs kwargs is not achievable (the underlying
+`TypeError` text differs by call convention), so the cross-convention floor is
+structural: all four wrap, prepend a step, and carry the docs slug.
+
+**2. Fill the gap.** `test_transient_positional_binding_typeerror_wraps` — the
+transient mirror of the existing cached-positional binding test.
+
+Both land in `tests/providers/test_factory.py`, beside the differential-harness
+suite whose idioms they share.
+
+## Non-goals
+
+- **No production change.** The duplication stays for speed; the tests make it
+  safe duplication. Deduping into a runtime helper is explicitly rejected (it
+  restores the removed frame).
+- **Not a coverage fix.** All four copies are already line-covered; the value is
+  the equivalence guard and the one behavioral cell.
+
+## Testing
+
+`just test-ci` — green, 100% coverage held. Mutation sanity: drop
+`prepend_step` from the cached-positional copy; the positional-pair equality goes
+red (cached loses the "Cannot resolve dependency chain:" prefix); revert.
+
+## Risk
+
+Low — test-only. The equivalence test's within-pair byte-identity depends on the
+two siblings sharing creator + scope + definition site; the fixtures use one
+module-level creator per pair so that holds by construction.

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -1118,3 +1118,71 @@ def test_cached_kwargs_body_typeerror_propagates_unchanged() -> None:
     with pytest.raises(TypeError) as exc:
         container.resolve_provider(G.thing)
     assert not isinstance(exc.value, exceptions.CreatorCallError)
+
+
+def test_transient_positional_binding_typeerror_wraps() -> None:
+    # Transient mirror of test_cached_positional_binding_typeerror_wraps: skip_creator_parsing -> 0
+    # parsed args -> positional-eligible, but the creator needs one. resolve_positional must wrap the
+    # binding TypeError. Fills the one matrix cell (transient positional, binding) left uncovered.
+    class G(Group):
+        thing = providers.Factory(
+            creator=_cov_needs_one_arg,
+            scope=Scope.APP,
+            skip_creator_parsing=True,
+            bound_type=_CovOneArgResult,
+        )
+
+    container = Container(groups=[G], validate=False)
+    with pytest.raises(exceptions.CreatorCallError):
+        container.resolve_provider(G.thing)
+
+
+def _resolve_creator_call_error(
+    factory: "providers.Factory[typing.Any]", bound_type: type
+) -> exceptions.CreatorCallError:
+    """Resolve `factory` in its own container and return the CreatorCallError it raises."""
+    container = Container(scope=Scope.APP, validate=False)
+    container.providers_registry.register(bound_type, factory)
+    with pytest.raises(exceptions.CreatorCallError) as exc_info:
+        container.resolve(bound_type)
+    return exc_info.value
+
+
+def test_creator_call_error_str_is_identical_across_transient_and_cached() -> None:
+    # The tb_next binding-error rule is inlined in four places (factory._call_creator plus three
+    # resolver_compiler closures). Nothing else asserts the copies AGREE. For a fixed creator+scope,
+    # a re-inlined copy must render byte-identically to its reused/canonical sibling:
+    #   - positional pair: resolve_positional (transient) vs create_positional (cached)
+    #   - kwargs pair:      resolve/build_kwargs (transient) vs Factory._call_creator (cached)
+    # A single copy drifting its message, dropping prepend_step, or changing the docs slug breaks one
+    # of these equalities.
+    transient_pos = _resolve_creator_call_error(
+        providers.Factory(creator=_cov_needs_one_arg, bound_type=_CovOneArgResult, skip_creator_parsing=True),
+        _CovOneArgResult,
+    )
+    cached_pos = _resolve_creator_call_error(
+        providers.Factory(
+            creator=_cov_needs_one_arg, bound_type=_CovOneArgResult, skip_creator_parsing=True, cache=True
+        ),
+        _CovOneArgResult,
+    )
+    transient_kw = _resolve_creator_call_error(
+        providers.Factory(creator=_needs_two_args, bound_type=int, skip_creator_parsing=True, kwargs={"a": 1}),
+        int,
+    )
+    cached_kw = _resolve_creator_call_error(
+        providers.Factory(
+            creator=_needs_two_args, bound_type=int, skip_creator_parsing=True, kwargs={"a": 1}, cache=True
+        ),
+        int,
+    )
+
+    assert str(transient_pos) == str(cached_pos)  # positional copies agree
+    assert str(transient_kw) == str(cached_kw)  # kwargs copies agree
+
+    # Cross-convention structural floor: all four wrapped, prepended a step, and carry the docs slug.
+    for error in (transient_pos, cached_pos, transient_kw, cached_kw):
+        rendered = str(error)
+        assert "Failed to call creator" in rendered  # the wrap happened
+        assert "Cannot resolve dependency chain:" in rendered  # a resolution step was prepended
+        assert "creator-call-error" in rendered  # docs slug intact


### PR DESCRIPTION
Pins the four inlined copies of the creator-call `tb_next` rule together, so a single copy can no longer drift silently.

## Background
The single-path compiled resolver inlines the creator call to avoid a per-node frame, so the rule — *a binding `TypeError` becomes `CreatorCallError` with a prepended step; a `TypeError` from the creator body propagates unchanged* — now lives in four copies:

- `factory.py:221` `_call_creator` (kwargs), canonical; reused by the cached-kwargs path
- `resolver_compiler.py:114` transient-positional
- `resolver_compiler.py:146` transient-kwargs
- `resolver_compiler.py:188` cached-positional

Per-copy behavior is well covered (body-propagation 4/4, binding-wrap 3/4), but every test checks *one* path in isolation. A copy that drifts its message, drops `prepend_step`, or changes the docs slug leaves all existing tests green — the exact failure mode four-way duplication creates.

## What
- **Cross-path equivalence (drift lock):** for a fixed creator+scope, each re-inlined copy must render byte-identically to its reused sibling within a call convention (positional pair; kwargs pair). Byte-identity across positional vs kwargs isn't achievable (the underlying `TypeError` text differs), so the cross-convention floor is structural — all four wrap, prepend a step, and carry the docs slug.
- **Gap fill:** `test_transient_positional_binding_typeerror_wraps` — the one uncovered matrix cell.

## Scope / non-goals
- Test-only; no production change. Deduping into a runtime helper is explicitly rejected — it restores the removed frame.
- 100% coverage held (`just test-ci`: 421 passed).

## Verification
- `just test-ci` — green, 100% coverage; `modern_di/` confirmed pristine.
- Mutation sanity: dropping `prepend_step` from the cached-positional copy turns the positional-pair equality red (cached loses the "Cannot resolve dependency chain:" prefix); reverted.

Spec: `planning/changes/2026-07-17.02-creator-call-error-drift-lock.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)