### PR TITLE
test(benchmarks): add validate() guard scenarios (G10 deep, G11 wide)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,13 +19,18 @@ cost. Runs in CI (informational, non-gating) and locally via `just bench`.
 | G7 | Full lifecycle: build REQUEST -> sync-init cached resolve -> `await close_async()` | real per-request cost incl. async teardown |
 | G8 | Cold first-resolve: build root container + compile + resolve, depth 6 | construction + first-compile cost |
 | G9 | Context resolve: request value by type + APP dep, warm child | non-pure context-folding path |
+| G10 | `validate()` on a depth-6 chain (isolated via `pedantic`) | graph-validation traversal, deep |
+| G11 | `validate()` on a wide 10-sibling graph (isolated via `pedantic`) | graph-validation traversal, fan-out |
 
 **Rules.** Containers are built/warmed in setup, never inside the timed call —
 **except G8**, the cold scenario, which builds the root container *inside* the
 timed call on purpose (its own file, `test_guard_cold.py`) so it measures the
 one-time construction + graph compile the other scenarios amortize away.
 Cold-resolve scenarios (G1, G3, G4) use transient (uncached) providers so each
-timed call does the full wiring. Every benchmark asserts the resolved graph is
+timed call does the full wiring. G10/G11 use `benchmark.pedantic` with a
+per-round setup that builds a fresh unvalidated container (untimed), so they
+isolate `validate()` from construction — a fresh registry each round means every
+round runs the full graph walk. Every benchmark asserts the resolved graph is
 correct. G7 is wall-clock only — instruction-count tooling cannot measure the
 awaited teardown, and a single reused event loop keeps loop overhead out of the
 signal as far as practical.
@@ -99,6 +104,13 @@ notes: dependency-injector injects **by reference** (`providers.Dependency` +
 requires the runtime type **registered** as a scoped injectable with a raising
 placeholder factory (its own integration idiom), the value then supplied via
 `enter_scope`.
+
+**No comparative validate() row.** `validate()` (G10/G11 in the guard tier) has
+no comparative equivalent: dependency-injector and that-depends run no build-time
+graph-validation pass, and for dishka and wireup validation is folded inside
+`make_container` / `create_sync_container` with no isolation seam (and their C5
+cold build already includes it). A cross-framework "validation cost" row would be
+n/a for two frameworks and redundant for the others, so it is omitted.
 
 ## Running
 

--- a/benchmarks/test_guard_validate.py
+++ b/benchmarks/test_guard_validate.py
@@ -1,0 +1,155 @@
+# ruff: noqa: ANN001, ANN201
+"""Guard tier — validate() graph-traversal cost.
+
+`Container.validate()` walks the whole provider graph (cycle detection + transitive-scope
+checks). It memoizes on the providers registry, so it does full work only once per registry;
+G10/G11 use `benchmark.pedantic` with a per-round setup that builds a fresh unvalidated
+container (untimed) and time `validate()` alone. 3.0 runs validate() by default at root
+construction, so this is a real startup cost; G10 guards the deep-chain traversal, G11 the
+wide fan-out. See benchmarks/README.md.
+"""
+
+import dataclasses
+
+from modern_di import Container, Group, Scope, providers
+
+
+# --- G10 subject: depth-6 chain (mirrors G3) -------------------------------
+@dataclasses.dataclass(slots=True)
+class C5:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class C4:
+    c5: C5
+
+
+@dataclasses.dataclass(slots=True)
+class C3:
+    c4: C4
+
+
+@dataclasses.dataclass(slots=True)
+class C2:
+    c3: C3
+
+
+@dataclasses.dataclass(slots=True)
+class C1:
+    c2: C2
+
+
+@dataclasses.dataclass(slots=True)
+class C0:
+    c1: C1
+
+
+class ChainGroup(Group):
+    c5 = providers.Factory(creator=C5, scope=Scope.APP)
+    c4 = providers.Factory(creator=C4, scope=Scope.APP)
+    c3 = providers.Factory(creator=C3, scope=Scope.APP)
+    c2 = providers.Factory(creator=C2, scope=Scope.APP)
+    c1 = providers.Factory(creator=C1, scope=Scope.APP)
+    c0 = providers.Factory(creator=C0, scope=Scope.APP)
+
+
+def test_g10_validate_deep_chain(benchmark):
+    good = Container(scope=Scope.APP, groups=[ChainGroup], validate=True)  # raises if invalid
+    assert isinstance(good.resolve_provider(ChainGroup.c0), C0)
+    benchmark.pedantic(
+        lambda c: c.validate(),
+        setup=lambda: ((Container(scope=Scope.APP, groups=[ChainGroup], validate=False),), {}),
+        rounds=3000,
+        iterations=1,
+    )
+
+
+# --- G11 subject: one object, 10 sibling deps (mirrors G4) ------------------
+@dataclasses.dataclass(slots=True)
+class L0:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L1:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L2:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L3:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L4:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L5:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L6:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L7:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L8:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class L9:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class Wide:
+    l0: L0
+    l1: L1
+    l2: L2
+    l3: L3
+    l4: L4
+    l5: L5
+    l6: L6
+    l7: L7
+    l8: L8
+    l9: L9
+
+
+class WideGroup(Group):
+    l0 = providers.Factory(creator=L0, scope=Scope.APP)
+    l1 = providers.Factory(creator=L1, scope=Scope.APP)
+    l2 = providers.Factory(creator=L2, scope=Scope.APP)
+    l3 = providers.Factory(creator=L3, scope=Scope.APP)
+    l4 = providers.Factory(creator=L4, scope=Scope.APP)
+    l5 = providers.Factory(creator=L5, scope=Scope.APP)
+    l6 = providers.Factory(creator=L6, scope=Scope.APP)
+    l7 = providers.Factory(creator=L7, scope=Scope.APP)
+    l8 = providers.Factory(creator=L8, scope=Scope.APP)
+    l9 = providers.Factory(creator=L9, scope=Scope.APP)
+    wide = providers.Factory(creator=Wide, scope=Scope.APP)
+
+
+def test_g11_validate_wide(benchmark):
+    good = Container(scope=Scope.APP, groups=[WideGroup], validate=True)  # raises if invalid
+    assert isinstance(good.resolve_provider(WideGroup.wide), Wide)
+    benchmark.pedantic(
+        lambda c: c.validate(),
+        setup=lambda: ((Container(scope=Scope.APP, groups=[WideGroup], validate=False),), {}),
+        rounds=3000,
+        iterations=1,
+    )

--- a/planning/changes/2026-07-19.05-validate-benchmarks.md
+++ b/planning/changes/2026-07-19.05-validate-benchmarks.md
@@ -1,0 +1,72 @@
+---
+summary: Add guard-tier validate() benchmarks (G10 deep, G11 wide) isolating the graph-validation traversal cost; comparative omitted (not cleanly isolable across rivals).
+---
+
+# Design: validate() guard benchmarks
+
+## Summary
+
+`Container.validate()` (cycle + transitive-scope checking via `DependencyGraph.walk`)
+is unbenchmarked, yet 3.0 will run it by default at root construction, so every
+app pays it at startup. Measured cost is substantial and scales ~linearly with
+graph size (chain-6 ~33 µs, chain-30 ~159 µs, wide-50 ~283 µs — ~5 µs/provider).
+This adds two guard-tier scenarios isolating that traversal: **G10** (deep chain)
+and **G11** (wide fan-out). No comparative scenario — see Non-goals.
+
+## Motivation
+
+- **Growing, unguarded startup cost.** validate() is a full graph walk with no
+  benchmark. Once 3.0 makes it the construction default, a 50-200-provider app
+  pays ~250 µs-1 ms every startup. A regression in `DependencyGraph.walk`,
+  `terminal_scope`, or the per-node issue iteration would be invisible today.
+- **Isolatable and stable.** Unlike cold (which conflates construction), validate()
+  can be timed alone on a pre-built container, giving a clean regression signal.
+
+## Design
+
+New self-contained file `benchmarks/test_guard_validate.py`, reusing the canonical
+depth-6 chain and wide-10 shapes (mirroring G3/G4) so the two traversal patterns
+— deep edge-chain vs wide fan-out — are both guarded.
+
+validate() memoizes on the providers registry (`is_validated()`), so it does full
+work only once per registry. To time it repeatedly in isolation, use
+`benchmark.pedantic` with a per-round `setup` that builds a fresh unvalidated
+container (untimed); the timed target is `container.validate()` alone:
+
+```python
+def test_g10_validate_deep_chain(benchmark):
+    good = Container(scope=Scope.APP, groups=[ChainGroup], validate=True)   # correctness: no raise
+    assert isinstance(good.resolve_provider(ChainGroup.c0), C0)
+    benchmark.pedantic(
+        lambda c: c.validate(),
+        setup=lambda: ((Container(scope=Scope.APP, groups=[ChainGroup], validate=False),), {}),
+        rounds=..., iterations=1,
+    )
+```
+
+Each fresh root container owns a fresh registry, so every round runs the full walk.
+
+## Non-goals
+
+- **No comparative tier.** validate() is not cleanly comparable: dependency-injector
+  and that-depends have no build-time graph-validation pass at all; for dishka and
+  wireup validation is folded inside `make_container` / `create_sync_container`
+  with no separate isolation seam (and C5 cold already covers their build). A
+  comparative "validation cost" row would be n/a for two frameworks and redundant
+  for the others — omitted as the honest call.
+- No override / concurrency / teardown scenarios (banked separately with triggers).
+
+## Testing
+
+- `just bench` — guard tier runs; G10/G11 report, correctness asserts (a validated
+  good graph resolves) pass.
+- `just test-ci` unaffected (`testpaths=["tests"]`, coverage omits `benchmarks/*`).
+- `just lint-ci` clean.
+
+## Risk
+
+- **pedantic isolation subtlety:** if a fresh container did *not* get a fresh
+  registry, validate() would memoize and rounds 2+ would time a no-op. Guarded by
+  the fact that a root `Container` always builds its own `ProvidersRegistry`;
+  the reported per-round cost being non-trivial (tens of µs) confirms full walks.
+- Guard numbers are interpreter-specific (guidance, not published claims).


### PR DESCRIPTION
## What

Adds guard-tier benchmarks for `Container.validate()` — the cycle + transitive-scope graph walk (`DependencyGraph.walk`) — which was unbenchmarked despite becoming the **default construction path in 3.0**.

- **G10** — `validate()` on a depth-6 chain (deep-edge traversal)
- **G11** — `validate()` on a wide 10-sibling graph (fan-out traversal)

Both isolate `validate()` from construction via `benchmark.pedantic` (fresh unvalidated container per round in untimed setup; only `validate()` timed). A fresh registry each round means every round runs the full walk.

## Why

`validate()` is a full graph traversal with no regression guard. Measured cost scales ~linearly at **~5 µs/provider** (chain-6 ~29 µs, wide-10 ~53 µs isolated; ~250 µs–1 ms for a realistic 50–200-provider app). Once 3.0 runs it by default at root construction, every app pays this at startup — and a regression in `walk`, `terminal_scope`, or the per-node issue iteration is invisible today.

## No comparative tier (deliberate)

`validate()` isn't cleanly comparable: dependency-injector and that-depends run **no** build-time graph-validation pass, and for dishka/wireup validation is folded inside `make_container`/`create_sync_container` with no isolation seam (their C5 cold build already includes it). A cross-framework row would be n/a for two frameworks and redundant for the rest — documented in the README.

## Testing

- `just bench` — guard tier, **12 pass** (G10 ~29 µs, G11 ~53 µs), correctness asserts (validated good graph resolves) pass.
- `just test-ci` unaffected (`testpaths=tests`, coverage omits `benchmarks/*`); `just lint-ci` clean.

Benchmarks only — no `modern_di/` change. Rationale: [`planning/changes/2026-07-19.05-validate-benchmarks.md`](planning/changes/2026-07-19.05-validate-benchmarks.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)