### PR TITLE
test(benchmarks): add cold first-resolve (G8/C5) and context (G9/C6) scenarios

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,8 +17,13 @@ cost. Runs in CI (informational, non-gating) and locally via `just bench`.
 | G5 | Cross-scope resolve, REQUEST -> APP dep | `find_container` traversal |
 | G6 | `build_child_container(REQUEST)` | per-request setup |
 | G7 | Full lifecycle: build REQUEST -> sync-init cached resolve -> `await close_async()` | real per-request cost incl. async teardown |
+| G8 | Cold first-resolve: build root container + compile + resolve, depth 6 | construction + first-compile cost |
+| G9 | Context resolve: request value by type + APP dep, warm child | non-pure context-folding path |
 
-**Rules.** Containers are built/warmed in setup, never inside the timed call.
+**Rules.** Containers are built/warmed in setup, never inside the timed call —
+**except G8**, the cold scenario, which builds the root container *inside* the
+timed call on purpose (its own file, `test_guard_cold.py`) so it measures the
+one-time construction + graph compile the other scenarios amortize away.
 Cold-resolve scenarios (G1, G3, G4) use transient (uncached) providers so each
 timed call does the full wiring. Every benchmark asserts the resolved graph is
 correct. G7 is wall-clock only — instruction-count tooling cannot measure the
@@ -37,6 +42,8 @@ graph shape. Local-only (`just bench-compare`); never in CI. Deps are pinned in
 | C2 | Singleton resolve, warm | G2 |
 | C3 | Deep chain, depth 6 | G3 |
 | C4 | Request lifecycle: enter request scope -> sync-init resolve -> async-finalize on exit | G7 |
+| C5 | Cold build + first resolve, depth 6 | G8 |
+| C6 | Context: per-request runtime value by type + app dep | G9 |
 
 ### Per-framework idiomatic mapping
 
@@ -62,6 +69,36 @@ whole request lifecycle (enter scope -> resolve -> async finalize) as wall-clock
 under a shared event loop, not an isolated resolve. C1-C3 are true synchronous
 resolves for every framework. wireup's transient/scoped resolves require an active
 scope, entered once in setup so C1/C3 time only `scope.get`.
+
+### C5 cold and C6 context idioms
+
+| Framework | C5 cold (build + first resolve) | C6 context (request value by type + app dep) |
+|-----------|---------------------------------|----------------------------------------------|
+| modern-di | `Container(groups=[...]) + resolve` | `ContextProvider` + `build_child(context=)` |
+| dishka | `Provider + provide×6 + make_container + get` | `from_context` + `container(context=)` |
+| that-depends | rebuild 6 `Factory` + `resolve_sync` | `fetch_context_item_by_type` + `container_context(global_context=)` |
+| dependency-injector | `ChainContainer() + c0()` | `providers.Dependency` + `.override()` |
+| wireup | `create_sync_container + enter_scope + get` | `enter_scope({RequestObj: value})`, registered placeholder |
+
+**Caveat — C5 is not one axis.** The frameworks front-load wiring at different
+points, so "cold" measures different things and the cells are **not** comparable
+one-to-one: modern-di / dishka / wireup time a real per-container build (dishka
+builds the graph; wireup `exec`-codegens a factory per provider);
+dependency-injector's number is ~98% provider-graph **deepcopy** on
+instantiation, not resolution; that-depends wires at **import** and has no
+per-call build, so its cell is a `Factory`-reconstruction analog (6× `Factory.__init__`
++ resolve), not a container build. The honest reading is modern-di vs the
+build-time codegen frameworks (dishka/wireup), where staying `exec`-free wins by
+a wide margin. C5 aligns validation off (modern-di `validate=False`, dishka
+`skip_validation=True`) so it isolates build+compile.
+
+**Caveat — C6 is sync for all five** (a clean sync-vs-sync comparison, unlike
+C4), timing the per-request "supply value + resolve" cycle. Two structural
+notes: dependency-injector injects **by reference** (`providers.Dependency` +
+`.override()`), not by type — a structural analog, not an equivalent; wireup
+requires the runtime type **registered** as a scoped injectable with a raising
+placeholder factory (its own integration idiom), the value then supplied via
+`enter_scope`.
 
 ## Running
 

--- a/benchmarks/comparative/test_dependency_injector.py
+++ b/benchmarks/comparative/test_dependency_injector.py
@@ -123,3 +123,51 @@ def test_c4_request_lifecycle(benchmark):
     finally:
         loop.close()
     assert result.closed is True
+
+
+# --- C5 cold: instantiate a fresh container + first resolve, per call ---------
+# The DeclarativeContainer subclass wires at class definition (import). Per call this instantiates
+# a fresh container (deep-copies the provider graph -- the dominant cost) and resolves; the number
+# is ~98% instance clone, not resolution (see README caveat).
+def test_c5_cold_first_resolve(benchmark):
+    def _cold():
+        container = ChainContainer()
+        return container.c0()
+
+    result = benchmark(_cold)
+    assert isinstance(result, C0)
+
+
+# --- C6 context: per-request runtime value via Dependency + override ----------
+# dependency-injector wires by provider REFERENCE, not by type: the runtime value is a
+# providers.Dependency node supplied per request via .override() (see README caveat).
+class RequestObj:
+    pass
+
+
+class AppDep:
+    pass
+
+
+class Handler:
+    def __init__(self, app_dep: AppDep, request: RequestObj) -> None:
+        self.app_dep = app_dep
+        self.request = request
+
+
+class ContextContainer(containers.DeclarativeContainer):
+    app_dep = providers.Singleton(AppDep)
+    request = providers.Dependency(instance_of=RequestObj)
+    handler = providers.Factory(Handler, app_dep=app_dep, request=request)
+
+
+def test_c6_context(benchmark):
+    container = ContextContainer()
+
+    def _one_request():
+        with container.request.override(RequestObj()):
+            return container.handler()
+
+    result = benchmark(_one_request)
+    assert isinstance(result, Handler)
+    assert isinstance(result.request, RequestObj)

--- a/benchmarks/comparative/test_dishka.py
+++ b/benchmarks/comparative/test_dishka.py
@@ -9,7 +9,7 @@ resolve is awaited and C4 measures the full async request lifecycle.
 import asyncio
 from collections.abc import AsyncIterable
 
-from dishka import Provider, Scope, make_async_container, make_container, provide
+from dishka import Provider, Scope, from_context, make_async_container, make_container, provide
 
 
 class Dep:
@@ -111,3 +111,55 @@ def test_c4_request_lifecycle(benchmark):
         loop.run_until_complete(container.close())
         loop.close()
     assert result.closed is True
+
+
+# --- C5 cold: build Provider + make_container + first resolve, per call -------
+def test_c5_cold_first_resolve(benchmark):
+    def _cold():
+        p = Provider(scope=Scope.APP)
+        for cls in (C0, C1, C2, C3, C4, C5):
+            p.provide(cls, cache=False)
+        container = make_container(p, skip_validation=True)  # align with modern-di validate=False
+        return container.get(C0)
+
+    result = benchmark(_cold)
+    assert isinstance(result, C0)
+
+
+# --- C6 context: per-request runtime value via from_context + APP dep ---------
+class RequestObj:
+    pass
+
+
+class Settings:
+    pass
+
+
+class Handler:
+    def __init__(self, req: RequestObj, settings: Settings) -> None:
+        self.req = req
+        self.settings = settings
+
+
+class _AppProvider(Provider):
+    settings = provide(Settings, scope=Scope.APP)
+
+
+class _ReqProvider(Provider):
+    req = from_context(RequestObj, scope=Scope.REQUEST)
+    handler = provide(Handler, scope=Scope.REQUEST)
+
+
+def test_c6_context(benchmark):
+    container = make_container(_AppProvider(), _ReqProvider())
+
+    def _one_request():
+        with container(context={RequestObj: RequestObj()}) as req:
+            return req.get(Handler)
+
+    try:
+        result = benchmark(_one_request)
+    finally:
+        container.close()
+    assert isinstance(result, Handler)
+    assert isinstance(result.req, RequestObj)

--- a/benchmarks/comparative/test_modern_di.py
+++ b/benchmarks/comparative/test_modern_di.py
@@ -121,3 +121,48 @@ def test_c4_request_lifecycle(benchmark):
         loop.close()
     assert isinstance(result, Connection)
     assert result.closed is True
+
+
+# --- C5 cold: fresh container build + first-resolve compile of the chain -----
+def test_c5_cold_first_resolve(benchmark):
+    def _cold():
+        c = Container(scope=Scope.APP, groups=[ChainGroup], validate=False)
+        return c.resolve_provider(ChainGroup.c0)
+
+    result = benchmark(_cold)
+    assert isinstance(result, C0)
+
+
+# --- C6 context: per-request runtime value by type + a shared app dep --------
+class RequestObj:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class AppDep:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class Handler:
+    req: RequestObj
+    dep: AppDep
+
+
+class ContextGroup(Group):
+    app_dep = providers.Factory(creator=AppDep, scope=Scope.APP, cache=True)
+    req_ctx = providers.ContextProvider(RequestObj, scope=Scope.REQUEST)
+    handler = providers.Factory(creator=Handler, scope=Scope.REQUEST)
+
+
+def test_c6_context(benchmark):
+    app = Container(scope=Scope.APP, groups=[ContextGroup], validate=False)
+
+    def _one_request():
+        req = app.build_child_container(scope=Scope.REQUEST, context={RequestObj: RequestObj()})
+        return req.resolve_provider(ContextGroup.handler)
+
+    result = benchmark(_one_request)
+    assert isinstance(result, Handler)
+    assert isinstance(result.req, RequestObj)
+    assert isinstance(result.dep, AppDep)

--- a/benchmarks/comparative/test_that_depends.py
+++ b/benchmarks/comparative/test_that_depends.py
@@ -10,6 +10,7 @@ import asyncio
 import typing
 
 from that_depends import BaseContainer, ContextScopes, container_context, providers
+from that_depends.providers.context_resources import fetch_context_item_by_type
 
 
 class Dep:
@@ -121,3 +122,53 @@ def test_c4_request_lifecycle(benchmark):
     finally:
         loop.close()
     assert result.closed is True
+
+
+# --- C5 cold: rebuild the 6 Factory objects + first resolve, per call ---------
+# that-depends wires at class definition (module import), so a class-level container has no
+# per-call cold step. This rebuilds the Factory chain per call as the closest build+resolve
+# analog; it measures 6x Factory.__init__ + one resolve, NOT a container build (see README caveat).
+def test_c5_cold_first_resolve(benchmark):
+    def _cold():
+        c5 = providers.Factory(C5)
+        c4 = providers.Factory(C4, c5=c5.cast)
+        c3 = providers.Factory(C3, c4=c4.cast)
+        c2 = providers.Factory(C2, c3=c3.cast)
+        c1 = providers.Factory(C1, c2=c2.cast)
+        c0 = providers.Factory(C0, c1=c1.cast)
+        return c0.resolve_sync()
+
+    result = benchmark(_cold)
+    assert isinstance(result, C0)
+
+
+# --- C6 context: per-request value pulled by type from the context ------------
+class RequestObj:
+    pass
+
+
+class AppDep:
+    pass
+
+
+class Handler:
+    def __init__(self, request_obj: RequestObj, app_dep: AppDep) -> None:
+        self.request_obj = request_obj
+        self.app_dep = app_dep
+
+
+class ContextContainer(BaseContainer):
+    app_dep = providers.Singleton(AppDep)
+    request_obj = providers.Factory(fetch_context_item_by_type, RequestObj)  # by-type pull from context
+    handler = providers.Factory(Handler, request_obj=request_obj.cast, app_dep=app_dep.cast)
+
+
+def test_c6_context(benchmark):
+    def _one_request():
+        ro = RequestObj()
+        with container_context(global_context={"request": ro}):
+            return ContextContainer.handler.resolve_sync()
+
+    result = benchmark(_one_request)
+    assert isinstance(result, Handler)
+    assert isinstance(result.request_obj, RequestObj)

--- a/benchmarks/comparative/test_wireup.py
+++ b/benchmarks/comparative/test_wireup.py
@@ -122,3 +122,53 @@ def test_c4_request_lifecycle(benchmark):
     finally:
         loop.close()
     assert result.closed is True
+
+
+# --- C5 cold: create_sync_container (codegen/exec) + first resolve, per call --
+# wireup exec-codegens a factory per provider inside create_sync_container, so this is dominated
+# by container construction, not resolution (see README caveat).
+def test_c5_cold_first_resolve(benchmark):
+    def _cold():
+        container = wireup.create_sync_container(injectables=[C0, C1, C2, C3, C4, C5])
+        with container.enter_scope() as scope:
+            return scope.get(C0)
+
+    result = benchmark(_cold)
+    assert isinstance(result, C0)
+
+
+# --- C6 context: per-request runtime value by type via enter_scope(provided) --
+class RequestObj:
+    def __init__(self) -> None:
+        pass
+
+
+@wireup.injectable(lifetime="scoped")
+def _request_placeholder() -> RequestObj:
+    # Never called: the value is always supplied via enter_scope; the scoped factory finds the
+    # seeded object first. Registration is required so the type is a known by-type dependency.
+    raise RuntimeError("RequestObj is only available during a request")
+
+
+@wireup.injectable
+class CtxSettings:
+    pass
+
+
+@wireup.injectable(lifetime="scoped")
+class CtxHandler:
+    def __init__(self, req: RequestObj, settings: CtxSettings) -> None:
+        self.req = req
+        self.settings = settings
+
+
+def test_c6_context(benchmark):
+    container = wireup.create_sync_container(injectables=[_request_placeholder, CtxSettings, CtxHandler])
+
+    def _one_request():
+        with container.enter_scope({RequestObj: RequestObj()}) as scope:
+            return scope.get(CtxHandler)
+
+    result = benchmark(_one_request)
+    assert isinstance(result, CtxHandler)
+    assert isinstance(result.req, RequestObj)

--- a/benchmarks/test_guard_cold.py
+++ b/benchmarks/test_guard_cold.py
@@ -1,0 +1,67 @@
+# ruff: noqa: ANN001, ANN201
+"""Guard tier — cold first-resolve (container build + graph compile).
+
+G8 is the **one** guard scenario that builds the root container *inside* the
+timed call: a fresh `Container(groups=[...])` has a fresh providers registry, so
+the first resolve compiles the whole provider graph from scratch. Every other
+guard file builds/warms in setup and times only the steady-state call; this one
+deliberately measures construction + compile + resolve as a single unit, the
+cost paid once per container in short-lived processes (serverless, CLI, tests)
+and at every app startup. See benchmarks/README.md.
+"""
+
+import dataclasses
+
+from modern_di import Container, Group, Scope, providers
+
+
+# --- depth-6 chain subject graph (mirrors G3/C3, the largest compile signal) ---
+@dataclasses.dataclass(slots=True)
+class C5:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class C4:
+    c5: C5
+
+
+@dataclasses.dataclass(slots=True)
+class C3:
+    c4: C4
+
+
+@dataclasses.dataclass(slots=True)
+class C2:
+    c3: C3
+
+
+@dataclasses.dataclass(slots=True)
+class C1:
+    c2: C2
+
+
+@dataclasses.dataclass(slots=True)
+class C0:
+    c1: C1
+
+
+class ChainGroup(Group):
+    c5 = providers.Factory(creator=C5, scope=Scope.APP)
+    c4 = providers.Factory(creator=C4, scope=Scope.APP)
+    c3 = providers.Factory(creator=C3, scope=Scope.APP)
+    c2 = providers.Factory(creator=C2, scope=Scope.APP)
+    c1 = providers.Factory(creator=C1, scope=Scope.APP)
+    c0 = providers.Factory(creator=C0, scope=Scope.APP)
+
+
+def _cold_build_and_resolve() -> C0:
+    # Fresh registry -> full compile every call: construction + first-resolve compile + resolve.
+    container = Container(scope=Scope.APP, groups=[ChainGroup], validate=False)
+    return container.resolve_provider(ChainGroup.c0)
+
+
+def test_g8_cold_first_resolve(benchmark):
+    result = benchmark(_cold_build_and_resolve)
+    assert isinstance(result, C0)
+    assert isinstance(result.c1.c2.c3.c4.c5, C5)

--- a/benchmarks/test_guard_resolve.py
+++ b/benchmarks/test_guard_resolve.py
@@ -201,3 +201,37 @@ def test_g5_cross_scope(benchmark):
     result = benchmark(req.resolve_provider, CrossScopeGroup.req_svc)
     assert isinstance(result, RequestService)
     assert isinstance(result.app, AppService)
+
+
+# --- G9 subject graph: context value injected by type + an APP dep ----------
+class RequestObj:  # a fresh per-request runtime value (e.g. a framework Request)
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class AppDep:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class Handler:
+    req: RequestObj
+    dep: AppDep
+
+
+class ContextGroup(Group):
+    app_dep = providers.Factory(creator=AppDep, scope=Scope.APP)
+    req_ctx = providers.ContextProvider(RequestObj, scope=Scope.REQUEST)
+    # transient -> folds the runtime context value on every resolve (the non-pure kwargs path)
+    handler = providers.Factory(creator=Handler, scope=Scope.REQUEST)
+
+
+def test_g9_context_resolve(benchmark):
+    # Isolates the context-folding (non-pure kwargs) path C1-C5 never touch: a factory mixing a
+    # runtime context value with a provider dep. Container + child built in setup; only resolve timed.
+    app = Container(scope=Scope.APP, groups=[ContextGroup], validate=False)
+    req = app.build_child_container(scope=Scope.REQUEST, context={RequestObj: RequestObj()})
+    result = benchmark(req.resolve_provider, ContextGroup.handler)
+    assert isinstance(result, Handler)
+    assert isinstance(result.req, RequestObj)
+    assert isinstance(result.dep, AppDep)

--- a/planning/changes/2026-07-19.04-cold-and-context-benchmarks.md
+++ b/planning/changes/2026-07-19.04-cold-and-context-benchmarks.md
@@ -1,0 +1,115 @@
+---
+summary: Add cold-first-resolve (G8/C5) and context-injection (G9/C6) scenarios to both benchmark tiers, closing the cold-path regression-guard gap and the pure-graph realism gap.
+---
+
+# Design: Cold first-resolve and context-injection benchmark scenarios
+
+## Summary
+
+The benchmark suite measures only steady-state resolve (C1-C4, all pure provider
+graphs) plus construction and one request cycle. Two real axes are unmeasured:
+the **cold / first-resolve** path (container build + graph compile — the path the
+2026-07-19.03 `inspect.signature` fix sped up 2.4x, with no benchmark to guard
+it) and the **context-injection** path (a runtime request value folded into a
+factory — the actual integration hot path, which C1-C4's pure graphs never
+touch). This adds both to the guard tier (G8, G9) and the comparative tier
+(C5, C6, across all five frameworks).
+
+## Motivation
+
+- **Cold has no regression guard.** Every existing scenario builds the container
+  in `setup`, and `pytest-benchmark` amortizes the one-time compile across its
+  repeated calls, so nothing in the suite would catch a cold-path regression. The
+  shipped `inspect.signature` removal (2.4x on chain-6 cold) is guarded only by a
+  unit test asserting the call is gone — not by a timing benchmark.
+- **C1-C4 are all pure provider graphs.** No context, no overrides. Real
+  integration handlers inject a per-request value (a FastAPI/Litestar request
+  object) by type, exercising the non-pure kwargs/context-folding path. Measured
+  gap: context resolve is ~2.05 µs vs ~0.5 µs for the pure C1 transient — a ~4x
+  path C1-C4 never surface.
+- Cold is also a **favorable competitive axis**: the codegen frameworks front-load
+  work at build (wireup `exec`-codegens per provider; dependency-injector
+  deepcopies the provider graph), so modern-di's zero-dep build should win cold
+  against them.
+
+## Design
+
+Scenario shapes verified end-to-end (guard numbers on py3.10 x86_64; comparative
+idioms verified in the pinned comparative venv, py3.14).
+
+### Guard tier (modern-di only)
+
+- **G8 cold first-resolve** — new file `benchmarks/test_guard_cold.py`. Times
+  `Container(groups=[ChainGroup], validate=False).resolve_provider(ChainGroup.c0)`
+  as one call: a fresh registry each call means a full construction + compile +
+  resolve. Reuses the depth-6 chain (largest compile signal; what the fix most
+  affected). **This is the one guard scenario that builds inside the timed call**
+  — its own file, its own documented rule, so it does not muddy the "build in
+  setup, never in the timed call" rule of the resolve/lifecycle files. ~41.8 µs.
+- **G9 context resolve** — appended to `benchmarks/test_guard_resolve.py`. A
+  REQUEST-scoped **transient** `Factory(Handler)` where `Handler(req: RequestObj,
+  dep: AppDep)` mixes a `ContextProvider(RequestObj, REQUEST)` runtime value with
+  an APP-scoped `Factory` dep. Container + REQUEST child (with
+  `context={RequestObj: ...}`) built in setup; only the resolve is timed, so it
+  isolates the non-pure context-folding path against C1's pure path. ~2.05 µs.
+
+### Comparative tier (all five frameworks)
+
+`C5` cold and `C6` context added to each `benchmarks/comparative/test_*.py`,
+using each framework's **verified idiomatic** API:
+
+| | C5 cold (build + first resolve) | C6 context (request value by type + app dep) |
+|---|---|---|
+| modern-di | `Container(groups=[G]) + resolve` | `ContextProvider` + `build_child(context=)` |
+| dishka | `Provider+provide×6+make_container+get` | `from_context` + `container(context=)` |
+| that-depends | rebuild 6 `Factory` + `resolve_sync` | `fetch_context_item_by_type` + `container_context(global_context=)` |
+| dependency-injector | `ChainContainer() + c0()` | `providers.Dependency` + `.override()` |
+| wireup | `create_sync_container + enter_scope + get` | `enter_scope({RequestObj: value})` (registered placeholder) |
+
+C6 is **fully synchronous for all five** — a clean sync-vs-sync comparison
+(unlike C4). Every benchmark asserts graph correctness (existing convention).
+
+### Methodology decisions (settled)
+
+- **C5 is not one axis.** modern-di / dishka / wireup time a real per-container
+  build; dependency-injector's number is ~98% provider-graph deepcopy; that-depends
+  has no per-call build (wiring is at import) so its cell is a Factory-rebuild
+  analog. Included per maintainer ruling **with per-row caveats**, extending the
+  README's existing C4-style caveat block. The honest headline is modern-di vs the
+  build-time codegen frameworks (dishka/wireup).
+- **Validation aligned in C5:** modern-di `validate=False` vs dishka
+  `skip_validation=True`, so C5 isolates build+compile, not validation.
+- **C6 caveats:** dependency-injector injects by **reference** (`Dependency`), not
+  by type — a structural analog, not an equivalent; wireup requires the runtime
+  type registered as a scoped injectable with a raising placeholder (its own
+  integration idiom).
+
+The README's guard and comparative tables plus the per-framework mapping and
+caveat sections are updated in this PR (benchmarks/README.md is the truth home
+for the benchmark vocabulary).
+
+## Non-goals
+
+- No change to `modern_di/` source — benchmarks only.
+- Not adding validate() / override / concurrent-throughput scenarios (separate,
+  deferred).
+- Not making C5 a single fair axis — the frameworks genuinely front-load work
+  differently; the caveat is the honest representation.
+
+## Testing
+
+- `just bench` — guard tier runs, G8/G9 report and their correctness asserts pass.
+- `just bench-compare` — comparative tier runs; C5/C6 for all five frameworks
+  report and assert correct graphs.
+- `just test-ci` unaffected: `testpaths=["tests"]` excludes `benchmarks/`, and
+  coverage omits `benchmarks/*`.
+- `just lint-ci` clean (ruff/ty/planning).
+
+## Risk
+
+- **Comparative cold misread as resolution cost.** Likely without the caveat;
+  mitigated by explicit per-row README caveats naming what each cell measures.
+- **Rival API drift on version bump.** The idioms are pinned to the comparative
+  `pyproject.toml` versions; a bump reruns `just bench-compare` and re-verifies.
+- **Guard numbers are interpreter-specific** (absolutes vary by Python version);
+  they are guidance, not published claims (README states this).


### PR DESCRIPTION
## What

Adds two benchmark scenarios to both tiers, closing two coverage gaps in the suite:

- **Cold first-resolve** (**G8** guard / **C5** comparative): container build + graph compile, timed as one call. Every existing scenario builds in `setup` and `pytest-benchmark` amortizes the one-time compile away, so nothing guarded the #349 `inspect.signature` fix (2.4x cold). G8 builds the root container *inside* the timed call (own file `test_guard_cold.py`, own documented rule).
- **Context injection** (**G9** guard / **C6** comparative): a per-request runtime value injected *by type* + an app-scoped dep, exercising the non-pure context-folding path that C1–C4's pure graphs never touch — the real integration hot path.

## Grounding

Every comparative idiom was verified end-to-end in the pinned comparative venv (py3.14) before writing:

| | C5 cold | C6 context |
|---|---|---|
| modern-di | `Container(groups=[...])+resolve` | `ContextProvider` + `build_child(context=)` |
| dishka | `Provider+provide×6+make_container+get` | `from_context` + `container(context=)` |
| that-depends | rebuild 6 `Factory` + `resolve_sync` | `fetch_context_item_by_type` + `container_context` |
| dependency-injector | `ChainContainer()+c0()` | `providers.Dependency` + `.override()` |
| wireup | `create_sync_container+enter_scope+get` | `enter_scope({RequestObj: value})` |

**C5 is not one axis** (documented per-row in the README): modern-di/dishka/wireup time a real container build; dependency-injector is ~98% instance deepcopy; that-depends wires at import (Factory-rebuild analog). **C6 is synchronous for all five** — a clean sync-vs-sync comparison. Two C6 structural caveats: dependency-injector injects by reference (not by type); wireup requires a registered scoped placeholder.

## Findings (median, py3.14 comparative — guidance, not published claims)

- **Cold is favorable:** modern-di **21 µs** vs dishka **1127 µs** / wireup **1044 µs** (build + `exec`-codegen), dependency-injector **115 µs** (deepcopy). Staying `exec`-free wins cold by ~50x against the codegen builders.
- **Context:** modern-di **1.87 µs**, mid-pack — behind wireup/dishka, ahead of that-depends/dependency-injector. Consistent with the warm-resolve pattern.

## Testing

- `just bench` — guard tier, 10 pass (G8 ~42 µs, G9 ~2.2 µs on py3.10), correctness asserts pass.
- `just bench-compare` — comparative tier, 30 pass (C1–C6 × 5).
- `just test-ci` unaffected (testpaths=`tests`, coverage omits `benchmarks/*`); `just lint-ci` clean.

Benchmarks only — no `modern_di/` change. Rationale: [`planning/changes/2026-07-19.04-cold-and-context-benchmarks.md`](planning/changes/2026-07-19.04-cold-and-context-benchmarks.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)