### PR TITLE
docs(release): 2.30.0 notes — free-threaded (Beta) + concurrency fix

### DIFF
--- a/planning/releases/2.30.0.md
+++ b/planning/releases/2.30.0.md
@@ -1,0 +1,70 @@
+# modern-di 2.30.0 — free-threaded (Beta), and a concurrency fix
+
+modern-di now declares free-threaded CPython (PEP 703) support at the Beta trove
+level — and, found while verifying it, this release fixes a real concurrency bug
+that affects **any** supported Python: two threads first-resolving the same
+provider concurrently could raise a spurious `RecursionError`. The fix leads.
+
+## Fixes
+
+- **Concurrent first-resolution of the same provider no longer false-cycles
+  (#344).** `ProvidersRegistry`'s cycle-guard set (`_building`) was shared across
+  threads, so when two threads resolved the same provider for the first time at
+  once, the second could mistake the first's in-flight compile for a dependency
+  cycle, take the runtime back-edge, and recurse to `RecursionError` — on a graph
+  with no cycle at all. The guard is now **thread-local**: it tracks
+  compilation per call stack, so a genuine same-thread `A → B → A` cycle is still
+  detected via the back-edge, while a concurrent first-resolve simply compiles
+  independently (an idempotent duplicate, last-writer-wins on the shared cache).
+  This reproduces **under the GIL too** — it is not specific to free-threaded
+  builds, so any multithreaded resolve on any supported Python benefits. A
+  deterministic regression test (a compile-stall gate, not timing) guards it on
+  every interpreter, so a revert fails CI on all cells.
+
+## Free-threaded (PEP 703) support — Beta
+
+- **`Programming Language :: Python :: Free Threading :: 2 - Beta` (#344).**
+  Being zero-dependency pure Python, modern-di's wheel already imported on
+  free-threaded builds; what is new is that its concurrency is now **verified**.
+  CI runs the full gated suite (100% coverage) on a free-threaded `3.14t`
+  interpreter, with a hard `sys._is_gil_enabled()` assertion, a 32-thread
+  concurrent-resolution stress test, and `-W error::RuntimeWarning` so a silent
+  GIL re-enable fails the run instead of passing trivially. Singleton creation is
+  the only locked path (a double-checked per-container `RLock`); the registry
+  memoization is lock-free and idempotent.
+
+- **Why Beta and not Stable.** CPython publishes no formal memory model, so
+  object-publication ordering rests on the current implementation's behavior, not
+  a spec guarantee — the same reliance every lock-free Python singleton makes.
+  That gap is the reason for the level, and it is documented rather than hidden.
+
+- **One caveat worth repeating:** apply `override()` / `reset_override()` and
+  `set_context` during single-threaded setup, *before* resolving concurrently —
+  mutating a shared registry mid-resolution is inherently unordered (it always
+  was, GIL or not). The full contract lives in
+  [`architecture/concurrency.md`](https://github.com/modern-python/modern-di/blob/main/architecture/concurrency.md).
+
+## Docs & internals
+
+- New [`architecture/concurrency.md`](https://github.com/modern-python/modern-di/blob/main/architecture/concurrency.md)
+  capability page — the standing thread-safety contract (the locked
+  singleton path, the idempotent lock-free memoization, the thread-local cycle
+  guard, the Beta stance and its publication-ordering caveat).
+- The free-threading research and full shared-state hazard inventory are recorded
+  in
+  [`planning/audits/2026-07-17-nogil-support-research-report.md`](https://github.com/modern-python/modern-di/blob/main/planning/audits/2026-07-17-nogil-support-research-report.md)
+  (its H3 verdict carries an in-file correction — the race fixed above is exactly
+  the hazard it first misjudged as self-healing).
+- Two GIL-caveat code comments now point at the capability page; a stale
+  free-threading item in `planning/deferred.md` was removed as actioned.
+- 100% line coverage maintained across Python 3.10–3.14 **and** the new
+  free-threaded `3.14t` cell; `ruff` and `ty` clean.
+
+## Downstream
+
+- **No action needed.** The concurrency fix is a pure correctness improvement
+  with no API change — anyone resolving from multiple threads, on **any** Python
+  version, gets it for free. The Free Threading classifier is advisory; nothing
+  in the public API changed.
+- **Existing integrations:** unaffected — no sibling `modern-di-*` adapter is
+  touched by either change.


### PR DESCRIPTION
Release notes for the next version, covering the just-merged #344.

Draft placement is **2.30.0** (minor bump — free-threaded Beta support is a new capability). Retag/rename if you'd number it differently; the file name tracks the version.

Leads with the concurrency fix (a correctness fix affecting any multithreaded resolve on any Python, GIL or not), then the free-threaded Beta support and its honest "why Beta not Stable" caveat. Per the release convention, the file is used verbatim as the GitHub Release body when the tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)