### PR TITLE
fix(wiring): honor the creator default for a ContextProvider passed via kwargs

### DIFF
--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -139,6 +139,17 @@ and the two paths are independent:
   shared `absent_disposition` helper: if the dependent parameter has a default or is nullable it is silently
   satisfied; otherwise an `ArgumentResolutionError` is raised, exactly as before this warning was added.
 
+Either **declaration route** reaches that dependent-parameter path: matched by type from the registry, or
+passed explicitly as `Factory(creator, kwargs={"request": the_provider})`. `WiringPlan.build` buckets both
+into `context_kwargs` with the parameter's `SignatureItem`, so the two agree — how the provider reaches the
+parameter is a declaration detail, not a behavior switch.
+
+The one exception is a `ContextProvider` passed via `kwargs={...}` for a parameter with **no parsed
+`SignatureItem`** — a `**kwargs` creator, or `skip_creator_parsing=True`. There is no default or nullability
+to consult, so it stays on the direct-resolve path above and warns accordingly. Treating it as required would
+raise where 2.x returns `None`; treating it as nullable would silently swallow the unset-context signal that
+3.0 turns into `ContextValueNotSetError`.
+
 `ContextProvider` also accepts an optional `bound_type` that overrides the inferred bound type.
 
 ---

--- a/modern_di/wiring.py
+++ b/modern_di/wiring.py
@@ -136,12 +136,14 @@ class WiringPlan:
             # UNWIRABLE: record the (name, item) pair but do not raise
             unwireable.append((name, item))
 
-        if kwargs:  # static overlay
-            for name, value in kwargs.items():
-                if isinstance(value, AbstractProvider):
-                    provider_kwargs[name] = value
-                else:
-                    static_kwargs[name] = value
+        if kwargs:
+            cls._apply_overlay(
+                kwargs=kwargs,
+                parsed_kwargs=parsed_kwargs,
+                provider_kwargs=provider_kwargs,
+                static_kwargs=static_kwargs,
+                context_kwargs=context_kwargs,
+            )
 
         return cls(
             provider_kwargs=provider_kwargs,
@@ -150,3 +152,28 @@ class WiringPlan:
             unwireable=unwireable,
             pure_provider=not static_kwargs and not context_kwargs,
         )
+
+    @staticmethod
+    def _apply_overlay(
+        *,
+        kwargs: dict[str, typing.Any],
+        parsed_kwargs: dict[str, SignatureItem],
+        provider_kwargs: dict[str, "AbstractProvider[typing.Any]"],
+        static_kwargs: dict[str, typing.Any],
+        context_kwargs: dict[str, "tuple[ContextProvider[typing.Any], SignatureItem]"],
+    ) -> None:
+        """Bucket each explicit ``kwargs={...}`` entry into the buckets built by the by-type pass.
+
+        A ``ContextProvider`` joins ``context_kwargs`` with its parameter's ``SignatureItem``, so an
+        unset value honors the default/nullable exactly as the by-type route does. With no parsed
+        item (a ``**kwargs`` creator, ``skip_creator_parsing=True``) there is no default to honor, so
+        it stays a plain provider and keeps the direct-resolve semantics.
+        """
+        for name, value in kwargs.items():
+            item = parsed_kwargs.get(name)
+            if isinstance(value, ContextProvider) and item is not None:
+                context_kwargs[name] = (value, item)
+            elif isinstance(value, AbstractProvider):
+                provider_kwargs[name] = value
+            else:
+                static_kwargs[name] = value

--- a/planning/changes/2026-07-17.04-context-provider-kwargs-wiring.md
+++ b/planning/changes/2026-07-17.04-context-provider-kwargs-wiring.md
@@ -1,0 +1,73 @@
+---
+summary: A ContextProvider passed via kwargs={...} is wired as a context kwarg (honoring the parameter's default/nullable) instead of being resolved directly, so explicit and by-type wiring of the same creator no longer diverge.
+---
+
+# Change: ContextProvider in `kwargs={...}` wires as a context kwarg
+
+**Lane:** lightweight — one branch in `WiringPlan.build`, no public-API change,
+no new file.
+
+## Goal
+
+The same creator parameter behaved differently depending on how its
+`ContextProvider` reached it. Wired **by type**, an unset context value consults
+`absent_disposition` and the parameter's default applies. Passed **explicitly**
+via `kwargs={"request": ctx_provider}`, it landed in `provider_kwargs` and
+resolved through `ContextProvider.resolve`, which discards the default, injects
+`None`, and emits `ContextValueNoneWarning`:
+
+```
+wired by TYPE            -> DEFAULT-APPLIED   warned=[]
+wired via kwargs={...}   -> got None          warned=['ContextValueNoneWarning']
+```
+
+Silently dropping a declared default is wrong on its own. It also mis-signals
+the 3.0 upgrade: once the warning becomes `ContextValueNotSetError`, this path
+would *raise* for a parameter that has a perfectly good default.
+
+## Approach
+
+`WiringPlan.build`'s static overlay tested only `isinstance(value,
+AbstractProvider)`, so a `ContextProvider` fell into the provider bucket. Split
+that branch: when the value is a `ContextProvider` **and** the parameter has a
+parsed `SignatureItem`, bucket it into `context_kwargs` with that item — the
+same pair the by-type path builds, so `_resolve_context_value` honors
+default-then-nullable-then-required identically.
+
+The `item is not None` guard is deliberate. With a `**kwargs` creator or
+`skip_creator_parsing=True` there is no parsed signature, so there is no default
+to honor and nothing to fix; those keep resolving through the provider bucket
+(`ContextValueNoneWarning` + `None` today, `ContextValueNotSetError` in 3.0).
+Routing them as required would raise where 2.x currently returns `None` — a
+break mid-2.x — and routing them as nullable would destroy the unset-context
+signal 3.0 depends on. Both rejected; the fix stays scoped to the divergence.
+
+`pure_provider` and `edges` need no change: both derive from the buckets, so a
+provider moving between them is accounted for automatically, and the validation
+graph still sees the same edge. Promotes into
+[`architecture/providers.md`](../../architecture/providers.md), which documents
+`ContextProvider` wiring but never covered the `kwargs={...}` route.
+
+The third branch pushed `build` to complexity 11 (`C901`, limit 10). The plan is
+memoized and cold, so there is no frame-count constraint to justify a `noqa` the
+way `resolver_compiler.py`'s hot closures have; the overlay loop is extracted to
+`WiringPlan._apply_overlay` instead, which is also where the no-`SignatureItem`
+guard is documented. The two loops were already distinct phases.
+
+## Files
+
+- `modern_di/wiring.py` — extract `_apply_overlay`; bucket a `ContextProvider` with a parsed item into `context_kwargs`
+- `tests/providers/test_context_provider.py` — divergence + guard coverage
+- `architecture/providers.md` — promotion
+
+## Verification
+
+- [x] Failing test first — `just test tests/providers/test_context_provider.py -k kwargs_context`
+      → `AssertionError: assert 'default-applied' == 'got None'` (the default discarded).
+- [x] Apply the change.
+- [x] Tests pass — 5 passed, incl. 3 guards pinning unchanged behavior
+      (present value, override, no-parsed-signature).
+- [x] `just test-ci` — 427 passed, 100% coverage held.
+- [x] `just lint` — clean (`ruff` + `ty`).
+- [x] `modern-di-fastapi` suite green against the patched build (8 passed) — the
+      integration registers the `Request`/`WebSocket` context providers this touches.

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -341,3 +341,68 @@ def test_context_provider_override_direct_short_circuits() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert app_container.resolve_provider(MyGroup.context_provider) is override_value
+
+
+_SENTINEL_DEFAULT = datetime.datetime(1999, 9, 9, tzinfo=datetime.timezone.utc)
+
+
+def _ctx_default_creator(*, ctx: datetime.datetime | None = _SENTINEL_DEFAULT) -> str:
+    return "default-applied" if ctx is _SENTINEL_DEFAULT else f"got {ctx!r}"
+
+
+class _KwargsCtxByTypeGroup(Group):
+    ctx = providers.ContextProvider(scope=Scope.APP, context_type=datetime.datetime)
+    out = providers.Factory(_ctx_default_creator, bound_type=None)
+
+
+class _KwargsCtxExplicitGroup(Group):
+    ctx = providers.ContextProvider(scope=Scope.APP, context_type=datetime.datetime)
+    out = providers.Factory(_ctx_default_creator, bound_type=None, kwargs={"ctx": ctx})
+
+
+def test_kwargs_context_provider_honors_creator_default_when_unset() -> None:
+    # A ContextProvider passed explicitly via kwargs={...} must wire as a context kwarg, not a plain
+    # provider: an unset value falls back to the creator's default rather than injecting None.
+    app_container = Container(groups=[_KwargsCtxExplicitGroup], validate=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert app_container.resolve_provider(_KwargsCtxExplicitGroup.out) == "default-applied"
+
+
+def test_kwargs_context_provider_matches_by_type_wiring() -> None:
+    # The same creator wired both ways agrees: how the ContextProvider reaches the parameter is a
+    # declaration detail, not a behavior switch.
+    by_type = Container(groups=[_KwargsCtxByTypeGroup], validate=False)
+    explicit = Container(groups=[_KwargsCtxExplicitGroup], validate=False)
+    assert by_type.resolve_provider(_KwargsCtxByTypeGroup.out) == explicit.resolve_provider(_KwargsCtxExplicitGroup.out)
+
+
+def test_kwargs_context_provider_injects_present_value() -> None:
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    app_container = Container(groups=[_KwargsCtxExplicitGroup], context={datetime.datetime: now}, validate=False)
+    assert app_container.resolve_provider(_KwargsCtxExplicitGroup.out) == f"got {now!r}"
+
+
+def test_kwargs_context_provider_override_wins() -> None:
+    override_value = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    app_container = Container(groups=[_KwargsCtxExplicitGroup], validate=False)
+    app_container.override(_KwargsCtxExplicitGroup.ctx, override_value)
+    assert app_container.resolve_provider(_KwargsCtxExplicitGroup.out) == f"got {override_value!r}"
+
+
+def _opaque_ctx_creator(**kw: object) -> str:
+    return f"ctx={kw.get('ctx')!r}"
+
+
+class _KwargsCtxNoSignatureGroup(Group):
+    ctx = providers.ContextProvider(scope=Scope.APP, context_type=datetime.datetime)
+    out = providers.Factory(_opaque_ctx_creator, bound_type=None, kwargs={"ctx": ctx})
+
+
+def test_kwargs_context_provider_without_parsed_signature_keeps_direct_resolve() -> None:
+    # A **kwargs creator parses no SignatureItem for `ctx`, so there is no default to honor and
+    # nothing to fix: it keeps resolving through the provider bucket, warning as before. Routing it
+    # as required would raise where 2.x returns None; as nullable would drop the 3.0 signal.
+    app_container = Container(groups=[_KwargsCtxNoSignatureGroup], validate=False)
+    with pytest.warns(ContextValueNoneWarning):
+        assert app_container.resolve_provider(_KwargsCtxNoSignatureGroup.out) == "ctx=None"


### PR DESCRIPTION
## The bug

The same creator parameter behaved differently depending on **how** its `ContextProvider` reached it:

```
wired by TYPE            -> DEFAULT-APPLIED   warned=[]
wired via kwargs={...}   -> got None          warned=['ContextValueNoneWarning']
```

Wired by type, an unset context value consults `absent_disposition` and the parameter's default applies. Passed explicitly via `kwargs={"request": ctx_provider}`, `WiringPlan.build`'s static overlay tested only `isinstance(value, AbstractProvider)`, so the provider landed in `provider_kwargs` and resolved through `ContextProvider.resolve` — discarding the declared default, injecting `None`, and emitting a spurious `ContextValueNoneWarning`.

Silently dropping a declared default is wrong on its own. It also mis-signals the 3.0 upgrade: once the warning becomes `ContextValueNotSetError`, this path would **raise** for a parameter that has a perfectly good default.

## The fix

Bucket a `ContextProvider` with a parsed `SignatureItem` into `context_kwargs` — the same pair the by-type path builds — so `_resolve_context_value` honors default-then-nullable-then-required identically. How the provider reaches the parameter is now a declaration detail, not a behavior switch.

## The deliberate non-fix

The `item is not None` guard is intentional. With a `**kwargs` creator or `skip_creator_parsing=True` there is no parsed signature, so there is no default to honor and nothing to fix; those keep today's direct-resolve semantics. Both alternatives were considered and rejected:

- **required** → raises where 2.x returns `None`, a break mid-2.x
- **nullable** → silently swallows the unset-context signal 3.0 turns into `ContextValueNotSetError`

Pinned by `test_kwargs_context_provider_without_parsed_signature_keeps_direct_resolve`.

## Notes

`pure_provider` and `edges` derive from the buckets, so a provider moving between them is accounted for automatically and the validation graph still sees the same edge.

The third branch pushed `build` to complexity 11 (`C901`). The plan is memoized and cold, so there's no frame-count constraint to justify a `noqa` the way `resolver_compiler.py`'s hot closures have — the overlay loop is extracted to `_apply_overlay` instead, which is also where the guard is documented.

## Verification

- Failing test first: `AssertionError: assert 'default-applied' == 'got None'`
- `just test-ci` — **427 passed, 100% coverage held**
- `just lint` — clean (`ruff` + `ty`)
- `modern-di-fastapi` suite green against the patched build (8 passed) — it registers the `Request`/`WebSocket` context providers this touches
- 3 of the 5 new tests are guards pinning behavior that must **not** change (present value, override, no-parsed-signature)

Promoted into `architecture/providers.md`, which documented `ContextProvider` wiring but never covered the `kwargs={...}` route.

Change: `planning/changes/2026-07-17.04-context-provider-kwargs-wiring.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)