### PR TITLE
docs: retract the custom-provider extension point; state the closed provider set

### DIFF
--- a/docs/providers/advanced-api.md
+++ b/docs/providers/advanced-api.md
@@ -11,27 +11,20 @@ Lower-level public surface for library authors and advanced use-cases.
 MRO override order (subclass attribute shadows parent attribute of the same name). Use it to
 inspect or iterate all providers declared on a group hierarchy.
 
-### Subclassing `AbstractProvider`
-
-To implement a custom provider, subclass `AbstractProvider` and implement:
-
-- **`resolve(container)`** *(required)* — returns the resolved instance.
-- **`get_dependencies(container)`** *(optional)* — returns a `dict[str, AbstractProvider]`
-  mapping parameter names to their providers; used by `Container.validate()` for graph
-  traversal.
-- **`iter_validation_issues(container)`** *(optional)* — yields `Exception` instances for
-  validation-time problems found in this provider; default yields nothing.
-- **`redirect_target(container)`** *(optional override)* — return the provider this one
-  transparently forwards to, or `None` (the default) when resolution terminates here. A transparent
-  or redirect provider (like `Alias`) overrides it to point at its source, so that `Container.validate()`
-  follows the redirect to the real target and checks callers against that target's scope rather than any
-  nominal scope on the wrapper itself.
+!!! note "The provider set is closed — `AbstractProvider` is not an extension point"
+    `Factory`, `Alias`, `ContextProvider`, and the pre-built `container_provider` are the
+    only provider types. `AbstractProvider` is their shared base and the type that appears
+    in public signatures (`resolve_dependency`, `kwargs=`), but it is **not** a hook for
+    adding your own: resolution compiles one closure per known provider type, so a subclass
+    of `AbstractProvider` — or of `Factory` — raises `TypeError` at its first resolve, and
+    `validate()` does not catch it. Compose behavior in a creator function, or use `Alias`,
+    instead of introducing a provider type.
 
 ### `CacheSettings.is_async_finalizer`
 
 `CacheSettings.is_async_finalizer` is a computed bool field set at construction time via
-`inspect.iscoroutinefunction(finalizer)`. `Factory.resolve` and the cache registry use it to
-decide whether to `await` the finalizer during `close_async()` or treat it as sync.
+`inspect.iscoroutinefunction(finalizer)`. The cache registry uses it to decide whether to
+`await` the finalizer during `close_async()` or treat it as sync.
 
 ### Deprecated: `cache_settings=`
 
@@ -43,8 +36,8 @@ emits a `DeprecationWarning`; pass `cache=True` (defaults) or `cache=CacheSettin
 
 `find_container(scope)` walks `_scope_map` and returns the container registered at
 `scope`; raises `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
-It is the primitive a custom `AbstractProvider.resolve` calls to locate the container at
-its scope — see [Subclassing `AbstractProvider`](#subclassing-abstractprovider) above.
+It is the primitive the compiled resolvers use to locate the container at a provider's
+scope when it differs from the resolving container's.
 
 ## Container internals — no stability guarantee
 
@@ -58,7 +51,8 @@ its scope — see [Subclassing `AbstractProvider`](#subclassing-abstractprovider
 - **`_scope_map`** — `dict[IntEnum, Container]` mapping every scope in the chain to its
   container; built at construction time and inherited (plus the new scope) by each child.
 - **`_lock`** — a `threading.RLock` instance, or `None` when the container was created with
-  `use_lock=False`. The lock gates singleton creation inside `Factory.resolve`.
+  `use_lock=False`. A cached `Factory`'s compiled resolver hands it to `CacheItem.get_or_create`,
+  which gates the cold-miss build so one instance is created per cache key.
 
 The former public names `scope_map` and `lock` remain as read-only properties that emit
 `DeprecationWarning` and will be removed in a future release.

--- a/docs/providers/container.md
+++ b/docs/providers/container.md
@@ -85,5 +85,5 @@ the full contract.
 
 - **Context propagation** — how context values reach (and don't reach) a `ContextProvider` is
   covered on the [Context Providers](context.md#context-propagation) page.
-- **Low-level API** — `find_container`, `scope_map`, `Group.get_providers()`, and subclassing
-  `AbstractProvider` are documented under [Advanced / low-level API](advanced-api.md).
+- **Low-level API** — `find_container`, `scope_map`, and `Group.get_providers()` are documented
+  under [Advanced / low-level API](advanced-api.md).

--- a/planning/changes/2026-07-17.05-retract-custom-provider-docs.md
+++ b/planning/changes/2026-07-17.05-retract-custom-provider-docs.md
@@ -1,0 +1,66 @@
+---
+summary: Retract the "Subclassing AbstractProvider" extension point from the docs and state the closed provider set, finishing the doc-rot #334 left behind; also drops two stale references to the removed Factory.resolve and AbstractProvider.resolve.
+---
+
+# Change: Retract the custom-provider extension point from the docs
+
+**Lane:** lightweight — documentation only, no code change. The API change itself
+shipped in `2026-07-16.02` (#334); this makes the docs describe it.
+
+## Goal
+
+`docs/providers/advanced-api.md` promised, under **"## Supported extension
+points"**, that you could subclass `AbstractProvider` and implement
+`resolve(container)`. #334 closed the provider set and deleted
+`AbstractProvider.resolve`, so that recipe now raises `TypeError` at first
+resolve. The docs were left describing a capability the code no longer has.
+
+Ruled by the maintainer (2026-07-17): retract the docs rather than restore the
+open dispatch or run a 2.x deprecation ramp. Rationale and the rejected
+alternatives are recorded in
+[`planning/decisions/2026-07-17-custom-providers-retracted.md`](../decisions/2026-07-17-custom-providers-retracted.md).
+
+## Approach
+
+Delete the `### Subclassing AbstractProvider` section. Replace it with a note
+that states the closed set positively — a returning reader who followed the old
+recipe needs to find out *why* it vanished, not just find it gone. The note names
+the two things the investigation surfaced that a user cannot infer: a `Factory`
+subclass fails identically (`compile_resolver` dispatches on `type(x) is`, not
+`isinstance`), and `validate()` does not catch it (validation walks the dependency
+graph; compilation is lazy at first resolve).
+
+Two adjacent references to methods #334 deleted are corrected in the same pass —
+same root cause, same file:
+
+- `find_container(scope)` — described as "the primitive a custom
+  `AbstractProvider.resolve` calls", cross-linking the retracted section. Now
+  describes the compiled resolvers' cross-scope navigation.
+- `CacheSettings.is_async_finalizer` — credited to `Factory.resolve`, which no
+  longer exists. `cache_registry.py:68` is now its only reader.
+
+`docs/providers/container.md`'s "See also" listed subclassing among the low-level
+API; that item is dropped.
+
+No `architecture/` promotion: `architecture/providers.md` documents the four
+concrete types and never claimed the set was open, so it is already true.
+
+## Files
+
+- `docs/providers/advanced-api.md` — retract the section; add the closed-set note; fix the three stale method references
+- `docs/providers/container.md` — drop subclassing from the "See also" low-level API item
+- `planning/decisions/2026-07-17-custom-providers-retracted.md` — the ruling and its rejected alternatives
+
+A third stale reference turned up during verification and is fixed here too: the
+`_lock` internals entry credited the lock to "singleton creation inside
+`Factory.resolve`". Confirmed against the code — the compiled cached resolver
+passes `target._lock` to `CacheItem.get_or_create`
+(`resolver_compiler.py:228`), which gates the cold-miss build.
+
+## Verification
+
+- [x] No surviving reference to subclassing `AbstractProvider`, `Factory.resolve`, or `AbstractProvider.resolve` in `docs/`.
+- [x] `just lint-ci` — clean (`ruff` + `ty` + planning bundles OK).
+- [x] `just test-ci` — 422 passed, 100% coverage held.
+- [x] `just docs-build` — `mkdocs build --strict` clean; no dangling anchor from the deleted section
+      (the only inbound link, in `find_container`, was rewritten).

--- a/planning/decisions/2026-07-17-custom-providers-retracted.md
+++ b/planning/decisions/2026-07-17-custom-providers-retracted.md
@@ -1,0 +1,86 @@
+---
+status: accepted
+summary: The provider-type set is closed (Factory, Alias, ContextProvider, container_provider). Retract "Subclassing AbstractProvider" from the documented supported extension points rather than restoring the open dispatch the compiled resolver removed.
+supersedes: null
+superseded_by: null
+---
+
+# Custom providers are not an extension point; the provider set is closed
+
+**Decision:** `modern-di` supports exactly four provider types — `Factory`,
+`Alias`, `ContextProvider`, and the pre-built `container_provider`. Subclassing
+`AbstractProvider` (or `Factory`) to add a provider type is **not** supported.
+The `docs/providers/advanced-api.md` section promising it is retracted rather
+than honored.
+
+## Context
+
+Until 2.28.0, `Container.resolve_provider` ended in `provider.resolve(self)` — a
+plain polymorphic call. Custom provider support was never designed; it was an
+**emergent property** of dispatching through a method. Any subclass implementing
+`resolve()` worked automatically, because that is how Python inheritance behaves.
+`docs/providers/advanced-api.md` then documented that accident under
+"## Supported extension points", with an implement-`resolve(container)` recipe.
+
+The single-path compiled resolver (`2026-07-16.02`, #334) replaced the
+polymorphic call with `compile_resolver`, which selects a closure by exact type
+identity and rejects everything else:
+
+```python
+if type(provider) is Factory: ...
+if type(provider) is Alias: ...
+if type(provider) is ContextProvider: ...
+raise TypeError(f"no compiled resolver for provider type {...}")
+```
+
+It also deleted `AbstractProvider.resolve` and `Alias.resolve`, so no hook
+survives to fall through to. The closure of the set was deliberate — asserted by
+`tests/test_container.py::test_resolve_provider_raises_for_unhandled_provider_type`
+and reasoned from in
+[2026-07-17-per-provider-compile-seam-declined](2026-07-17-per-provider-compile-seam-declined.md)
+("the provider-type set is closed and tiny"). Only the docs were left behind.
+
+Investigation (2026-07-17) established the blast radius and the failure mode:
+
+- **`type(x) is Factory` is identity, not `isinstance`.** A `LoggingFactory(Factory)`
+  that overrides nothing at all fails exactly like a from-scratch provider. The
+  break is wider than "exotic custom providers".
+- **`validate()` cannot catch it.** Validation walks the dependency graph via
+  `get_dependencies()`; compilation happens lazily in `resolver_for` at first
+  resolve. A container built with `validate=True` reports clean and then raises
+  `TypeError` at first resolve, under traffic.
+- **Zero consumers.** All 13 sibling `modern-di-*` repos, the two templates, and
+  `lite-bootstrap` contain no `AbstractProvider` subclass. (`that-depends` hits
+  are that library's own unrelated base class.)
+
+Options weighed: (a) retract the docs and ship 2.29.0; (b) restore a fallback in
+2.x behind a `DeprecationWarning` naming the 3.0 removal, matching the
+`ContainerClosedWarning` / `ContextValueNoneWarning` / `UnvalidatedContainerWarning`
+ramps, and retract at 3.0; (c) hold the whole post-2.28.0 backlog for 3.0.
+
+## Decision & rationale
+
+Chose (a). The capability was never intended, is asserted against by a test, and
+has no consumer anywhere in the project's own ecosystem. Restoring an open
+dispatch to preserve an accident would re-import the exact indirection #334
+removed, and would contradict a decision taken the same day on the same seam.
+
+Rejected (b) — the deprecation ramp — despite it being the house pattern for
+2.x→3.0 removals. Those three ramps each guard a capability users demonstrably
+rely on; this one would guard an audience believed to be empty, at the cost of
+carrying a resurrected fallback path plus a warning class through the 2.x line.
+The residual risk is accepted knowingly: an unknown external user subclassing
+`Factory` gets a runtime `TypeError` on a minor bump, with `validate()` giving a
+false all-clear first. The 2.29.0 notes call this out explicitly under a
+breaking-change heading so the release, not the docs, carries the warning.
+
+Rejected (c) — 3.0 is not scoped, and holding the compiled resolver and the perf
+work behind it strands shipped, tested work for an unscoped release.
+
+## Revisit trigger
+
+A real user reports a broken custom provider or `Factory` subclass — which would
+falsify the zero-audience premise this rests on. At that point the migration path
+is the polymorphic `compile()` hook named in
+[2026-07-17-per-provider-compile-seam-declined](2026-07-17-per-provider-compile-seam-declined.md)'s
+own revisit trigger, not a restored interpreted fallback.


### PR DESCRIPTION
Docs-only. No code change — the API change itself shipped in #334; this makes the docs describe it.

## The problem

`docs/providers/advanced-api.md` promised, under **`## Supported extension points`**, that you could subclass `AbstractProvider` and implement `resolve(container)`. #334 closed the provider set and deleted `AbstractProvider.resolve`, so that published recipe now fails:

```
2.28.0:  resolve -> hello
main:    TypeError: no compiled resolver for provider type ConstProvider
```

Custom provider support was never designed. It was an **emergent property** of `resolve_provider` ending in a polymorphic `provider.resolve(self)` call — any subclass worked for free, because that's how Python inheritance works. The compiled resolver replaced that with dispatch on exact type identity. The closure was deliberate (pinned by `test_resolve_provider_raises_for_unhandled_provider_type`, reasoned from in `2026-07-17-per-provider-compile-seam-declined`); only the docs were left behind.

## What the investigation found

Two things a user cannot infer, so the new note states them explicitly:

- **A `Factory` subclass fails identically.** Dispatch is `type(x) is Factory`, not `isinstance`, so a `LoggingFactory(Factory)` that overrides *nothing* raises too. Wider than "exotic custom providers."
- **`validate()` does not catch it.** Validation walks the dependency graph via `get_dependencies()`; compilation is lazy inside `resolver_for` at first resolve. A `validate=True` container reports clean, then raises at runtime.

Blast radius: all 13 sibling `modern-di-*` repos, both templates, and `lite-bootstrap` contain zero `AbstractProvider` subclasses. (`that-depends` hits are that library's own unrelated base class.)

## The ruling

Maintainer ruled: retract the docs rather than restore the open dispatch or run a 2.x deprecation ramp. The rejected alternatives — and the knowingly-accepted residual risk that an unknown external user breaks at runtime on a minor bump — are recorded in `planning/decisions/2026-07-17-custom-providers-retracted.md`. The 2.29.0 notes will carry that warning under a breaking-change heading.

## Also fixed (same root cause, #334 doc-rot)

Three adjacent references to deleted methods, each verified against the code:

| Reference | Was | Now |
|---|---|---|
| `find_container` | "the primitive a custom `AbstractProvider.resolve` calls" | the compiled resolvers' cross-scope navigation |
| `CacheSettings.is_async_finalizer` | credited to `Factory.resolve` | `cache_registry.py:68`, its only reader |
| `_lock` internals | "singleton creation inside `Factory.resolve`" | `CacheItem.get_or_create`, per `resolver_compiler.py:228` |

No `architecture/` promotion: `architecture/providers.md` documents the four concrete types and never claimed the set was open.

## Verification

- `just docs-build` — `mkdocs build --strict` clean; no dangling anchor (the one inbound link, in `find_container`, was rewritten)
- `just lint-ci` — clean (`ruff` + `ty` + planning bundles)
- `just test-ci` — 422 passed, 100% coverage held

🤖 Generated with [Claude Code](https://claude.com/claude-code)