### PR TITLE
perf(compiler): drop compile-time inspect.signature from positional fast-path predicate

### DIFF
--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -27,7 +27,14 @@ class CacheSettings(typing.Generic[types.T_co]):
 
 
 class Factory(AbstractProvider[types.T_co]):
-    __slots__ = ("_cached_definition_site", "_creator", "_kwargs", "_parsed_kwargs", "cache_settings")
+    __slots__ = (
+        "_cached_definition_site",
+        "_creator",
+        "_has_positional_only_gap",
+        "_kwargs",
+        "_parsed_kwargs",
+        "cache_settings",
+    )
 
     def __init__(  # noqa: C901, PLR0913
         self,
@@ -69,8 +76,9 @@ class Factory(AbstractProvider[types.T_co]):
                 )
             parsed_type: type | None = None
             parsed_kwargs: dict[str, SignatureItem] = {}
+            has_positional_only_gap = False
         else:
-            return_sig, parsed_kwargs = parse_creator(creator)
+            return_sig, parsed_kwargs, has_positional_only_gap = parse_creator(creator)
             parsed_type = return_sig.arg_type
             if kwargs:
                 self._validate_kwargs_against_signature(creator, kwargs, parsed_kwargs)
@@ -87,6 +95,7 @@ class Factory(AbstractProvider[types.T_co]):
                     ),
                 )
         self._parsed_kwargs = parsed_kwargs
+        self._has_positional_only_gap = has_positional_only_gap
         super().__init__(scope=scope, bound_type=parsed_type if isinstance(bound_type, types.UnsetType) else bound_type)
         self._creator = creator
         self.cache_settings = resolved_cache

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -6,7 +6,6 @@ dependencies' resolvers by reference. Behavior-sensitive helpers (`_resolution_s
 `_resolve_context_value`, `prepend_step`) are reused, not reimplemented.
 """
 
-import inspect
 import typing
 
 from modern_di import exceptions, types
@@ -45,10 +44,7 @@ def _positional_names(f: "Factory[typing.Any]", plan: "WiringPlan") -> "tuple[st
         return None  # a param was omitted/reordered, or a kwargs-overlay added an extra -> not a clean prefix
     if any(item.is_keyword_only for item in f._parsed_kwargs.values()):  # noqa: SLF001
         return None
-    if names and any(
-        p.kind is inspect.Parameter.POSITIONAL_ONLY
-        for p in inspect.signature(f._creator).parameters.values()  # noqa: SLF001
-    ):
+    if names and f._has_positional_only_gap:  # noqa: SLF001
         return None  # positional-only param, dropped from _parsed_kwargs by the parser, would shift positional binding
     return names
 

--- a/modern_di/types_parser.py
+++ b/modern_di/types_parser.py
@@ -91,10 +91,8 @@ def parse_creator(
 ) -> tuple[SignatureItem, dict[str, SignatureItem], bool]:
     """Return (return-type item, name→param item, has_positional_only_gap).
 
-    ``has_positional_only_gap`` is True when a positional-only parameter was dropped from the
-    param map (positional-only-with-default). The compiled positional fast path consults it so it
-    never binds a dependency into a dropped positional-only slot — the one param-kind signal it
-    would otherwise have to re-introspect the signature for.
+    ``has_positional_only_gap`` is True when a positional-only-with-default parameter was dropped
+    from the param map, so the map is no longer a faithful positional prefix of the signature.
     """
     try:
         sig = inspect.signature(creator)

--- a/modern_di/types_parser.py
+++ b/modern_di/types_parser.py
@@ -86,11 +86,20 @@ def _parse_parameter(
     return item
 
 
-def parse_creator(creator: typing.Callable[..., typing.Any]) -> tuple[SignatureItem, dict[str, SignatureItem]]:
+def parse_creator(
+    creator: typing.Callable[..., typing.Any],
+) -> tuple[SignatureItem, dict[str, SignatureItem], bool]:
+    """Return (return-type item, name→param item, has_positional_only_gap).
+
+    ``has_positional_only_gap`` is True when a positional-only parameter was dropped from the
+    param map (positional-only-with-default). The compiled positional fast path consults it so it
+    never binds a dependency into a dropped positional-only slot — the one param-kind signal it
+    would otherwise have to re-introspect the signature for.
+    """
     try:
         sig = inspect.signature(creator)
     except (ValueError, TypeError):
-        return SignatureItem.from_type(typing.cast(type, creator)), {}
+        return SignatureItem.from_type(typing.cast(type, creator)), {}, False
 
     is_class = isinstance(creator, type)
     try:
@@ -108,12 +117,17 @@ def parse_creator(creator: typing.Callable[..., typing.Any]) -> tuple[SignatureI
         type_hints = {}
 
     param_hints = {}
+    has_positional_only_gap = False
     for param_name, param in sig.parameters.items():
         if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
             continue
         item = _parse_parameter(creator, param_name, param, type_hints)
-        if item is not None:
-            param_hints[param_name] = item
+        if item is None:
+            # positional-only-with-default: dropped from param_hints, so a positional creator()
+            # call would bind a later dependency into this slot -> fast path must keep **kwargs.
+            has_positional_only_gap = True
+            continue
+        param_hints[param_name] = item
 
     if is_class:
         return_sig = SignatureItem.from_type(creator)
@@ -125,4 +139,4 @@ def parse_creator(creator: typing.Callable[..., typing.Any]) -> tuple[SignatureI
     else:
         return_sig = SignatureItem()
 
-    return return_sig, param_hints
+    return return_sig, param_hints, has_positional_only_gap

--- a/planning/audits/2026-07-19-cold-and-cycle-hotspot-hunt-report.md
+++ b/planning/audits/2026-07-19-cold-and-cycle-hotspot-hunt-report.md
@@ -1,0 +1,160 @@
+# Cold / cycle hotspot hunt: profiling paths the C1-C4 audits under-exercise
+
+Where does modern-di spend time on paths the existing benchmark tiers and the
+competitor-perf audit did **not** mine — the one-time cold first-resolve
+(compile), the realistic per-request cycle (build child -> resolve -> close),
+and a deeper line-level look at the C1-C4 steady state? Commissioned as a
+token-frugal, profiler-driven search for **new** optimization opportunities not
+already in `planning/deferred.md`. The trigger was that the shipped perf work
+(single-path compiled resolver #334, dispatch-floor #347, `_next_deeper` memo
+#348) has repeatedly mined C1-C4 steady state, so a fresh hotspot is likelier to
+hide in the paths those benchmarks never time.
+
+## Method
+
+`cProfile` + `pstats` over three driver shapes reusing the guard/comparative
+graph definitions (`Dep`/`Service`, chain-6, cached REQUEST connection). Output
+filtered to `modern_di` for the per-target summaries, then re-run unfiltered on
+the standout target to attribute stdlib cost. The one headline candidate was
+then validated with a throwaway monkeypatch (no repo change) under wall-clock
+`perf_counter`, not cProfile, to get a profiler-overhead-free magnitude. Every
+candidate was cross-checked against `deferred.md` so only **new** findings are
+filed here; known items get a one-line cross-ref.
+
+**Interpreter caveat:** run on CPython **3.10 x86_64** (the repo's `--no-sync`
+default venv on this machine), not the M2 / py3.14 of
+`.superpowers/plans/benchmark-results.md`. Absolute microseconds are
+interpreter-specific; read the **ratios and the call attribution**, which hold
+across versions because the finding is structural (a duplicated call), not
+constant-factor. Drivers: session scratchpad `profile_hotspots.py` (git-ignored,
+not committed).
+
+## Per-target profile summary
+
+Times are total wall for the profiled loop; per-cycle in the prose.
+
+### Cold first-resolve (fresh `Container(groups=[...])` + first `resolve()`)
+
+Per-cycle figures here are **under cProfile** (roughly 2x inflated by profiler
+overhead — the same chain-6 cold cycle is 99.8 µs on clean wall-clock, see
+Candidate 1); read them for relative attribution, not as absolutes.
+
+| Graph | per cold cycle | top `modern_di` frame (cumtime share) |
+|---|---|---|
+| transient (2-node) | ~78 µs | `_compile_transient_factory` (72%) |
+| chain-6 | ~230 µs | `_compile_transient_factory` (89%) |
+| build-only (ctor, no resolve) | ~15 µs | `container.__init__` + `group.get_named_providers` |
+
+Cold is dominated by the **one-time compiled-closure build**, not container
+construction (build-only is ~15 µs of the 230 µs). Unfiltered attribution of the
+chain-6 cold run is decisive: **`inspect.signature` and its callees are 2.57 s of
+4.57 s = ~56% of total cold time** (`_signature_from_callable` 2.57 s cum,
+`_signature_from_function` 0.97 s, `Parameter.__init__` 0.31 s,
+`_signature_bound_method` 0.32 s, `unwrap` 0.21 s, `get_annotations` 0.13 s).
+Every bit of it is triggered by `_positional_names` (`resolver_compiler.py:33`),
+which calls `inspect.signature(f._creator)` at compile — see Candidate 1.
+
+### Realistic request cycle (`build_child_container` + resolve cached REQUEST conn + `close_sync`)
+
+~11.7 µs/cycle, spread across three areas (tottime, `modern_di` only):
+
+- **Construction** — `container.__init__` 0.135 (cum 0.197) + `build_child_container` 0.056. The child-alloc trio (RLock / CacheRegistry / ContextRegistry). *Already banked.*
+- **Resolve (cold-miss cache path)** — `resolve` 0.101, `get_or_create` 0.084, `build_kwargs` 0.083, `fetch_cache_item` 0.066, `resolve_provider` 0.054, `mark_created` / `resolver_for` / lambda / `_call_creator` ~0.02 each.
+- **Close** — `CacheItem.close_sync` 0.073 (cum 0.210) + `CacheRegistry.close_sync` 0.054 (cum 0.269) + `container.close_sync` 0.026 + `_clear` 0.022.
+
+No single dominant frame; the cycle is genuinely distributed. The largest lever
+(construction) is the already-banked lazy-alloc trio. See Candidates 2-3 for the
+two small new observations.
+
+### Deeper C1-C4 steady state (warm container, resolve-only loop)
+
+- **C1 transient / C3 chain-6:** `resolve_positional` (`resolver_compiler.py:95`) + its arg listcomp (`:107`) are ~76% of resolve time (C3: 0.590 + 0.221 tottime, called 6x/resolve recursively). This **is** the per-node closure-call frame — the codegen ceiling. *Already banked / stance.*
+- **C2 warm singleton:** `resolve_provider` 0.081 + `resolve` 0.056 + `fetch_cache_item` 0.034 + `resolver_for` 0.034 — the dispatch floor. *Already banked (C2 swap dropped).*
+
+Nothing new at line granularity here; the audits' function-level picture holds.
+
+## Candidate NEW hotspots
+
+### Candidate 1 — compile-time `inspect.signature` duplication (RECOMMEND: ship)
+
+- **Where:** `resolver_compiler.py:48-52`, inside `_positional_names`:
+  ```python
+  if names and any(
+      p.kind is inspect.Parameter.POSITIONAL_ONLY
+      for p in inspect.signature(f._creator).parameters.values()
+  ):
+      return None
+  ```
+- **Cost:** ~56% of cold first-resolve (chain-6), one full `inspect.signature`
+  build per provider-with-params, every compile.
+- **Why it is pure waste:** `parse_creator` (`types_parser.py:91`) **already**
+  calls `inspect.signature(creator)` at Factory construction and **already
+  inspects positional-only params** — `_parse_parameter` (`:62-72`) silently
+  drops a positional-only-with-default param from `param_hints`, which is exactly
+  the shift `_positional_names` re-detects. The information the compile-time call
+  recovers was in hand at construction and thrown away.
+- **Fix hypothesis:** `parse_creator` records a `bool` (e.g.
+  `has_dropped_positional_only`, True iff it dropped such a param) alongside
+  `param_hints`; `Factory` stores it; `_positional_names` consults the flag
+  instead of calling `inspect.signature`. **Same decision, zero behavior change**,
+  the entire `inspect.signature` subtree leaves the compile path.
+- **Measured ceiling (validated, monkeypatch, wall-clock):** chain-6 cold
+  first-resolve **99.8 µs -> 41.2 µs, −59% (2.4x)**. The real flag-based fix
+  lands just under this ceiling (it still does one bool check).
+- **Risk:** low. Compile-time only; **no resolve hot-path change** (unlike the
+  banked lazy-alloc trio, this adds no per-resolve branch). Touch surface:
+  `_positional_names`, `parse_creator`'s return shape, `Factory` storage. TDD:
+  a positional-only-with-default creator must still take the kwargs path (the
+  existing correctness case the branch guards) — assert the flag reproduces it.
+- **Who benefits:** startup / short-lived processes (serverless cold start, CLI,
+  test suites building many fresh containers) and every app's first-resolve of
+  each provider. It does **not** help steady state (compile is memoized per
+  registry). Framed honestly, this is a **cold-path / startup** win, plus a
+  genuine simplification (removes a redundant introspection), not a throughput
+  win.
+
+### Candidate 2 — double closed-check per `resolve_provider` (OBSERVE, do not action)
+
+`resolve_provider` (`container.py:200`) calls `self._warn_and_reopen_if_closed()`
+on entry, and the compiled resolver **also** re-checks `if target.closed:`
+(`resolver_compiler.py:104`/`:130`). For a same-scope resolve (`target is self`,
+the common case) that is two closed-checks per resolve. Cheap (~0.015 tottime)
+and behavior-sensitive: the two checks are on different containers for
+cross-scope resolves, and the whole `_warn_and_reopen` shim is transitional — it
+becomes a hard `ContainerClosedError` in 3.0, at which point this collapses
+naturally. **Not worth touching before the 3.0 change lands.**
+
+### Candidate 3 — `inspect.isawaitable` per sync close (OBSERVE, reject)
+
+`CacheItem.close_sync` (`cache_registry.py:71`) calls `inspect.isawaitable(result)`
+on every finalizer run even when `is_async_finalizer` is already known False.
+Considered skipping it, **rejected**: it is the safety net that catches a
+sync-typed finalizer that actually returns a coroutine (would otherwise leak an
+un-awaited awaitable). Close is not the cycle's dominant cost. Keep.
+
+## Already-banked (cross-refs, not re-filed)
+
+- **Child-container construction trio** (RLock ~214 ns, CacheRegistry ~217 ns,
+  ContextRegistry ~189 ns) — the cycle's construction cost.
+  `deferred.md` "Child-container construction: lazy-allocation leads". Net win
+  untested because it adds a resolve hot-path branch; unchanged by this hunt.
+- **`resolve_positional` per-node closure frame** (C1/C3 steady state) — the
+  `exec`-free codegen ceiling. `deferred.md` "The codegen ceiling on C1/C3";
+  rejected stance, not a task.
+- **C2 warm-singleton dispatch floor** — `deferred.md` C2 memo-swap, tried and
+  dropped 2026-07-18 (`planning/changes/2026-07-18.01`).
+
+## Recommendation
+
+**Ship Candidate 1** as a `planning/changes/` bundle (small lane): a clean ~2.4x
+cold first-resolve win that is also a simplification, with no resolve hot-path
+risk — the strongest cost/benefit found and the only genuinely new, actionable
+hotspot. It is a startup/cold-path win, so frame it as such (not a throughput
+claim). TDD as usual: a failing benchmark-style assertion is awkward for a
+one-time cost, so gate on a **behavior** test (positional-only-with-default
+creator still uses kwargs) plus a before/after cold micro-measurement noted in
+the bundle.
+
+Candidates 2-3 are observations, not tasks. Everything else profiled is either
+already banked or at its accepted floor. No new `deferred.md` trigger is
+warranted beyond Candidate 1's bundle.

--- a/planning/changes/2026-07-19.03-drop-compile-inspect-signature.md
+++ b/planning/changes/2026-07-19.03-drop-compile-inspect-signature.md
@@ -1,0 +1,95 @@
+---
+summary: Drop the compile-time inspect.signature in _positional_names; the parser records a positional-only-gap flag at construction instead (~2.4x faster cold first-resolve, no hot-path change).
+---
+
+# Design: Drop the compile-time `inspect.signature` from the positional fast-path predicate
+
+## Summary
+
+`_positional_names` (the compile-time predicate that decides whether a Factory's
+creator can be called positionally) runs a full `inspect.signature(creator)` on
+every compile, solely to detect a positional-only parameter that would shift
+positional binding. That information was already computed at Factory
+construction, when `parse_creator` first introspected the signature and dropped
+the positional-only param. This change has `parse_creator` record a
+`has_positional_only_gap` bool, `Factory` store it, and `_positional_names` read
+the flag — removing the duplicated introspection. Behavior is unchanged; cold
+first-resolve gets ~2.4x faster.
+
+## Motivation
+
+Profiling the cold / first-resolve path (never benchmarked; matters for
+serverless cold start, CLIs, and test suites that build many fresh containers)
+found `inspect.signature` and its callees at **~56% of total cold time** for a
+depth-6 chain — 2.57 s of 4.57 s under cProfile. The entire cost is the
+`inspect.signature(f._creator)` call at `resolver_compiler.py:48-52`, run once
+per provider-with-params per compile. A throwaway monkeypatch that skips it
+measured chain-6 cold first-resolve dropping **99.8 µs -> 41.2 µs (−59%, 2.4x)**
+on clean wall-clock. The call is pure duplication: `parse_creator`
+(`types_parser.py:91`) already builds the signature at construction and
+`_parse_parameter` (`:62`) already sees positional-only params — it drops a
+positional-only-with-default one from `param_hints` (and raises on one without a
+default). Full findings: `planning/audits/2026-07-19-cold-and-cycle-hotspot-hunt-report.md`,
+Candidate 1.
+
+## Design
+
+The predicate's four exclusion rules stay; only rule 4's evidence source moves
+from a live re-introspection to a construction-time flag.
+
+- **`parse_creator`** returns a third value, `has_positional_only_gap: bool`,
+  True iff the parse loop dropped a positional-only parameter (i.e.
+  `_parse_parameter` returned `None`). The unparseable-signature early return
+  yields `False`.
+- **`Factory`** gains a `_has_positional_only_gap` slot, set from the parse
+  result (and `False` under `skip_creator_parsing`, which parses nothing).
+- **`_positional_names`** replaces
+
+  ```python
+  if names and any(
+      p.kind is inspect.Parameter.POSITIONAL_ONLY
+      for p in inspect.signature(f._creator).parameters.values()
+  ):
+      return None
+  ```
+
+  with
+
+  ```python
+  if names and f._has_positional_only_gap:
+      return None
+  ```
+
+  This is exactly equivalent: the old scan fired iff a positional-only param
+  existed *and* `names` was non-empty; the flag encodes the same "a positional-only
+  param existed" fact. The `names`-guard is kept, so an all-positional-only creator
+  (empty `names`) still reaches the fast path via `creator()` as before. `import
+  inspect` leaves `resolver_compiler.py` (no other use).
+
+## Non-goals
+
+- No change to the resolve hot path — this is compile-time only, so it adds no
+  per-resolve branch (unlike the banked child-alloc lazy-allocation lever).
+- No new fast-path cases; the positive/negative selection is identical.
+
+## Testing
+
+- `just test-ci` — full suite, 100% line coverage gate. The new
+  `has_positional_only_gap=True` branch is covered by
+  `test_positional_only_param_with_default_is_skipped` (asserts the flag) and the
+  `_positional_names` rule-4 test; the `False` branch by every other parse.
+- New perf-guard test: with `inspect.signature` spied, a first resolve of a
+  simple graph must not call it (red before this change, green after).
+- Behavior regression: `test_positional_names_rejects_positional_only_param` and
+  the differential harness in `tests/providers/test_factory.py` stay green.
+
+## Risk
+
+- **Under-detecting the gap (would be a correctness bug: a positional call binds
+  the wrong slot).** Low: the flag is set whenever `_parse_parameter` drops a
+  param, which is the exact and only positional-only-with-default case; over-
+  detection (were it to occur) only forgoes the fast path, which is safe. Pinned
+  by the rule-4 test and the ordering-invariant test.
+- **Return-shape churn** in `parse_creator`'s tests. Mechanical: the parametrized
+  table unpacks the 3-tuple and compares the first two elements; the flag gets
+  its own assertions.

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -8,6 +8,9 @@ called directly.
 """
 
 import dataclasses
+import inspect
+
+import pytest
 
 from modern_di import Container, Group, Scope, providers
 from modern_di.providers import ContextProvider
@@ -160,7 +163,7 @@ def test_positional_names_rejects_keyword_only_param() -> None:
 def test_positional_names_rejects_positional_only_param() -> None:
     # rule 4: `prefix` is positional-only WITH a default, dropped from parsed_kwargs so the
     # remaining names look like a clean prefix ("dep",) -- but a positional call would bind
-    # `dep` to the `prefix` slot. The raw-signature scan must reject it.
+    # `dep` to the `prefix` slot. The parser's has_positional_only_gap flag must reject it.
     def creator(prefix: str = "P", /, dep: _A = None) -> _Ordered:  # ty: ignore[invalid-parameter-default]
         raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
 
@@ -170,3 +173,27 @@ def test_positional_names_rejects_positional_only_param() -> None:
     registry.add_providers(owner)
 
     assert _positional_names(owner, _plan(registry, owner)) is None
+
+
+def test_first_resolve_does_not_reintrospect_creator(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Perf guard (audit 2026-07-19 Candidate 1): parse_creator records positional-only params at
+    # construction, so the compile-time positional predicate must not re-run inspect.signature.
+    class G(Group):
+        a = providers.Factory(creator=_A, scope=Scope.APP)
+        b = providers.Factory(creator=_B, scope=Scope.APP)
+        c = providers.Factory(creator=_C, scope=Scope.APP)
+        ordered = providers.Factory(creator=_make, scope=Scope.APP)
+
+    container = Container(groups=[G], validate=False)  # parse_creator already ran at G's class def
+    calls: list[object] = []
+    real_signature = inspect.signature
+
+    def _spy(
+        obj: object, *args: object, **kwargs: object
+    ) -> inspect.Signature:  # pragma: no cover - runs only on regression
+        calls.append(obj)
+        return real_signature(obj, *args, **kwargs)  # ty: ignore[invalid-argument-type]
+
+    monkeypatch.setattr(inspect, "signature", _spy)
+    container.resolve_provider(G.ordered)  # triggers compile of the whole graph
+    assert calls == []  # no re-introspection at compile

--- a/tests/test_types_parser.py
+++ b/tests/test_types_parser.py
@@ -52,7 +52,7 @@ def nonetype_func(hook: None = None) -> None: ...
 
 
 def test_nonetype_params_keep_defaults_through_parse_creator() -> None:
-    _ret, params = parse_creator(nonetype_func)
+    _ret, params, _gap = parse_creator(nonetype_func)
     assert params["hook"] == SignatureItem(default=None, is_nullable=True)
 
 
@@ -191,7 +191,8 @@ class ClassWithWrongAnnotations:
     ],
 )
 def test_parse_creator(creator: type, result: tuple[SignatureItem | None, dict[str, SignatureItem]]) -> None:
-    assert parse_creator(creator) == result
+    return_sig, params, _gap = parse_creator(creator)
+    assert (return_sig, params) == result
 
 
 def test_parse_creator_str_generic_annotation_without_default_raises() -> None:
@@ -281,10 +282,13 @@ def _pos_only_with_default(x: int = 0, /, y: int = 1) -> int:
 
 def test_positional_only_param_with_default_is_skipped() -> None:
     assert _pos_only_with_default(2) == _pos_only_with_default(1, 2)
-    assert parse_creator(_pos_only_with_default) == (
+    return_sig, params, has_positional_only_gap = parse_creator(_pos_only_with_default)
+    assert (return_sig, params) == (
         SignatureItem(arg_type=int),
         {"y": SignatureItem(arg_type=int, default=1)},
     )
+    # the dropped positional-only `x` is recorded so the compiled fast path keeps **kwargs
+    assert has_positional_only_gap is True
 
 
 def _mixed_kind_creator(pos_or_kw: int, *, kw_only: int) -> int:
@@ -295,6 +299,6 @@ def test_keyword_only_signal_recorded() -> None:
     # A keyword-only parameter records is_keyword_only=True; a positional-or-keyword one records
     # False. This is the only param-kind signal the compiled positional fast path consults.
     assert _mixed_kind_creator(1, kw_only=2) == 1 + 2  # exercise the creator body for coverage
-    _ret, params = parse_creator(_mixed_kind_creator)
+    _ret, params, _gap = parse_creator(_mixed_kind_creator)
     assert params["pos_or_kw"].is_keyword_only is False
     assert params["kw_only"].is_keyword_only is True


### PR DESCRIPTION
## What

`_positional_names` (the compile-time predicate that decides whether a Factory's creator can be called positionally) re-ran a full `inspect.signature(creator)` on every compile, solely to detect a positional-only parameter that would shift positional binding. The parser already sees that at construction — `parse_creator` drops the positional-only-with-default param from `parsed_kwargs`. This records a `has_positional_only_gap` bool on `Factory` and reads it instead of re-introspecting.

**Behavior is unchanged** (same predicate, same four exclusion rules, `names`-guard preserved so an all-positional-only creator still reaches the fast path). It's a compile-time-only change — no resolve hot-path branch added.

## Why

Cold / first-resolve profiling (never benchmarked; matters for serverless cold start, CLIs, and test suites building many fresh containers) found `inspect.signature` at **~56% of total cold time** for a depth-6 chain. Removing it measured **99.8 → 41.8 µs/cold-cycle, 2.4x** on clean wall-clock, reconfirmed on the shipped code.

Full rationale in the [change file](planning/changes/2026-07-19.03-drop-compile-inspect-signature.md); the profiling that surfaced it in the [hotspot-hunt audit](planning/audits/2026-07-19-cold-and-cycle-hotspot-hunt-report.md), Candidate 1.

## Testing

- `just test-ci` — 432 passed, 100% line coverage.
- `just lint-ci` — ruff/ty/planning all clean.
- New perf-guard test (`test_first_resolve_does_not_reintrospect_creator`): red before, green after — a first resolve must not call `inspect.signature`.
- Regression: the rule-4 positional-only test and the differential harness stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)