### PR TITLE
refactor: ProvidersRegistry owns its validation-freshness check

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -35,7 +35,7 @@ def _handle_recursion_error(
     boundary to re-arm on before raising.
     """
     reg = container.providers_registry
-    if reg.validated_version == reg.version:
+    if reg.is_validated():
         raise exc  # validated => acyclic static graph => genuine self-recursion
     cycle = DependencyGraph().find_cycle_from(provider, container)
     if cycle is None:
@@ -205,7 +205,7 @@ class Container:
 
     def validate(self) -> None:
         reg = self.providers_registry
-        if reg.validated_version == reg.version:
+        if reg.is_validated():
             self._validated = True
             return  # already validated at this registry version — no re-walk
 
@@ -235,7 +235,7 @@ class Container:
         if validation_errors:
             raise exceptions.ValidationFailedError(errors=validation_errors)
         self._validated = True
-        reg.validated_version = reg.version
+        reg.mark_validated()
 
     def add_providers(self, *providers: AbstractProvider[typing.Any]) -> None:
         """Register providers on this (root) container after construction.

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -40,6 +40,14 @@ class ProvidersRegistry:
         """
         return self._version
 
+    def is_validated(self) -> bool:
+        """Return whether the graph was validated at the current version — no mutation since the stamp."""
+        return self.validated_version == self._version
+
+    def mark_validated(self) -> None:
+        """Stamp the current version as validated; a later mutation re-arms it via the version bump."""
+        self.validated_version = self._version
+
     def find_provider(self, dependency_type: type[types.T]) -> AbstractProvider[types.T] | None:
         return self._providers.get(dependency_type)
 

--- a/planning/changes/2026-07-17.03-registry-owns-validation-freshness.md
+++ b/planning/changes/2026-07-17.03-registry-owns-validation-freshness.md
@@ -1,0 +1,43 @@
+---
+summary: Wrap the validated_version == version freshness idiom behind ProvidersRegistry.is_validated()/mark_validated(), so Container asks the registry instead of comparing two of its fields.
+---
+
+# Change: ProvidersRegistry owns its validation-freshness check
+
+**Lane:** lightweight — additive methods on an internal registry, three call
+sites migrated, no behavior change.
+
+## Goal
+
+The "is the graph validated at the current version?" idiom
+(`reg.validated_version == reg.version`) was interpreted by `Container` at three
+sites — `validate()`'s short-circuit and stamp, plus `_handle_recursion_error`.
+The registry owns both fields and their invalidation, so Container was reaching
+across to reconstruct the registry's own freshness protocol. Concentrate it on
+its owner.
+
+## Approach
+
+Add two methods to `ProvidersRegistry`:
+
+- `is_validated() -> bool` — `validated_version == self._version`
+- `mark_validated() -> None` — `validated_version = self._version`
+
+Migrate the three `Container` sites: the two reads become `reg.is_validated()`
+(notably `_handle_recursion_error` now reads as intent — "if already validated,
+this is genuine self-recursion" — not field arithmetic), and the stamp becomes
+`reg.mark_validated()`. The `validated_version` field stays public (invalidation
+still lives in the registry's mutators; the per-container `_validated` bool is a
+separate concept and is untouched). No behavior change, so
+`architecture/validation.md`'s field-level description stays accurate.
+
+## Files
+
+- `modern_di/registries/providers_registry.py` — add `is_validated`/`mark_validated`
+- `modern_di/container.py` — migrate the three call sites
+- `tests/registries/test_providers_registry.py` — exercise the methods directly
+
+## Verification
+
+- [x] `just test-ci` — 422 passed, 100% coverage held.
+- [x] `just lint` — clean.

--- a/tests/registries/test_providers_registry.py
+++ b/tests/registries/test_providers_registry.py
@@ -15,17 +15,28 @@ def test_providers_registry_find_provider_not_found() -> None:
 
 
 def test_validated_version_defaults_none() -> None:
-    assert ProvidersRegistry().validated_version is None
+    registry = ProvidersRegistry()
+    assert registry.validated_version is None
+    assert registry.is_validated() is False  # None != version -> not validated
+
+
+def test_mark_validated_stamps_current_version() -> None:
+    registry = ProvidersRegistry()
+    registry.mark_validated()
+    assert registry.is_validated() is True
+    assert registry.validated_version == registry.version
 
 
 def test_mutation_invalidates_validated_version() -> None:
     registry = ProvidersRegistry()
-    registry.validated_version = registry.version
+    registry.mark_validated()
+    assert registry.is_validated() is True
 
     class _MutationTarget: ...
 
     registry.add_providers(providers.Factory(scope=Scope.APP, creator=_MutationTarget))
     assert registry.validated_version is None
+    assert registry.is_validated() is False
 
 
 def test_providers_registry_add_provider_duplicates() -> None:


### PR DESCRIPTION
Concentrates the "is the graph validated at the current version?" idiom on the registry that owns the fields.

## What
`reg.validated_version == reg.version` was interpreted by `Container` at three sites — `validate()`'s short-circuit and stamp, plus `_handle_recursion_error`. The registry already owns both fields and their invalidation, so Container was reaching across to reconstruct the registry's own freshness protocol.

Adds two methods to `ProvidersRegistry`:
- `is_validated() -> bool`
- `mark_validated() -> None`

The two reads become `reg.is_validated()` (notably `_handle_recursion_error` now reads as intent — "if already validated, this is genuine self-recursion" — instead of field arithmetic); the stamp becomes `reg.mark_validated()`.

## Scope
- `validated_version` stays public; invalidation still lives in the registry's mutators.
- The per-container `_validated` bool is a separate concept ("did *this* container validate") and is untouched.
- No behavior change, so `architecture/validation.md`'s field-level description stays accurate.

## Verification
`just test-ci` — 422 passed, 100% coverage held; `just lint` and `just check-planning` clean.

Change: `planning/changes/2026-07-17.03-registry-owns-validation-freshness.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)