### PR TITLE
docs: DI concurrency lifecycle contract + C2 memo-swap attempt (dropped)

### DIFF
--- a/architecture/concurrency.md
+++ b/architecture/concurrency.md
@@ -6,6 +6,31 @@ and tested under real multithreading, with the caveats below documented. The
 [2026-07-17 research report](../planning/audits/2026-07-17-nogil-support-research-report.md)
 is the full analysis; this page is the standing contract.
 
+## The lifecycle
+
+A container has three phases, and thread-safety is defined per phase — the same
+build → resolve → dispose shape every comparable DI framework assumes (the
+[2026-07-18 concurrency-contract research](../planning/audits/2026-07-18-di-concurrency-contract-report.md)
+found no framework that supports tearing a container down while other threads
+resolve from it):
+
+1. **Configure — single-threaded (startup).** Registering providers
+   (`add_providers`, group construction) mutates the registry under its own lock,
+   but the resolve path reads the registry without taking that lock; `override` /
+   `reset_override` and `set_context` mutate shared state with no lock at all.
+   Either way, racing these against live `resolve()` is unsafe — do them on one
+   thread before concurrent resolution begins.
+2. **Resolve — concurrent (the hot phase).** `resolve` / `resolve_provider` /
+   `resolve_dependency` and `build_child_container` are safe to call from many
+   threads at once. Singleton creation is locked and double-checked (see below),
+   so a cached value is built exactly once and shared.
+3. **Close — single-threaded (shutdown).** `close_sync` / `close_async` run
+   finalizers and reset caches/overrides; `open` reopens a closed container so it
+   can resolve and build children again. Close (or reopen) a container at a
+   single-threaded edge, after concurrent resolution has quiesced — **closing or
+   reopening a container while other threads still resolve from it is not
+   supported.**
+
 ## The model
 
 - **Singleton creation is the only locked path.** A cached `Factory` builds its
@@ -46,12 +71,11 @@ not **Stable**. See the report for the full argument.
 
 ## Caveats
 
-- **Apply overrides before concurrent resolution.** `override()` / `reset_override()`
-  mutate a shared registry without a lock; racing them against live `resolve()` calls
-  is inherently unordered (it always was, GIL or not). Set overrides during
-  single-threaded setup, then resolve concurrently.
-- **Seed context before concurrent resolution too.** `set_context` writes a shared
-  dict; populate a container's context before resolving from it on many threads.
-- **Performance, not correctness, is the open question.** Whether the per-container
-  lock contends under heavy parallel first-resolution is unmeasured and out of scope
-  for the Beta claim (report §7).
+- **Configure and close at single-threaded edges** (see [The lifecycle](#the-lifecycle)).
+  `override` / `reset_override` and `set_context` mutate shared state without a
+  lock; racing them against live `resolve()` is inherently unordered (it always
+  was, GIL or not). `close` / `open` are the same: tear a container down only
+  after concurrent resolution has stopped.
+- **Performance, not correctness, is the open question.** Whether the
+  per-container lock contends under heavy parallel first-resolution is unmeasured
+  and out of scope for the Beta claim (report §7).

--- a/planning/audits/2026-07-18-di-concurrency-contract-report.md
+++ b/planning/audits/2026-07-18-di-concurrency-contract-report.md
@@ -1,0 +1,171 @@
+# DI-framework concurrency contract: comparative research
+
+How do dependency-injection frameworks handle multithreaded concurrency, and
+what container lifecycle do they assume? Commissioned to decide whether
+modern-di's thread-safety contract — *concurrent resolution is safe; singleton
+creation is locked (double-checked); configure and close happen at
+single-threaded lifecycle edges* — is the field standard (document it) or
+unusually narrow (consider expanding to concurrent teardown). The trigger was
+a free-threaded stress test that surfaced a `RuntimeError` when a container is
+closed **while** other threads resolve from it (the warm-singleton memo-swap
+work, `planning/changes/2026-07-18.01`).
+
+## Method
+
+A fan-out research pass (6 angles, 27 sources fetched, 104 candidate claims,
+25 verified by 3-vote adversarial checking — 24 confirmed, 1 refuted). Sources
+are current primary docs/source unless noted: Microsoft Learn (updated
+2026-03-30), Autofac latest docs, Guice master source, Spring issues/javadoc,
+uber-go/dig + Fx docs, Koin releases, and the Python frameworks' own docs.
+Coverage is uneven — see Caveats; absent frameworks are *unmeasured*, not
+negative.
+
+## Headline
+
+**modern-di's build → resolve → dispose lifecycle with single-threaded
+teardown is the universal field standard. No framework in the evidence set
+offers concurrent disposal-during-resolution as a supported guarantee.** The
+contract should be stated explicitly, not expanded.
+
+## Findings
+
+### 1. Concurrent teardown-during-resolution is supported nowhere (high confidence)
+
+- **.NET** (`Microsoft.Extensions.DependencyInjection`): resolving after
+  disposal *deadlocked* before .NET 6 and now throws `ObjectDisposedException`.
+  Disposal is terminal, never a concurrent-safe path.
+  ([compat note](https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/6.0/service-provider-disposed))
+- **Autofac**: documents thread-safe resolution *and* explicitly warns against
+  teardown-under-resolution — "you must be very careful that the parent scope
+  doesn't get disposed out from under the spawned thread," and "you can get
+  into a bad situation where components can't be resolved if you spawn the
+  thread and then dispose the parent scope."
+  ([concurrency](https://docs.autofac.org/en/latest/advanced/concurrency.html),
+  [instance-scope](https://docs.autofac.org/en/latest/lifetime/instance-scope.html))
+- **Guice**: `SingletonScope` addresses only construction/initialization
+  concurrency; there is no dispose/shutdown lifecycle at all.
+  ([source](https://github.com/google/guice/blob/master/core/src/com/google/inject/internal/SingletonScope.java))
+- **Uber Fx** (Go): an explicit two-phase `initialization → execution`
+  lifecycle (OnStart hooks, then OnStop hooks) — build/run/teardown, not
+  concurrent teardown. ([lifecycle](https://uber-go.github.io/fx/lifecycle.html))
+- **Koin**: as recently as 4.2.1 had to *fix* a `Scope._closed` non-volatile
+  memory-visibility bug (#2389) — even where concurrent-close state is
+  contemplated, it has been a bug source, not a clean guarantee.
+  ([4.2.1](https://github.com/InsertKoinIO/koin/releases/tag/4.2.1))
+
+### 2. Concurrent resolution after build is the near-universal guarantee — construction only (high)
+
+.NET verbatim: "Once an `IServiceProvider` or `IServiceScope` has been built,
+it's safe to resolve services concurrently from multiple threads," with the
+note that this "doesn't make the resolved service instances themselves
+thread-safe." Autofac: "All container operations are safe for use between
+multiple threads" (while resolution-context objects are single-threaded).
+that-depends: Singleton is "thread-safe and async-safe." The guarantee is
+scoped to the post-build phase and covers *getting* the instance, never the
+instance's own thread-safety.
+([.NET guidelines](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection/guidelines))
+
+### 3. Configure/registration is a single-threaded startup phase (high)
+
+Autofac verbatim: "ContainerBuilder and ComponentRegistryBuilder are not
+thread-safe and are designed to be used only on a single thread at the time
+the application starts up." .NET's model (thread-safety applies only after the
+provider/scope is built) is the same shape. This mirrors modern-di's rule that
+`register`/`override`/`set_context` happen at single-threaded edges.
+
+### 4. Singleton creation is locked, usually double-checked (high)
+
+Guice: per-binding lock + double-checked locking over a volatile field
+("double-checked locking for quick exit when scope is initialized"). .NET: the
+singleton factory "is guaranteed to be called only once by a single thread"
+(like a static constructor). Spring: `DefaultSingletonBeanRegistry`
+synchronizes singleton access (a lenient `ReentrantLock` scheme since 6.2;
+`getSingletonMutex` deprecated). that-depends: "If multiple threads call
+`resolve_sync()` at the same time, the factory is only called once." This
+double-checked pattern is exactly modern-di's approach.
+
+### 5. A design mistake modern-di already avoids (high)
+
+Both Spring and .NET hit **deadlocks from holding the singleton-creation lock
+while running user factory code**. Spring #23501 verbatim: "This call into user
+code while holding a lock can result in deadlock" → Spring 6.2 introduced
+lenient singleton locking. .NET PR #46157 moved from a global lock to a
+per-singleton-call-site lock for the same reason. modern-di already resolves
+the dependency graph **outside** the lock (only creation + the cache store run
+under it — `architecture/concurrency.md`), so it is on the correct side of a
+bug two major frameworks had to fix.
+([Spring #23501](https://github.com/spring-projects/spring-framework/issues/23501),
+[.NET PR #46157](https://github.com/dotnet/runtime/pull/46157))
+
+### 6. Python singleton thread-safety varies widely (high)
+
+- **that-depends**: Singleton "is thread-safe and async-safe."
+- **dependency-injector**: default Singleton is *NOT* thread-safe ("Otherwise
+  you could trap into the race condition problem: Singleton will create
+  multiple objects"); thread-safety is opt-in via `ThreadSafeSingleton` /
+  `ThreadLocalSingleton`.
+- **dishka**: the APP-scope container has a lock by default, but deeper
+  concurrently-entered child scopes need an explicit `lock_factory` or "you
+  cannot guarantee that only one instance of that object is created" — and the
+  caller must pick the right lock type ("threading and asyncio locks are not
+  interchangeable").
+
+modern-di's default double-checked locking on singleton creation sits on the
+safer end of this spread.
+([dependency-injector](https://python-dependency-injector.ets-labs.org/providers/singleton.html),
+[dishka](https://dishka.readthedocs.io/en/stable/container/index.html),
+[that-depends](https://that-depends.modern-python.org/providers/singleton/))
+
+### 7. Free-threading (PEP 703) is a near-empty field — a modern-di differentiator (medium)
+
+Of the covered Python frameworks, **only wireup** makes an explicit no-GIL
+claim: its README says it is "thread-safe, no-GIL (PEP 703) ready, and
+fail-fast by design." This is a self-advertisement with **no documented locking
+mechanism and no independent audit**. dishka, dependency-injector, and
+that-depends make no explicit free-threading statements (that-depends documents
+thread-/async-safe singletons but does not mention 3.13t/3.14t). modern-di's
+Beta free-threaded support with an actual tested, documented mechanism is thus
+a stronger claim than the only stated peer.
+([wireup](https://github.com/maldoinc/wireup))
+
+## What this means for modern-di
+
+1. **Document the lifecycle contract explicitly; do not expand it.** State the
+   positive model — configure (single-threaded) → resolve and child-container
+   build (concurrent) → close/teardown (single-threaded) — in
+   `architecture/concurrency.md`, replacing the current caveat-list framing. The
+   teardown-during-resolution finding that triggered this research is an
+   out-of-contract scenario by the field-standard definition; no comparable
+   framework promises otherwise.
+2. **The free-threaded story is a positioning edge.** An *explicit* lifecycle
+   contract plus real Beta no-GIL support is a clarity advantage in a field
+   that is either silent or (wireup) unaudited on PEP 703.
+3. **The graph-resolves-outside-the-lock design is validated** against the
+   Spring/.NET deadlock history — worth stating as a deliberate choice, not an
+   accident.
+
+## Caveats and coverage gaps
+
+- **No surviving verified evidence** for svcs, python-injector, punq, Dagger
+  (compile-time; runtime concurrency largely N/A), uber-go/dig and Fx internals
+  beyond the cited issues/docs, or Koin beyond release notes/issues.
+  Conclusions about those are **absent, not negative**.
+- The **wireup** free-threading line is marketing, not an audit; its actual
+  locking strategy is undocumented.
+- One refuted claim: that Spring guards singleton creation with a *coarse
+  per-registry monitor* (0-3) — the current scheme is the lenient
+  `ReentrantLock` (since 6.2); exact internals are version-sensitive.
+- Python framework docs move fast; verify against the installed version before
+  relying on exact behavior.
+- Everywhere, "thread-safe resolution" means construction/resolution only —
+  never that resolved instances are themselves thread-safe.
+
+## Open questions
+
+- Do svcs, python-injector, punq, or the Go frameworks make any thread-safety
+  or free-threaded statements, and do any support concurrent scope disposal?
+- What is wireup's actual locking strategy behind its "no-GIL ready" claim, and
+  has anyone tested it under 3.13t/3.14t?
+- Does *any* framework, in any language, genuinely support tearing down a scope
+  while other threads resolve (reference-counting, epoch/RCU, drain-then-dispose)
+  — or is single-threaded teardown truly universal?

--- a/planning/changes/2026-07-18.01-warm-singleton-memo-swap.md
+++ b/planning/changes/2026-07-18.01-warm-singleton-memo-swap.md
@@ -1,0 +1,167 @@
+---
+summary: ATTEMPTED AND DROPPED (2026-07-18). Built the spike-gated warm-singleton resolver memo-swap (APP-scope, override/close/version-bump invalidation, free-threaded 200/200, 100% cov); measured ~1.6x warm-hit reduction (flips ahead of dishka but misses the ≥2x gate — the resolve_provider dispatch floor caps the win). Dropped: a ~1.6x win did not justify the permanent cross-cutting invalidation invariant. Keepers: the explicit lifecycle contract in concurrency.md and the DI-concurrency-contract audit report. See ## Outcome.
+---
+
+# Design: Warm-singleton resolver memo-swap (C2 lever)
+
+## Summary
+
+After an **APP-scoped** cached `Factory` builds its singleton for the first
+time, replace that provider's entry in the shared `ProvidersRegistry._resolvers`
+memo with a bare `lambda c: value` closure. Every subsequent warm hit then
+executes `return value` — skipping the override front-guard, scope compare,
+closed check, `fetch_cache_item` nested frame, and sentinel check that today's
+cached resolver pays on every call (`resolver_compiler.py:215-236`). This is the
+wireup self-modifying-closure technique, adapted to modern-di's shared-registry /
+per-container-cache split. It is a **measurement-gated spike**: build it, bench
+C2, and ship only if the warm hit clears the kill-gate below — otherwise record
+the negative result and drop, so none of the invalidation coupling lands.
+
+## Motivation
+
+The single-path compiled resolver (change `2026-07-16.02`, PR #334) left one
+perf lever open, tracked in `planning/deferred.md`: the warm-singleton hit is
+**292 ns**, 3-4.8x slower than the slot/memoized rivals (dishka codegen ~245 ns,
+wireup self-modifying closure ~98 ns, that-depends lock-free slot ~85 ns,
+dependency-injector C-level slot ~61 ns). modern-di still pays `resolver_for`
+dispatch + the override front-guard + `fetch_cache_item` on every warm hit. The
+wireup technique makes the warm hit near-free; the deferred note flagged it as
+non-trivial here (shared resolver, per-container cache) and asked to **measure
+whether the added machinery is worth closing C2 to ~dishka**. This bundle is
+that measurement, with a pre-committed ship bar.
+
+## Design
+
+**Soundness boundary (why APP-only).** Each root container owns its own
+`ProvidersRegistry` (`container.py:108`); children share the parent's
+(`:105`). So there is a clean 1:1:1 — **one registry ↔ one APP container ↔ one
+APP-singleton value**. Only an APP singleton has a single tree-wide value that a
+registry-level constant can legitimately return. A SESSION/REQUEST singleton is
+cached per child container, so a shared-registry constant would be wrong. The
+swap therefore applies only to `type(provider) is Factory and
+provider.cache_settings is not None and provider.scope == Scope.APP`. Transient
+factories, deeper-scoped singletons, aliases, context/container providers are
+never swapped.
+
+**Install.** In `_compile_cached_factory`'s `resolve`, on the cold-miss branch,
+after `mark_created`, only when `created is True` and the APP-scope predicate
+holds: call `registry.install_warm_resolver(pid, value)`. That overwrites
+`_resolvers[pid] = (version, lambda c: value)` and stashes the displaced compiled
+resolver in a new `_warm_original[pid]` for O(1) restore. Keeping the mutation
+inside the registry preserves "the registry owns its `_resolvers` storage."
+
+**Dispatch — unchanged.** `resolver_for` still returns whatever `_resolvers[pid]`
+holds (one dict.get + version check). No new cost on the dispatch path; the win
+is entirely in the swapped closure body.
+
+**Invalidate** (restore the compiled resolver from `_warm_original`):
+
+- **Registry mutation — free.** A `version` bump staledates the stamp, so
+  `resolver_for` recompiles the real resolver on the next call. Covers
+  `add_providers` / `register` / `_remove_providers`.
+- **`override(pid)`** — un-swap that pid in `Container.override` (both registries
+  are reachable there) so the front-guard runs again and returns the mock.
+  `reset_override` needs no action: an overridden pid was already un-swapped and
+  is not re-armed (a warm cache means no later cold-miss to re-swap — accepted).
+- **Root close** (`close_sync`/`close_async`, the existing
+  `if not self.parent_container` branch) — invalidate **all** swaps. This blunt
+  form does double duty: it drops a possibly-cleared value (`clear_cache=True`)
+  *and* restores the closed-container warn/reopen shim that a bare closure would
+  otherwise bypass (the swap skips the `target.closed` check). Chosen over
+  per-cache-item conditional invalidation because the semantic restoration is
+  worth more than re-arming the swap across a rare root reopen.
+
+**Free-threaded soundness (enabled everywhere).** install/invalidate are single
+dict-item stores on `_resolvers`, atomic under both the GIL and PEP 703 per-dict
+locking. A concurrent `resolver_for` reader sees either the old compiled resolver
+(correct: normal warm path) or the new constant (correct) — no torn state, no
+read-path lock. Only the create-winner (`created is True`) installs, so at most
+one installer per pid. One benign race: a first-cold concurrent compile could
+overwrite a just-installed swap with the compiled resolver — costing the
+optimization for that pid, never correctness.
+
+## Non-goals
+
+- **Deeper-scoped singletons.** SESSION/REQUEST/ACTION/STEP keep today's warm
+  path — no per-container value fits a shared-registry constant.
+- **The codegen ceiling (C1/C3).** `exec`-inlining stays rejected (zero-dep);
+  not touched here.
+- **The per-container slot fallback.** If the memo-swap fails its free-threaded
+  stress test or the bar, a fresh bundle opens for the that-depends-style
+  per-APP-container slot array; it is not pre-built or pre-authorized here.
+
+## Testing
+
+- **Correctness** (`just test`): override-after-warm returns the mock; reset
+  restores the singleton; `add_providers` invalidates the swap; root close/reopen
+  rebuilds (or retains per `clear_cache`) and re-checks closed semantics; a
+  swapped APP singleton and a non-swapped REQUEST singleton coexist in one tree.
+- **Free-threaded stress test**: N threads hammering a warm APP singleton while
+  one thread flips `override`/`reset_override` and another closes/reopens the
+  root, asserting no stale or torn returns. Runs on the free-threaded build.
+- **Gate** (`just test-ci`): 100% line coverage on the new install/invalidate
+  branches.
+- **Benchmark**: the existing C2 warm-singleton scenario in the comparative
+  tier, median-of-medians over 5 runs, same protocol as the deferred note.
+
+**Kill-gate.** Ship **iff** the warm hit is **≤ ~146 ns** (≥2x / at least
+halved) **and** below dishka's ~245 ns, with zero correctness regression and a
+green free-threaded stress test. Below the bar → update the C2 entry in
+`planning/deferred.md` with the measured negative result and drop the bundle; no
+coupling lands.
+
+## Risk
+
+- **Free-threaded regression on the just-stabilized hot path** (low likelihood ×
+  high impact). 2.30 fixed a `resolver_for` race; this adds hot-path memo
+  mutation. Mitigation: the stress test is a hard gate, and the swap is a single
+  atomic store with a proven old-or-new-both-correct reader invariant.
+- **Closed-container semantics drift** (low × medium): a bare closure skips the
+  `target.closed` reopen shim. Mitigated by invalidate-all-on-root-close, which
+  restores the normal path after close.
+- **Machinery not worth the win** (medium × low): the coupling of the resolver
+  memo to override/close may not earn its keep. Mitigated by the kill-gate —
+  below the bar, nothing ships but a recorded measurement.
+
+## Promotion
+
+On ship, in the implementing PR: `architecture/concurrency.md` (the swap + its
+free-threaded reasoning) and `architecture/providers.md` (APP-scope warm caching
+now memo-swaps). On drop: only the `planning/deferred.md` C2 entry.
+
+## Outcome (2026-07-18): dropped
+
+The mechanism was built exactly as designed and fully tested (free-threaded
+`--count=100` 200/200, `test-ci` 100% coverage), then **reverted**. The design
+here stands as the record of the attempt.
+
+**Measured (best-of-3, stable medians; machine-relative):** guard g2 warm hit
+584→375 ns; comparative C2 333→208 ns — a consistent **~1.6x** reduction that
+**flips modern-di ahead of dishka** (292 ns) but **misses the ≥2x / ≤146 ns
+kill-gate**. Root cause: `resolve_provider`'s dispatch floor
+(`_warn_and_reopen_if_closed` frame + `resolver_for` dict.get + version check)
+is unremovable by the swap; unlike wireup, modern-di keeps the
+resolve→resolver_for dispatch, so "near-free" was never architecturally
+reachable.
+
+**Why dropped (maintainer ruling):** a ~1.6x win did not justify a permanent
+cross-cutting invariant — a bypass resolver spanning override/close/add_providers
+plus a second source of truth (`_warm_swapped`) — against the
+conservative-feature-set and legibility principles.
+
+**Two mid-course events, both keepers:**
+1. The free-threaded stress test surfaced that close-during-resolve was not
+   torn-free, which triggered the [DI-concurrency-contract
+   research](../audits/2026-07-18-di-concurrency-contract-report.md): the
+   build→resolve→dispose lifecycle with single-threaded teardown is the
+   universal field standard. That is now stated explicitly in
+   [`architecture/concurrency.md`](../../architecture/concurrency.md).
+2. The attempt revealed a better direction — the **dispatch-floor
+   simplification** (invalidate-on-mutation instead of version-stamp-per-resolve),
+   recorded in [`planning/deferred.md`](../deferred.md). It *removes* per-resolve
+   work rather than adding a bypass, and is licensed by the now-explicit lifecycle
+   contract.
+
+Reverted commits restored `providers_registry.py`, `resolver_compiler.py`,
+`container.py`, and their tests to the pre-swap state; `concurrency.md` and the
+audit report were kept.

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -31,18 +31,58 @@ lifecycle, and trails the two `exec`-codegen frameworks by 1.3-1.9x on transient
   (unlike wireup): the resolver is shared tree-wide on the registry while the cached value is
   per-container, so a bare swap is only sound for **APP-scoped** singletons (one value tree-wide), and it
   must be invalidated on runtime `override()`/`reset_override()` and on cache clear at container close —
-  coupling the swap to those paths. A safe design restricts to APP scope and hooks override/close
-  invalidation; measure whether the added machinery is worth closing C2 to ~dishka.
+  coupling the swap to those paths. **Attempted and dropped (2026-07-18, change
+  [`2026-07-18.01`](changes/2026-07-18.01-warm-singleton-memo-swap.md)):** built the APP-scope-restricted
+  swap with override/close/version-bump invalidation, fully tested (free-threaded 200/200, 100% cov).
+  Measured **~1.6x** warm-hit reduction (median-of-stable, both tiers: guard g2 584→375 ns; comparative C2
+  333→208 ns), which **flips modern-di ahead of dishka** (292 ns) but **misses the ≥2x / ≤146 ns bar**. Root
+  cause: `resolve_provider`'s dispatch floor (`_warn_and_reopen_if_closed` frame + `resolver_for` dict.get +
+  version check) is unremovable by the swap — unlike wireup, modern-di keeps the resolve→resolver_for
+  dispatch, so "near-free" is not architecturally reachable. Dropped because a ~1.6x win did not justify a
+  permanent cross-cutting invalidation invariant (a bypass resolver across override/close/add_providers, a
+  second source of truth in `_warm_swapped`) against the conservative-feature-set principle. The attempt did
+  produce two keepers: the explicit lifecycle contract in [`concurrency.md`](../architecture/concurrency.md)
+  and the [DI-concurrency-contract research](audits/2026-07-18-di-concurrency-contract-report.md). The
+  better next direction it revealed is the **dispatch-floor simplification** below, not this swap.
 - **The codegen ceiling on C1/C3.** The remaining 1.3-1.9x behind `dishka`/`wireup` on transient/chain is
   the cost of staying `exec`-free: both inline dependency calls into generated source, removing the
   per-node closure-call frame that modern-di keeps. Closing it needs `exec` codegen, **rejected** for a
   zero-dependency library (competitor-perf audit §1/§4). So ~1.3-1.9x behind the codegen leaders on
   construction-heavy graphs is the accepted floor without `exec`; revisit only if that stance changes.
 
-**Revisit trigger:** a user-reported warm-singleton bottleneck, or a decision to prioritize closing the
-`dishka` gap. The C2 lever is the concrete next step; the codegen ceiling is a stance, not a task.
+**Revisit trigger:** a user-reported warm-singleton bottleneck. The C2 swap was tried and dropped (above);
+the codegen ceiling is a stance, not a task. The live next step is the dispatch-floor simplification below.
 See the [competitor-perf research](audits/2026-07-16-competitor-perf-research-report.md) (the design
 evidence: closures capture ~80-90% of the ceiling, `exec` buys 0-4% at fixed arity).
+
+## Dispatch-floor simplification: invalidate-on-mutation instead of version-stamp-per-resolve — from the 2026-07-18 C2 attempt
+
+The C2 swap tried to *add* a bypass layer and capped at ~1.6x because it could not remove
+`resolve_provider`'s dispatch floor. The inverse — *removing* per-resolve work — is the better trifecta
+(simpler + more readable + faster), and the explicit lifecycle contract now licenses it.
+
+Today every `resolver_for` / `plan_for` call does `cached = dict.get(pid); if cached and cached[0] ==
+version: return cached[1]` — a tuple-unpack + int-compare on the hot path (`providers_registry.py`), purely
+to guard against a registry mutation that (per the now-explicit configure→resolve→close lifecycle) only
+happens during single-threaded configure. **Refactor:** on `register` / `add_providers` / `_remove_providers`,
+`clear()` the resolver + plan memos; store bare callables (drop the version tuple). The hot path becomes a
+plain `self._resolvers.get(pid)`, recompile-on-miss.
+
+- **Simpler + readable:** the memos become plain `dict[int, Callable]`; the invariant collapses to "the memo
+  is valid until the registry changes, and changing it clears the memo," replacing the snapshot-version-before-build
+  subtlety (a whole docstring paragraph today). Keep `_version` only for `is_validated` (validation
+  freshness), decoupled from the memo.
+- **Faster:** removes the per-resolve tuple-index + int-compare — part of the exact dispatch floor that
+  capped C2. No new state (removes the version tuples).
+- **Companion (optional):** post-3.0, `_warn_and_reopen_if_closed` collapses to an inlined `if self.closed:
+  raise` (closed→error, which the [DI-concurrency research](audits/2026-07-18-di-concurrency-contract-report.md)
+  validates against .NET's `ObjectDisposedException`) — one fewer dispatch frame.
+
+**Needs (like C2):** a design pass, a free-threaded soundness check (`clear()` vs `get()` race only during
+configure, which the contract puts out of bounds — verify), and a benchmark to confirm the win before
+asserting a number.
+
+**Revisit trigger:** the live next perf step; pick up when perf work resumes.
 
 ## Opt-in DEBUG resolution tracing (ERR-8) — from 2026-07-05 3.0 UX research
 


### PR DESCRIPTION
Docs-only. Nets to no code change: the C2 warm-singleton memo-swap was built and fully tested, measured, and dropped — this PR keeps the durable outputs the attempt produced.

## What lands
- **Explicit thread-safety lifecycle contract** (`architecture/concurrency.md`): replaces the implicit caveat-list with a positive three-phase model — configure (single-threaded) → resolve + child-build (concurrent) → close (single-threaded) — and states that closing/reopening a container while other threads resolve is unsupported.
- **DI-concurrency-contract research report** (`planning/audits/2026-07-18-...`): verified comparative research (25 adversarially-checked claims) establishing that the build→resolve→dispose lifecycle with single-threaded teardown is the universal field standard, and that free-threading (PEP 703) is a near-empty field (only wireup claims it, unaudited).
- **C2 attempt record** (`planning/changes/2026-07-18.01-...` `## Outcome`, `planning/deferred.md`): the memo-swap measured ~1.6x on the warm hit (flips ahead of dishka, misses the ≥2x gate — `resolve_provider`'s dispatch floor is unremovable by the swap), so it was dropped rather than carry a permanent cross-cutting invalidation invariant for a sub-2x win.

## The better next direction (recorded, not done here)
`deferred.md` now lines up the inverse approach: a **dispatch-floor simplification** — invalidate-on-mutation instead of version-stamp-per-resolve — which *removes* per-resolve work (simpler + faster) and is licensed by the now-explicit lifecycle contract.

Full rationale in the [change bundle](planning/changes/2026-07-18.01-warm-singleton-memo-swap.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)