### PR TITLE
feat: free-threaded (PEP 703) support at Beta (+ fix a resolver_for concurrency race)

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -44,7 +44,7 @@ jobs:
       - run: just test-ci
       - name: Stress the concurrency test (free-threaded only)
         if: matrix.python-version == '3.14t'
-        run: just test tests/test_free_threading.py --count=50
+        run: just test tests/test_free_threading.py --count=50 -W error::RuntimeWarning
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -27,6 +27,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.14t"
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v4
@@ -37,7 +38,13 @@ jobs:
       - run: uv python install ${{ matrix.python-version }}
       - run: uv python pin ${{ matrix.python-version }}
       - run: just install
+      - name: Confirm the interpreter is free-threaded
+        if: matrix.python-version == '3.14t'
+        run: uv run --no-sync python -c "import sys; assert not sys._is_gil_enabled(), 'GIL is enabled on a t-build'"
       - run: just test-ci
+      - name: Stress the concurrency test (free-threaded only)
+        if: matrix.python-version == '3.14t'
+        run: just test tests/test_free_threading.py --count=50
 
   docs:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Where the detail lives — read the matching capability file before changing beh
 | [architecture/validation.md](architecture/validation.md) | `validate()` cycle + scope checks |
 | [architecture/testing-and-overrides.md](architecture/testing-and-overrides.md) | overrides + the `modern-di-pytest` integration |
 | [architecture/integration-kit.md](architecture/integration-kit.md) | framework-agnostic primitives for building an integration adapter |
+| [architecture/concurrency.md](architecture/concurrency.md) | thread-safety + free-threaded (PEP 703) support, at Beta |
 
 ### Key files
 

--- a/architecture/concurrency.md
+++ b/architecture/concurrency.md
@@ -1,0 +1,57 @@
+# Concurrency and free-threaded (PEP 703) safety
+
+modern-di is safe to resolve from multiple threads, and supported on free-threaded
+CPython (PEP 703, the `3.14t` build) at trove level **`2 - Beta`**: production-ready
+and tested under real multithreading, with the caveats below documented. The
+[2026-07-17 research report](../planning/audits/2026-07-17-nogil-support-research-report.md)
+is the full analysis; this page is the standing contract.
+
+## The model
+
+- **Singleton creation is the only locked path.** A cached `Factory` builds its
+  value under the resolving container's `threading.RLock`, double-checked: the
+  dependency graph resolves *outside* the lock, then creation and the cache store
+  run *inside* it behind a second cache-populated check, so at most one caller ever
+  runs the creator (`CacheItem.get_or_create`). Concurrent first-resolvers of the
+  same singleton share **one** `CacheItem` because `CacheRegistry.fetch_cache_item`
+  publishes it with `dict.setdefault` — a single atomic operation. Containers built
+  with `use_lock=False` opt out of the lock and are single-thread-only.
+- **Registry memoization is lock-free and idempotent.** The compiled resolver, the
+  wiring plan, and their registry caches (`_resolvers`, `_plans`) are pure functions
+  of `(provider, registry version)`. Two threads racing to build the same entry
+  produce identical objects and store the same `(version, object)` tuple; the worst
+  case is one duplicated build, never a wrong result. The cycle-guard `_building`
+  set is **thread-local**: it tracks which providers are being compiled on *this*
+  call stack, so a genuine same-thread `A -> B -> A` cycle is still caught by the
+  back-edge thunk, while a concurrent first-resolve of the same provider on another
+  thread simply compiles it independently (an idempotent duplicate) rather than
+  being misread as a cycle. (A shared `_building` set was a real bug fixed in this
+  change — it recursed to `RecursionError` on acyclic graphs under concurrent
+  first-resolution.) Registry *mutation* (`register` / `add_providers` / removal)
+  is guarded by the registry's own lock.
+
+## Why this is sound without the GIL
+
+Free-threaded CPython makes single built-in-container operations (`dict.setdefault`,
+`dict[k] = v`, `dict.get`, `list.append`) internally atomic — one such operation
+cannot corrupt the structure. modern-di never relies on a *compound* check-then-act
+over shared state being atomic: every such sequence above is either idempotent
+(rebuild-if-stale) or already under the container lock. The one reliance CPython
+does not *formally* guarantee is object-publication ordering — that a reader
+observing a stored reference sees the object's fully-initialized fields — because
+CPython publishes no memory model. In the current implementation, publication
+through a container's internal critical section provides that ordering; that gap
+between "implementation behavior" and "spec guarantee" is why the claim is **Beta**,
+not **Stable**. See the report for the full argument.
+
+## Caveats
+
+- **Apply overrides before concurrent resolution.** `override()` / `reset_override()`
+  mutate a shared registry without a lock; racing them against live `resolve()` calls
+  is inherently unordered (it always was, GIL or not). Set overrides during
+  single-threaded setup, then resolve concurrently.
+- **Seed context before concurrent resolution too.** `set_context` writes a shared
+  dict; populate a container's context before resolving from it on many threads.
+- **Performance, not correctness, is the open question.** Whether the per-container
+  lock contends under heavy parallel first-resolution is unmeasured and out of scope
+  for the Beta claim (report §7).

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -173,8 +173,8 @@ class Factory(AbstractProvider[types.T_co]):
         # The plan is memoized on the providers registry (shared by a container and every child), so a
         # deeper-scope factory builds it once per registry version, not once per child container. Passing
         # the build inputs to plan_for (rather than a closure) keeps the hot cache-hit path allocation-free.
-        # Building runs outside the container lock — safe under the GIL since it's a deterministic function
-        # of the registry as of the version it was built against (free-threaded/nogil caveat: planning/deferred.md).
+        # Building runs outside the container lock — a deterministic function of the registry as of the
+        # version it was built against, so a race at worst repeats the build (see architecture/concurrency.md).
         return container.providers_registry.plan_for(self, self._parsed_kwargs, self._kwargs)
 
     def _resolve_context_value(

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -88,7 +88,8 @@ class CacheRegistry:
     def fetch_cache_item(self, provider: Factory[types.T_co]) -> CacheItem:
         # Fast path: return an existing item without building a throwaway CacheItem (plain
         # setdefault eagerly constructs one on every hit). The creation path still uses
-        # setdefault so it stays atomic under the GIL — fetch runs outside the container lock,
+        # setdefault so first-resolvers share one CacheItem via a single atomic op — fetch runs outside
+        # the container lock (free-threaded-safe; see architecture/concurrency.md),
         # and concurrent first-resolvers must share one CacheItem because the singleton cache
         # and its double-checked lock live on that object.
         item = self._items.get(provider.provider_id)

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -21,7 +21,7 @@ class ProvidersRegistry:
         self._providers: dict[type, AbstractProvider[typing.Any]] = {}
         self._plans: dict[int, tuple[int, WiringPlan]] = {}
         self._resolvers: dict[int, tuple[int, typing.Callable[[Container], typing.Any]]] = {}
-        self._building: set[int] = set()
+        self._building = threading.local()  # per-thread compile-in-flight set; the cycle guard is per-call-stack
         self._version = 0
         self.validated_version: int | None = None
 
@@ -77,6 +77,18 @@ class ProvidersRegistry:
         self._plans[provider_id] = (version, plan)
         return plan
 
+    def _building_set(self) -> set[int]:
+        """Return the current thread's in-flight-compile set (the cycle guard).
+
+        Per-call-stack: a concurrent first-resolve of the same provider on another thread compiles it
+        independently (an idempotent duplicate) instead of being misread as a dependency cycle.
+        """
+        building: set[int] | None = getattr(self._building, "value", None)
+        if building is None:
+            building = set()
+            self._building.value = building
+        return building
+
     def resolver_for(self, provider: "AbstractProvider[typing.Any]") -> "typing.Callable[[Container], typing.Any]":
         """Return `provider`'s memoized compiled resolver, building it cycle-safely on a miss.
 
@@ -89,13 +101,14 @@ class ProvidersRegistry:
         cached = self._resolvers.get(pid)
         if cached is not None and cached[0] == version:
             return cached[1]
-        if pid in self._building:
+        building = self._building_set()
+        if pid in building:
             return lambda c: c.resolve_provider(provider)  # back-edge: route the cycle through runtime
-        self._building.add(pid)
+        building.add(pid)
         try:
             resolver = compile_resolver(provider, self)
         finally:
-            self._building.discard(pid)
+            building.discard(pid)
         self._resolvers[pid] = (version, resolver)
         return resolver
 

--- a/planning/audits/2026-07-17-nogil-support-research-report.md
+++ b/planning/audits/2026-07-17-nogil-support-research-report.md
@@ -1,0 +1,252 @@
+# Free-threaded (nogil / PEP 703) support research: correctness gap and cost to support
+
+**Date:** 2026-07-17
+**Scope:** correctness only (parallel-resolution *performance* is explicitly out
+of scope — noted as follow-up, see §7). Sizes the gap between modern-di today and
+a defensible free-threaded compatibility claim, and recommends whether to pursue it.
+**Method:** Part A — read every path that touches shared mutable state during
+concurrent `resolve()` (`container.py`, the four `registries/*`, `providers/factory.py`,
+`resolver_compiler.py`, `providers/abstract.py`). Part B — a focused web-research
+pass (official python.org docs, PEP 703 / PEP 779, packaging.python.org,
+`py-free-threading.github.io`, live PyPI metadata for five peer DI libraries) to
+establish current free-threaded CPython facts, since 3.14 shipped after the
+assistant knowledge cutoff. This report **supersedes** the "Free-threaded (nogil)
+safety of wiring-plan compilation" item in [`../deferred.md`](../deferred.md),
+whose core premise turns out to be false (§3).
+
+---
+
+## 1. TL;DR / recommendation
+
+**GO — support free-threading at classifier level `2 - Beta`, at low cost.** The
+deferred doc's fear (concurrent `dict.__setitem__` corrupts the dict / a resize
+corrupts it) is **not true** for real free-threaded CPython: built-in container
+single-operations are internally locked and cannot corrupt or crash (§3). Every
+lock-free memoization publish in modern-di is **idempotent** (rebuild-if-stale,
+at worst duplicated work), so single-op safety is sufficient for correctness. No
+non-idempotent corruption bug was found (§4).
+
+The one honest caveat is **object-publication ordering**: CPython publishes *no
+formal Python-level memory model*, so "a reader that sees the stored reference is
+guaranteed to see the object's fully-initialized fields" rests on *implementation
+behavior*, not spec (§3c). This is the same reliance every lock-free Python
+singleton pattern makes; it is why the honest classifier level is `2 - Beta`
+(production-ready, tested, caveats documented), not `3 - Stable` (a full
+thread-safety guarantee we cannot spec-back).
+
+For a **zero-dependency pure-Python** library the packaging cost is ~nil: no C
+extension, no `Py_mod_gil`, no special wheel — the existing `py3-none-any` wheel
+already runs on `3.14t`. The work is CI + a stress test + a classifier + doc
+truth-up (§6). **Competitive note:** none of `dishka`, `that-depends`,
+`dependency-injector`, `wireup`, `svcs` has adopted the `Free Threading` trove
+classifier; only wireup claims readiness in prose. Adopting it is a differentiator.
+
+---
+
+> **Correction (2026-07-18, during implementation).** The H3 verdict below —
+> "the `_building` cycle-guard self-heals, low severity" — was **wrong**.
+> Implementation reproduced a real, pre-existing bug: because `_building` is
+> shared across threads, two threads first-resolving the same provider
+> concurrently make the second mistake the first's in-flight compile for a cycle,
+> take the back-edge thunk, and recurse to `RecursionError` on an acyclic graph.
+> It reproduces **under the GIL too** (verified on CPython 3.10), so it is not a
+> free-threading artifact. Fixed by making `_building` thread-local (the guard is
+> per-call-stack). The GO / Beta / low-cost conclusion still holds — this is one
+> bounded production fix, not a redesign — but §1's "no hot-path code change" and
+> §4's "no non-idempotent corruption path exists" are amended by it. See the
+> implementing change bundle.
+
+## 2. Part A — shared-state hazard inventory
+
+Every piece of shared mutable state reachable from concurrent `resolve()`, with
+its current synchronization and hazard class. "Idempotent publish" means two
+threads racing produce the *same* value for the same registry version, so a
+last-writer-wins store is correct and the worst case is repeated work.
+
+| # | State | Site | Current sync | Class | Verdict |
+|---|---|---|---|---|---|
+| H1 | `ProvidersRegistry._plans` | `plan_for` | lock-free `get`+`setitem`, version-stamped | idempotent publish | safe under §3 |
+| H2 | `ProvidersRegistry._resolvers` | `resolver_for` | lock-free `get`+`setitem`, version-stamped | idempotent publish | safe under §3 |
+| H3 | `ProvidersRegistry._building` set | `resolver_for` | lock-free `add`/`discard` | compound cycle-guard | **REAL BUG (see correction above)** — fixed via thread-local `_building` |
+| H4 | `CacheItem.cache` warm read | `_compile_cached_factory.resolve` | writer stores under RLock; warm reader reads bare | bare-attr publication | §3c reliance |
+| H5 | `CacheRegistry._creation_order.append` | `mark_created` | lock-free `append`, one call per item | single-op list write | safe under §3 |
+| H6 | `OverridesRegistry` / `ContextRegistry` dicts | `override` / `set_context` vs resolve | lock-free | runtime mutate-during-resolve | inherent race, matches GIL semantics |
+| H7 | `provider_id` = `itertools.count()` | provider `__init__` | lock-free `next()` | startup-only | out of hot path |
+
+**The deferred doc is stale on two counts** independent of the corruption
+finding: (1) it names only `_plans` (H1); the compiled resolver shipped after it
+(PR #334, 2026-07-16) and added `_resolvers` (H2) — an exact structural twin — plus
+the `_building` cycle-guard set (H3). Any statement about H1 must now cover H2.
+
+---
+
+## 3. Part B — the CPython facts that decide it
+
+### (a) 3.14 free-threading is officially supported
+
+PEP 779 was accepted 2025-06-16; "What's New in Python 3.14" states verbatim
+*"PEP 779: Free-threaded Python is officially supported."* This is Phase II
+(supported, still a separate opt-in build), not experimental. Single-threaded
+overhead is now ~5–10% (down from ~40% in 3.13). Supporting it is a stable
+commitment against a fixed target, not a moving experiment.
+Sources: `docs.python.org/3/whatsnew/3.14.html`, `peps.python.org/pep-0779/`.
+
+### (b) Single container ops are safe; compound ops are not
+
+There is now an official `docs.python.org/3/library/threadsafety.html`. Built-in
+`dict`/`list`/`set` use per-object locks / critical sections
+(`Py_BEGIN_CRITICAL_SECTION`) plus QSBR for lock-free reads. **A single
+operation** — `d[k]=v`, `d.get(k)`, `k in d`, `d.setdefault(...)`, `lst.append(x)`
+— **cannot corrupt the structure or crash.** **Compound** check-then-act
+(`if k in d: del d[k]`, `d[k]=d[k]+1`, `if lst: lst.pop()`, iterate-while-mutate)
+is explicitly *not* atomic. **Caveat:** the docs frame single-op safety as *"a
+description of the current implementation, not a guarantee."*
+
+This directly **refutes** the deferred doc's premise. There is no dict-corruption
+hazard; the only question is whether modern-di's *compound* sequences are
+idempotent (they are — §4).
+
+### (c) No formal memory model — publication is implementation-safe, not spec-safe
+
+PEP 703 is implementation-focused (per-object locks, critical sections,
+QSBR/mimalloc for use-after-free safety) and makes **no statement** about whether
+a reader observing a shared reference sees fully-initialized fields. PEP 583 (a
+Python memory model) is withdrawn/historical, not in force. In practice, storing
+into a built-in container goes through that container's critical section (with the
+attendant atomics), so publication *through a dict/list* is expected safe in the
+current implementation — but this is **not a documented guarantee**. H4 is the
+weakest point because it publishes via a **bare `slots` attribute store**
+(`self.cache = value`), not through a container critical section — it relies purely
+on "CPython does not tear a pointer store or reorder the object's field inits
+past it," which holds on all real targets but is unspecified.
+
+### (d) Pure-Python declares compatibility with a classifier and nothing else
+
+The `Free Threading` trove classifier is live in `pypa/trove-classifiers` with
+four status levels: `1 - Unstable`, `2 - Beta`, `3 - Stable`, `4 - Resilient`
+(rough semantics: 1 = feedback-only; 2 = production-ready + multithreaded-tested +
+caveats documented; 3 = fully thread-safe; 4 = resilient). A `py3-none-any` wheel
+needs **no** free-threading wheel tag and **no** `Py_mod_gil` — those are
+C-extension-only. Pure Python runs on `3.14t` unchanged.
+Sources: `github.com/pypa/trove-classifiers`, `py-free-threading.github.io/porting/`.
+
+### (e) CI mechanics
+
+`uv python install 3.14t` (and `3.13t`) installs the free-threaded build;
+`uv python pin 3.14t` selects it. `actions/setup-python` accepts `python-version:
+3.14t`. Confirm the GIL is off at runtime with `sys._is_gil_enabled() is False`
+(a `t` build defaults off; `PYTHON_GIL=1`/`-X gil=1` forces it back on). Importing
+a non-ported C extension auto-re-enables the GIL with a `RuntimeWarning` — a
+non-issue for a zero-dependency lib. Thread-stress tool: **`pytest-run-parallel`**
+(Quansight-Labs) reruns the existing suite across a thread pool
+(`--parallel-threads=auto`, `--iterations=N`).
+
+### (f) Peer libraries have not claimed it
+
+Live PyPI `classifiers`: `that-depends`, `dishka`, `dependency-injector`, `svcs`
+— **none** carry a Free Threading classifier. `wireup` claims *"no-GIL (PEP 703)
+ready"* in its description text only (no classifier, not independently verified).
+The classifier is an open differentiator.
+
+---
+
+## 4. Why modern-di is already correct (given §3)
+
+Walking each compound sequence for a non-idempotent race:
+
+- **`plan_for` / `resolver_for` (H1/H2):** `get(pid)` miss → build → `setitem`.
+  A `WiringPlan`/resolver is a pure function of `(provider, registry-version)`, so
+  two racers build **identical** objects and both store the same `(version, obj)`
+  tuple. Last-writer-wins is correct; worst case is one duplicated build. The
+  version snapshot is taken *before* the build, so a plan built against a
+  since-mutated registry carries the old stamp and is never served as current.
+- **`_building` set (H3):** for a shared diamond dependency, racer B may see
+  A's `pid` mid-compile and return the **unmemoized** runtime-routing thunk
+  (`lambda c: c.resolve_provider(provider)`). That thunk is correct (routes through
+  the runtime path) and is never stored, so it self-heals to the memoized resolver
+  on the next call. `discard` (not `remove`) is safe even if already discarded.
+- **`fetch_cache_item`:** `get` fast-path miss → `setdefault`. `setdefault` is a
+  single atomic op (§3b), so concurrent first-resolvers share **one** `CacheItem`
+  — which is the invariant the double-checked lock on that object depends on. The
+  code already comments this intent.
+- **`get_or_create`:** `resolve()` (dependency build) runs unlocked; `create` +
+  store run under the container RLock, double-checked. Two racers may both run
+  `resolve()`; exactly one wins `create` under the lock, the other sees the set
+  cache and returns it. A cached *dependency* recurses into its own
+  `get_or_create` (no double-create); a transient dependency's discarded value is
+  never finalized anyway.
+- **`mark_created` (H5):** only the `created=True` winner calls it, once per item;
+  `list.append` is single-op safe. Relative order of *independent* singletons is
+  already nondeterministic, so the finalizer LIFO invariant (a dependency finalizes
+  after its dependents) is unaffected.
+- **Override front-guard (H6):** `has_overrides` read + `fetch_override` is racy
+  against a concurrent runtime `override()`, but mutate-during-resolve is inherently
+  racy under *any* model and already is under the GIL. Not a free-threading
+  regression; document as "apply overrides before concurrent resolution."
+
+**Conclusion:** no non-idempotent corruption path exists. The only residual is the
+§3c publication-ordering reliance (H1/H2/H4), shared by all lock-free Python
+singleton code.
+
+---
+
+## 5. The one design choice for the maintainer
+
+Given §4, the publication-ordering reliance can be handled two ways. This is a
+genuine design fork — it trades a spec-level guarantee against hot-path cost and
+the zero-`exec`/lock-free-memoization design that PR #334 deliberately bought:
+
+- **Option P1 — accept documented single-op + publication behavior (recommended).**
+  Add no locks to H1/H2/H4. Rely on §3b single-op safety (documented) + §3c
+  publication (implementation behavior), validate with a `pytest-run-parallel`
+  stress job, claim classifier `2 - Beta`, and document the reliance. Zero hot-path
+  cost. This is what "beta / production-ready with documented caveats" *means*, and
+  matches how every lock-free singleton in the ecosystem already ships.
+- **Option P2 — lock/barrier the publishes for a spec-hard guarantee.** Wrap the
+  H1/H2 store (and the H4 warm read) so publication has an explicit
+  happens-before. This buys classifier `3 - Stable` honesty but **regresses the
+  exact lock-free memoization PR #334 shipped** (a lock on every cold publish, and
+  for H4 either a lock on the warm-hit fast path or a redesign). Given the plan/
+  resolver are immutable-once-built and the store is idempotent, the marginal
+  correctness this buys on real targets is ~nil.
+
+Recommendation: **P1 at level `2 - Beta`.** Revisit level `3 - Stable` only if a
+real free-threaded miscompile is ever reproduced, or CPython publishes a memory
+model that makes P2 cheap to assert.
+
+---
+
+## 6. If GO — the correctness-only work (for the design phase)
+
+1. **CI:** add a `3.14t` job (`uv python install 3.14t` + pin) running the full
+   suite, plus a `pytest-run-parallel` thread-stress pass over resolution
+   (`--parallel-threads=auto --iterations=N`), asserting `sys._is_gil_enabled()
+   is False`. Decide: matrix addition vs. a dedicated stress job (pytest's own
+   fixture-sharing-across-threads caveat may argue for a separate, purpose-built
+   concurrent-resolution test rather than blindly parallelizing the whole suite).
+2. **A concurrent-resolution stress test:** N threads resolving overlapping graphs
+   (shared singletons, deep chains, cross-scope) off one root + many child
+   containers, asserting single-instance identity for singletons and no exceptions.
+3. **Trove classifier:** add `Programming Language :: Python :: Free Threading ::
+   2 - Beta` to `pyproject.toml`.
+4. **Doc truth-up:** replace the `deferred.md` item with this report's finding;
+   add a "free-threading" note to the relevant `architecture/` capability
+   (containers or a concurrency note) stating the P1 stance and the H6 override
+   caveat; retarget the two GIL-caveat code comments (`factory.py:_plan`,
+   `cache_registry.fetch_cache_item`) at this report.
+
+Est. size: one **Full** change bundle (new CI surface + public-metadata change +
+architecture promotion). No hot-path code change under P1.
+
+---
+
+## 7. Explicitly out of scope (follow-up)
+
+**Parallel-resolution performance.** Without the GIL, the per-container RLock in
+`get_or_create` serializes concurrent first-resolution of *distinct* singletons
+sharing a container, and the warm-hit path still pays `fetch_cache_item` +
+override front-guard per call. Whether that RLock becomes a contention bottleneck
+under real parallel load — and whether a lock-free or per-provider-lock resolution
+path is worth it — is a separate investigation that ties into the warm-singleton
+perf item in [`../deferred.md`](../deferred.md). Not required for a correctness
+claim; revisit if a user reports parallel-resolution contention.

--- a/planning/changes/2026-07-17.07-nogil-free-threading-support.md
+++ b/planning/changes/2026-07-17.07-nogil-free-threading-support.md
@@ -1,0 +1,160 @@
+---
+summary: Claim free-threaded (PEP 703) support at classifier level 2 - Beta — first fixing a pre-existing resolver_for cycle-guard race (thread-local _building), then a 3.14t CI job, a hand-rolled concurrent-resolution stress test, the trove classifier, and an architecture/concurrency.md truth home.
+---
+
+# Design: Free-threaded (PEP 703) support at Beta
+
+## Summary
+
+Claim free-threaded CPython support at trove level `2 - Beta`, correctness-only.
+The [2026-07-17 research report](../audits/2026-07-17-nogil-support-research-report.md)
+established that modern-di's lock-free memoization is idempotent and largely
+correct on free-threaded builds — but **implementation surfaced one real,
+pre-existing bug the report misjudged**: the `resolver_for` cycle-guard set
+(`_building`) was shared across threads, so concurrent first-resolution of the
+same provider recursed to `RecursionError` on an acyclic graph (reproduces under
+the GIL too). So the work is **one bounded production fix** (make `_building`
+thread-local — the guard is per-call-stack) plus verification and declaration: a
+`3.14t` CI job, a hand-rolled concurrent-resolution stress test, the
+`Free Threading :: 2 - Beta` classifier, and promoting the concurrency story into
+a new `architecture/concurrency.md` (replacing the stale `deferred.md` item, and
+correcting the report's H3 verdict). Parallel-resolution *performance* stays out
+of scope (report §7).
+
+## Motivation
+
+PEP 779 made free-threading **officially supported** in Python 3.14 — a stable
+target, not an experiment. modern-di is zero-dependency pure Python, so the
+`py3-none-any` wheel already runs on `3.14t` with no packaging work. The research
+refuted the `deferred.md` premise (concurrent `dict.__setitem__` cannot corrupt a
+real free-threaded dict; single ops are internally locked), and an audit of every
+compound check-then-act sequence found no non-idempotent race. So the gap between
+today and a defensible Beta claim is *verification + declaration + documentation*,
+not a fix. Competitive note: none of dishka/that-depends/dependency-injector/svcs
+carries the classifier; only wireup claims readiness in prose — an open
+differentiator.
+
+## Design
+
+**1. CI — `3.14t` in the gated matrix.** Append `"3.14t"` to the `python-version`
+list in `.github/workflows/_checks.yml`. `uv python install 3.14t` /
+`uv python pin 3.14t` already resolve the free-threaded build; the job runs the
+same `just test-ci` (full suite, 100% coverage) under a GIL-disabled interpreter.
+This is the free structural gate — anything import-time or coverage-affecting
+surfaces here.
+
+**2. Concurrent-resolution stress test** — new `tests/test_free_threading.py`,
+hand-rolled (no new dev dependency; runs on every Python version). Shape:
+
+```python
+def test_concurrent_resolution_shares_singletons() -> None:
+    class G(Group):
+        singleton = providers.Factory(creator=_Obj, scope=Scope.APP, cache=True)
+        chain_root = providers.Factory(creator=_deep, scope=Scope.APP, cache=True)
+        transient = providers.Factory(creator=_Obj, scope=Scope.APP)  # no cache
+    container = Container(groups=[G], validate=True)
+    n = 32
+    barrier = threading.Barrier(n)
+    results: list[object] = [None] * n
+    errors: list[BaseException] = []
+
+    def worker(i: int) -> None:
+        barrier.wait()  # release all threads into resolution simultaneously
+        try:
+            results[i] = container.resolve(_Obj)  # the cached singleton
+            container.resolve(_Deep)              # deep chain of cached deps
+            with container.build_child_container(scope=Scope.REQUEST) as child:
+                child.resolve(...)                # cross-scope child resolution
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    assert not errors
+    assert len({id(r) for r in results}) == 1  # one shared singleton identity
+```
+
+- A `threading.Barrier` releases all workers at once to maximize contention on
+  the double-checked lock and `fetch_cache_item` `setdefault`.
+- The **singleton-identity** assertion (`len({id(r)}) == 1`) is the real signal:
+  it proves the double-checked `get_or_create` + `setdefault`-shared `CacheItem`
+  hold under parallelism (a torn race would yield two instances).
+- The "did it run GIL-free" assertion lives in **CI** (a `3.14t`-only
+  `assert not sys._is_gil_enabled()` step), not in the test — keeping the suite
+  version-agnostic and free of a version-conditional line that would break the
+  100% line-coverage gate on the GIL cells.
+- **Stress:** amplify with the already-present `pytest-repeat` dev dep via a
+  **separate, non-gated** step in the `3.14t` job — `just test
+  tests/test_free_threading.py --count=50` (`just test` runs *without* the
+  coverage gate, so aiming it at one file is fine; `just test-ci` still runs the
+  full gated suite in its own step). A rare interleaving is then more likely to
+  surface. Under the GIL it passes trivially but still exercises the threading
+  paths (keeps the test meaningful on 3.10–3.14).
+
+**3. Trove classifier.** Add
+`"Programming Language :: Python :: Free Threading :: 2 - Beta"` to
+`pyproject.toml` `classifiers`.
+
+**4. Promotion / truth-up:**
+- New `architecture/concurrency.md` — the truth home for the thread-safety story:
+  the per-container `RLock` + double-checked singleton creation, the idempotent
+  lock-free registry memoization (`_plans`/`_resolvers`/`_building`, `CacheItem`),
+  the **P1 stance** (single-op safety + implementation-behavior publication; no
+  hot-path locks), the honest Beta level, and the H6 caveat: *apply overrides
+  before concurrent resolution* (runtime `override()` racing a resolve is
+  inherently racy, unchanged from GIL behavior). Add its row to the `CLAUDE.md`
+  architecture table and a cross-link from `containers.md`/`providers.md`.
+- Delete the `deferred.md` "Free-threaded (nogil) safety of wiring-plan
+  compilation" item outright — the work is actioned in this change (it is no
+  longer *deferred*), and its corruption premise is refuted; the audit report and
+  `architecture/concurrency.md` are the record, so no pointer is left behind.
+- Retarget the two GIL-caveat code comments — `factory.py._plan`
+  ("free-threaded/nogil caveat: planning/deferred.md") and
+  `cache_registry.fetch_cache_item` — at `architecture/concurrency.md`.
+
+## Non-goals
+
+- **Parallel-resolution performance** — RLock contention on distinct singletons
+  sharing a container, warm-hit per-call overhead. Correctness does not need it;
+  ties into the warm-singleton item in `deferred.md`. (Report §7.)
+- **Classifier level `3 - Stable`** — would require locking/barriering the
+  publishes (P2), regressing PR #334's lock-free memoization for a ~nil real-world
+  gain. Revisit only on a reproduced free-threaded miscompile or a CPython memory
+  model. (Report §5.)
+- **`pytest-run-parallel`** — a hand-rolled targeted stress test needs no new dev
+  dep, runs on all versions, and avoids the plugin's fixture-sharing-across-threads
+  caveat. The targeted test exercises the shared state that matters.
+- **Exactly one production logic change** — the `resolver_for` thread-local fix.
+  Everything else is verification, declaration, and docs (comments only in
+  `modern_di/` beyond the fix). The report's "no hot-path change" framing is
+  amended by this; the fix is bounded, not a redesign.
+
+## Testing
+
+- `just test-ci` green on all of 3.10–3.14 **and** the new `3.14t` job.
+- The new `tests/test_free_threading.py` passes, and on `3.14t` its
+  `sys._is_gil_enabled()` guard confirms it ran GIL-free.
+- Mutation sanity check during development: temporarily bypass the double-checked
+  second `cache is not UNSET` guard in `CacheItem.get_or_create` and confirm the
+  singleton-identity assertion goes red under `--count`, then revert — proves the
+  test actually bites the shared-state path.
+- 100% line coverage held (the stress test is self-covering; no production lines
+  added).
+
+## Risk
+
+- **Test flakiness (most likely).** A threaded stress test can flake if written
+  with hidden ordering assumptions. Mitigation: the only assertions are
+  order-independent (set-identity of singletons; empty error list); the `Barrier`
+  makes contention deterministic-ish; `pytest-repeat` amplifies rather than masks.
+- **`3.14t` CI availability / speed.** `uv` installs `3.14t` today; if the runner
+  image lags, the job may need an explicit `uv python install`. Low impact —
+  isolated to one matrix cell, `fail-fast: false` already set.
+- **Over-claiming.** Beta asserts "tested, caveats documented," not "guaranteed
+  thread-safe." The `architecture/concurrency.md` caveat section + the honest
+  level are the mitigation; the report §3c publication reliance is stated plainly.
+
+Promotion: this change **adds** the `architecture/concurrency.md` capability page
+and edits the `CLAUDE.md` architecture table — done in the implementing PR
+alongside the code, per the planning convention.

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -44,29 +44,6 @@ lifecycle, and trails the two `exec`-codegen frameworks by 1.3-1.9x on transient
 See the [competitor-perf research](audits/2026-07-16-competitor-perf-research-report.md) (the design
 evidence: closures capture ~80-90% of the ceiling, `exec` buys 0-4% at fixed arity).
 
-## Free-threaded (nogil) safety of wiring-plan compilation — from 2026-06-14 audit (A-1)
-
-`Factory._plan` builds the `WiringPlan` outside any lock and publishes it via
-`ProvidersRegistry.plan_for`, which stores it in the registry's `_plans` dict keyed by `provider_id`
-(`modern_di/registries/providers_registry.py`). Under the GIL this is safe: the plan is a deterministic
-function of the providers registry's state as of the version it was built against (a
-`ProvidersRegistry.version` stamp, bumped on every `register`/`add_providers`/removal, is stored
-alongside the plan and snapshotted *before* the build so a later registration invalidates it), so two
-threads that both see the same stamp build identical plans — at worst the work is repeated once — and the
-GIL ensures a thread seeing a stored `(version, plan)` entry also sees the fully-built (frozen) object.
-
-Under free-threaded CPython that guarantee is lost on two counts: concurrent `dict.__setitem__` on the
-shared `_plans` dict is itself a data race (a resize can corrupt it), and without a memory barrier a
-reader could observe the stored reference before the `WiringPlan`'s fields are visible and resolve
-against a partially-constructed plan.
-
-**Revisit trigger:** if/when free-threading (PEP 703 / `--disable-gil`) support becomes a goal. Fix
-options: build and publish under the registry's own `_lock` (co-located with the `_providers`/`_version`
-mutations the plan reads, and deadlock-safe since plan-building is pure lookup that never re-enters
-`register`), or publish the reference behind an explicit barrier/atomic. Until then, document modern-di
-as GIL-assuming for plan compilation.
-See [2026-06-14 audit A-1](audits/2026-06-14-deep-audit-report.md).
-
 ## Opt-in DEBUG resolution tracing (ERR-8) — from 2026-07-05 3.0 UX research
 
 A module-level `logging.getLogger("modern_di")` narrating resolution at DEBUG level: resolve start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Typing :: Typed",
     "Topic :: Software Development :: Libraries",
 ]

--- a/tests/registries/test_providers_registry.py
+++ b/tests/registries/test_providers_registry.py
@@ -1,10 +1,13 @@
 import sys
 import threading
+import typing
 
 import pytest
 
-from modern_di import providers, suggester
+from modern_di import Container, Group, providers, suggester
 from modern_di.exceptions import DuplicateProviderTypeError
+from modern_di.providers.abstract import AbstractProvider
+from modern_di.registries import providers_registry as pr_mod
 from modern_di.registries.providers_registry import ProvidersRegistry
 from modern_di.scope import Scope
 
@@ -104,3 +107,60 @@ def test_iteration_is_safe_while_another_thread_registers() -> None:
         sys.setswitchinterval(old_interval)
 
     assert errors_seen == []
+
+
+def test_concurrent_first_resolve_of_same_provider_does_not_false_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Thread 2 must not mistake thread 1's in-flight compile of the SAME provider for a cycle.
+    # Deterministic: a stall gate holds thread 1 mid-compile while thread 2 enters the window.
+    class _Leaf: ...
+
+    class _Root:
+        def __init__(self, leaf: _Leaf) -> None:
+            self.leaf = leaf
+
+    class _G(Group):
+        leaf = providers.Factory(creator=_Leaf, scope=Scope.APP)
+        root = providers.Factory(creator=_Root, scope=Scope.APP)
+
+    container = Container(groups=[_G], validate=False)
+    real_compile = pr_mod.compile_resolver
+    entered = threading.Event()
+    release = threading.Event()
+    stalled = threading.Event()
+
+    def stalling_compile(
+        provider: AbstractProvider[typing.Any], registry: pr_mod.ProvidersRegistry
+    ) -> typing.Callable[[Container], typing.Any]:
+        if provider is _G.root and not stalled.is_set():
+            stalled.set()
+            entered.set()  # thread 1's pid is now in _building
+            release.wait(timeout=5)
+        return real_compile(provider, registry)
+
+    monkeypatch.setattr(pr_mod, "compile_resolver", stalling_compile)
+    errors: list[BaseException] = []
+
+    def first() -> None:
+        try:
+            container.resolve(_Root)
+        except BaseException as exc:  # noqa: BLE001  # pragma: no cover - pre-fix path only
+            errors.append(exc)
+
+    def second() -> None:
+        entered.wait(timeout=5)  # enter only once thread 1 is mid-compile of _Root
+        try:
+            container.resolve(_Root)
+        except BaseException as exc:  # noqa: BLE001  # pragma: no cover - pre-fix path only
+            errors.append(exc)
+        finally:
+            release.set()  # let thread 1 finish
+
+    threads = [threading.Thread(target=first), threading.Thread(target=second)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors  # pre-fix: thread 2 raises RecursionError (a false cycle)

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -1,0 +1,68 @@
+"""Free-threaded (PEP 703) correctness: concurrent resolution shares singletons.
+
+Hand-rolled thread stress (no plugin dependency) so it runs on every interpreter.
+Under the GIL it passes trivially but still exercises the double-checked cache lock
+and the setdefault-shared CacheItem; on a 3.14t build it runs those paths GIL-free.
+The free-threaded *interpreter* assertion lives in CI (_checks.yml), not here, to
+keep this suite version-agnostic and 100%-line-covered on every build.
+See architecture/concurrency.md.
+"""
+
+import threading
+
+from modern_di import Container, Group, Scope, providers
+
+
+class _Leaf: ...
+
+
+class _Mid:
+    def __init__(self, leaf: _Leaf) -> None:
+        self.leaf = leaf
+
+
+class _Top:
+    def __init__(self, mid: _Mid) -> None:
+        self.mid = mid
+
+
+class _RequestObj:
+    def __init__(self, top: _Top) -> None:
+        self.top = top
+
+
+class _StressGroup(Group):
+    leaf = providers.Factory(creator=_Leaf, scope=Scope.APP, cache=True)
+    mid = providers.Factory(creator=_Mid, scope=Scope.APP, cache=True)
+    top = providers.Factory(creator=_Top, scope=Scope.APP, cache=True)
+    request_obj = providers.Factory(creator=_RequestObj, scope=Scope.REQUEST)
+
+
+def test_concurrent_resolution_shares_app_singletons() -> None:
+    container = Container(groups=[_StressGroup], validate=True)
+    n = 32
+    barrier = threading.Barrier(n)
+    top_results: list[_Top | None] = [None] * n
+    request_ok: list[bool] = [False] * n
+    errors: list[BaseException] = []
+
+    def worker(i: int) -> None:
+        barrier.wait()  # release all threads into resolution at once to maximize contention
+        try:
+            top = container.resolve(_Top)  # APP singleton: one instance shared tree-wide
+            top_results[i] = top
+            with container.build_child_container(scope=Scope.REQUEST) as child:
+                obj = child.resolve(_RequestObj)  # REQUEST obj wiring the shared APP singleton
+                request_ok[i] = obj.top is top  # child sees the same APP instance
+        except BaseException as exc:  # noqa: BLE001  # pragma: no cover - a race would surface here
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert len({id(result) for result in top_results}) == 1  # exactly one shared APP singleton
+    assert all(request_ok)  # every child resolved that same singleton through its request object


### PR DESCRIPTION
Claims free-threaded CPython (PEP 703) support at trove level **`2 - Beta`**, correctness-only — and first fixes a real, pre-existing concurrency bug found while verifying it.

Design & rationale: `planning/changes/2026-07-17.07-nogil-free-threading-support.md`.
Full analysis: `planning/audits/2026-07-17-nogil-support-research-report.md` (its H3 verdict carries an in-file correction — the bug below is the thing it originally dismissed).

## The fix (the foundation)

`ProvidersRegistry.resolver_for` shared its `_building` cycle-guard set across threads. Two threads first-resolving the **same** provider concurrently made the second mistake the first's in-flight compile for a dependency cycle, take the back-edge thunk, and recurse to `RecursionError` on an **acyclic** graph. It reproduces **under the GIL too** (verified on CPython 3.10), so it is not a free-threading artifact. Fixed by making `_building` **thread-local** — the cycle guard is inherently per-call-stack; genuine same-thread `A → B → A` cycles are still detected. A **deterministic** regression test (a monkeypatched compile-stall gate, not sleeps) runs in the gated suite on **every** interpreter, so a future revert fails CI on all cells.

## The Beta support

- **Stress test** (`tests/test_free_threading.py`): 32 threads released on a barrier resolve overlapping APP-singleton graphs off one root; asserts one shared singleton identity and no thread errors. Hand-rolled, no new dependency.
- **CI**: a `3.14t` gated matrix cell (full suite + 100% coverage GIL-free), a hard `assert not sys._is_gil_enabled()`, a `--count=50` stress amplification, and `-W error::RuntimeWarning` on that step so a silent GIL re-enable fails instead of passing trivially.
- **Classifier**: `Programming Language :: Python :: Free Threading :: 2 - Beta`.
- **Docs**: new `architecture/concurrency.md` (the standing contract — thread-local `_building`, the double-checked singleton lock, the Beta stance and its honest object-publication-ordering caveat, the "apply overrides before concurrent resolution" note); retargets the two GIL code comments at it; removes the now-actioned+refuted `deferred.md` A-1 item.

**Beta, not Stable:** CPython gives no formal memory-model guarantee for object-publication ordering; that gap (shared by every lock-free Python singleton) is the reason for the level, and it is documented rather than hidden.

**Out of scope:** parallel-resolution *performance* (report §7).

Local gate green: `just test-ci` 429 passed at 100% coverage, `just lint-ci` clean, `just check-planning` OK; the stress test verified GIL-free on a real `3.14t` interpreter (unmutated 50/50; a cache-lock mutation makes the singleton-identity assertion fail, proving it bites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)