### PR TITLE
docs(resolver): drop phantom references to dissolved interpreted methods

### DIFF
--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -103,7 +103,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
             target = container if container.scope == scope else _navigate(container, scope, resolution_step)
             if target.closed:
                 target._warn_and_reopen_if_closed()  # noqa: SLF001
-            try:  # inlined Factory._resolve_kwargs (a dependency can raise ResolutionError)
+            try:  # build the positional args from the dependency resolvers (a dependency can raise ResolutionError)
                 args = [r(target) for r in pos]
             except _STEP_ERRORS as exc:
                 exc.prepend_step(resolution_step())
@@ -129,7 +129,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
             target._warn_and_reopen_if_closed()  # noqa: SLF001
-        try:  # inlined Factory._resolve_kwargs
+        try:  # build the kwargs dict from provider/static/context bindings
             kwargs = {name: r(target) for name, r in prov}
             if not pure:
                 kwargs.update(static)
@@ -243,11 +243,10 @@ def _compile_unwireable_factory(
 ) -> "typing.Callable[[Container], typing.Any]":
     """Compile the always-raising resolver for a Factory with an unwireable parameter.
 
-    Mirrors the interpreted `Factory._resolve_kwargs` unwireable branch: front-guard the override
-    (an unwireable factory can still be overridden with a mock), navigate to the scope-correct
-    target (a scope error there wins, with its step prepended), then raise the freshly built error
-    with this factory's own resolution step. The error is built on every call (never memoized) so
-    `prepend_step`'s mutation cannot leak a breadcrumb across repeated resolves.
+    Front-guard the override (an unwireable factory can still be overridden with a mock), navigate
+    to the scope-correct target (a scope error there wins, with its step prepended), then raise the
+    freshly built error with this factory's own resolution step. The error is built on every call
+    (never memoized) so `prepend_step`'s mutation cannot leak a breadcrumb across repeated resolves.
     """
     pid = f.provider_id
     scope = f.scope
@@ -274,8 +273,8 @@ def _compile_unwireable_factory(
 def _compile_alias(a: "Alias[typing.Any]") -> "typing.Callable[[Container], typing.Any]":
     """Forward to the alias's source resolver, wrapping scope/resolution errors with its own step.
 
-    Mirrors `Alias.resolve` exactly (same single try/except, same exception tuple) so a
-    dangling-source `str()` is byte-identical.
+    A single try/except covers both the dangling-source lookup and the forwarded resolve, so a
+    missing source and a source's own scope error each carry this alias's resolution step.
     """
     pid = a.provider_id
     resolution_step = a._resolution_step  # noqa: SLF001
@@ -297,7 +296,7 @@ def _compile_alias(a: "Alias[typing.Any]") -> "typing.Callable[[Container], typi
 
 
 def _compile_container_provider() -> "typing.Callable[[Container], typing.Any]":
-    """Resolve to the resolving container itself, matching `_ContainerProvider.resolve` (no scope navigation)."""
+    """Resolve to the resolving container itself — no scope navigation."""
     pid = container_provider.provider_id
 
     def resolve(container: "Container") -> typing.Any:  # noqa: ANN401

--- a/planning/decisions/2026-07-17-per-provider-compile-seam-declined.md
+++ b/planning/decisions/2026-07-17-per-provider-compile-seam-declined.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+summary: Decline a per-provider compile() seam that would dissolve resolver_compiler's type-dispatch and its reaches into provider privates — one compiler makes it a hypothetical seam, and the concentrated hot-path closures are a deliberate property. Only the phantom docstrings were a real defect; those were fixed.
+---
+
+# No per-provider compile() seam
+
+**Decision:** Do not move `resolver_compiler`'s per-type closure builders into a
+`provider.compile(registry) -> resolver` method on each provider class (Card 1
+of the 2026-07-17 architecture review). The `compile_resolver` type-dispatch and
+its `# noqa: SLF001` reaches into `Factory`/`Alias` privates stay. The three
+phantom docstrings that named dissolved interpreted methods were the one real
+defect and were corrected.
+
+## Context
+
+The single-path compiled resolver (`2026-07-16.02`) made resolve fast by
+inlining per-type closures in `resolver_compiler.py`. The review read three
+things as friction: (1) `compile_resolver` dispatches on provider type with a
+hardcoded `if type(provider) is Factory / Alias / ...` chain; (2) the builders
+reach ~16 times into `Factory` privates (`_creator`, `_parsed_kwargs`,
+`_resolution_step`, `_resolve_context_value`, `_call_creator`,
+`_argument_resolution_error`) and twice into `Alias` (`SLF001`); (3) three
+docstrings claimed the closures "mirror" `Factory._resolve_kwargs`,
+`Alias.resolve`, and `_ContainerProvider.resolve` — methods that no longer exist.
+
+The proposed deepening: give each provider a `compile()` method, collapsing the
+dispatch to `provider.compile(registry)` and turning the private reaches into
+`self.` access. Options weighed: (a) full seam — move each builder into its
+provider class; (b) middle form — `compile()` extracts its own fields and hands
+them to shared flat closure-builders that stay concentrated; (c) decline the
+structural change and fix only the docstrings.
+
+## Decision & rationale
+
+Chose (c). The deciding evidence mirrors
+[2026-07-15-provider-facing-seam-declined](2026-07-15-provider-facing-seam-declined.md):
+**there is exactly one compiler.** `resolver_compiler` is the sole consumer of
+those provider privates; nothing else varies across the proposed seam. By the
+project's standing rule (one adapter = hypothetical seam, two = a real one), a
+`compile()` seam is hypothetical — cleanliness, not a swap point.
+
+Reinforcing it:
+
+- **The `SLF001` reaches are intra-package intimacy, not a leaked abstraction.**
+  The compiler co-evolves with the classes it compiles; they ship and change
+  together. The markers are honest labels on a deliberate friendship, not a
+  boundary violation.
+- **The provider-type set is closed and tiny.** Polymorphic dispatch buys
+  extensibility for types that are essentially never added; the `if type() is`
+  chain over four types is not worse.
+- **Concentration is a deliberate, valuable property.** Every perf-critical
+  closure lives in one file, reviewed together, sharing the positional/kwargs and
+  two-phase-error patterns. The full seam (a) sacrifices that; the middle form
+  (b) preserves concentration only by adding a field-extraction indirection that
+  earns nothing while the seam stays hypothetical.
+
+The genuine defect was the doc-rot: three docstrings and two inline comments
+named dissolved methods. Those were rewritten to describe the behavior directly
+(no interpreted-path references remain), which is the whole of the fix.
+
+## Revisit trigger
+
+A **second consumer of provider compile-time privates** appears (a distinct
+compiler, an alternate resolver backend), making `compile()` a real two-adapter
+seam — **or** provider types become an open, user-extended set where adding one
+must not require editing a central dispatch, at which point the polymorphic
+`compile()` hook becomes the migration path.


### PR DESCRIPTION
Fixes the doc-rot left by the single-path compiled resolver, and records the decision to keep the concentrated compiler rather than build a per-provider `compile()` seam (Card 1 of the 2026-07-17 review, declined).

## The defect
`resolver_compiler`'s docstrings and inline comments named three interpreted methods as the paths the compiled closures "mirror":

- `Factory._resolve_kwargs` (2 inline comments + 1 docstring)
- `Alias.resolve` (1 docstring)
- `_ContainerProvider.resolve` (1 docstring)

All three were removed when the compiled resolver became the single path. The five references are rewritten to describe the closure behavior directly. The `Factory._call_creator` references stay — that method still exists and is genuinely reused.

## Why only docstrings (Card 1 declined)
Exploration turned the review's read around. The `SLF001` reaches (~16 into `Factory`, 2 into `Alias`) are intra-package intimacy, not a leaked abstraction — `resolver_compiler` is the *sole* consumer of those privates and co-evolves with the classes it compiles. By the project's standing rule (one adapter = hypothetical seam, two = real), a `provider.compile()` seam is hypothetical. Against that, the concentrated hot-path closures are a deliberate, valuable property a per-provider seam would scatter. The one real defect was the doc-rot.

Recorded in `planning/decisions/2026-07-17-per-provider-compile-seam-declined.md` (same reasoning as the earlier `provider-facing-seam-declined`, different axis) so future reviews don't re-suggest it.

## Verification
No behavior change (docstrings/comments only). `just test-ci` green, 100% coverage; `just lint` and `just check-planning` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)