### PR TITLE
test(benchmarks): add override (G12) and teardown (G13) guard scenarios

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,6 +21,8 @@ cost. Runs in CI (informational, non-gating) and locally via `just bench`.
 | G9 | Context resolve: request value by type + APP dep, warm child | non-pure context-folding path |
 | G10 | `validate()` on a depth-6 chain (isolated via `pedantic`) | graph-validation traversal, deep |
 | G11 | `validate()` on a wide 10-sibling graph (isolated via `pedantic`) | graph-validation traversal, fan-out |
+| G12 | Resolve a depth-6 chain with one unrelated override active | override front-guard (`fetch_override`) tax |
+| G13 | Per-request cycle finalizing 10 cached resources (`close_sync`) | LIFO teardown at scale |
 
 **Rules.** Containers are built/warmed in setup, never inside the timed call —
 **except G8**, the cold scenario, which builds the root container *inside* the

--- a/benchmarks/test_guard_lifecycle.py
+++ b/benchmarks/test_guard_lifecycle.py
@@ -74,3 +74,38 @@ def test_g7_request_lifecycle(benchmark):
         loop.close()
     assert isinstance(result, Connection)
     assert result.closed is True  # async finalizer ran
+
+
+# --- G13: teardown at scale -- 10 cached REQUEST resources, sync finalizers ---
+# G7 finalizes one resource; a real request closes several. G13 measures the per-request cycle
+# with 10 cached REQUEST providers (each a sync finalizer) so the LIFO close loop is exercised.
+def _noop_finalizer(_obj: object) -> None:
+    pass
+
+
+_RES_TYPES = [type(f"Res{i}", (), {}) for i in range(10)]
+_TEARDOWN_GROUP = type(
+    "TeardownGroup",
+    (Group,),
+    {
+        f"res{i}": providers.Factory(
+            creator=t, scope=Scope.REQUEST, cache=providers.CacheSettings(finalizer=_noop_finalizer)
+        )
+        for i, t in enumerate(_RES_TYPES)
+    },
+)
+_TEARDOWN_PROVIDERS = [getattr(_TEARDOWN_GROUP, f"res{i}") for i in range(len(_RES_TYPES))]
+
+
+def test_g13_teardown_at_scale(benchmark):
+    app = Container(scope=Scope.APP, groups=[_TEARDOWN_GROUP], validate=False)
+
+    def _one_request() -> Container:
+        req = app.build_child_container(scope=Scope.REQUEST)
+        for provider in _TEARDOWN_PROVIDERS:
+            req.resolve_provider(provider)
+        req.close_sync()  # finalizes all 10 in reverse creation order
+        return req
+
+    result = benchmark(_one_request)
+    assert result.closed is True

--- a/benchmarks/test_guard_resolve.py
+++ b/benchmarks/test_guard_resolve.py
@@ -235,3 +235,28 @@ def test_g9_context_resolve(benchmark):
     assert isinstance(result, Handler)
     assert isinstance(result.req, RequestObj)
     assert isinstance(result.dep, AppDep)
+
+
+# --- G12 subject graph: depth-6 chain + one unrelated overridable provider ---
+class Sentinel:
+    pass
+
+
+class OverrideChainGroup(Group):
+    c5 = providers.Factory(creator=C5, scope=Scope.APP)
+    c4 = providers.Factory(creator=C4, scope=Scope.APP)
+    c3 = providers.Factory(creator=C3, scope=Scope.APP)
+    c2 = providers.Factory(creator=C2, scope=Scope.APP)
+    c1 = providers.Factory(creator=C1, scope=Scope.APP)
+    c0 = providers.Factory(creator=C0, scope=Scope.APP)
+    sentinel = providers.Factory(creator=Sentinel, scope=Scope.APP)
+
+
+def test_g12_override_active_resolve(benchmark):
+    # Override front-guard tax: an UNRELATED override flips has_overrides True, so every node in the
+    # depth-6 chain pays a fetch_override lookup per resolve (the path a test suite with mocks hits).
+    container = Container(scope=Scope.APP, groups=[OverrideChainGroup], validate=False)
+    container.override(OverrideChainGroup.sentinel, Sentinel())
+    container.resolve_provider(OverrideChainGroup.c0)  # warm
+    result = benchmark(container.resolve_provider, OverrideChainGroup.c0)
+    assert isinstance(result, C0)

--- a/planning/changes/2026-07-19.06-override-and-teardown-benchmarks.md
+++ b/planning/changes/2026-07-19.06-override-and-teardown-benchmarks.md
@@ -1,0 +1,37 @@
+---
+summary: Add guard benchmarks G12 (override-active resolve, the front-guard tax) and G13 (teardown at scale, 10-resource LIFO close), closing two of the three remaining unmeasured axes.
+---
+
+# Change: Override and teardown guard benchmarks
+
+## What
+
+Two guard-tier scenarios from the 2026-07-19 remaining-axes evaluation:
+
+- **G12 override-active resolve** (`test_guard_resolve.py`): a depth-6 chain
+  resolved with one **unrelated** override active, so `has_overrides` is True and
+  every node pays a `fetch_override` lookup — the per-node tax a test suite using
+  mocks hits on every resolve. ~3.5 µs vs ~1.3 µs plain (the tax is visible).
+- **G13 teardown at scale** (`test_guard_lifecycle.py`): the per-request cycle
+  (build REQUEST child, resolve 10 cached resources with sync finalizers,
+  `close_sync`) so the LIFO close loop over many finalizers is exercised — G7
+  finalizes only one. ~26 µs.
+
+## Why
+
+The evaluation flagged these as real-but-narrow axes with **no blocker** to
+measuring: G12 guards the override front-guard cost (`fetch_override` per node,
+the `modern-di-pytest` path), G13 guards `close_sync`'s `reversed(_creation_order)`
+teardown loop and finalizer aggregation at a realistic resource count. Both are
+cheap regression guards; delivered rather than banked.
+
+## Testing
+
+- `just bench` — guard tier runs; G12/G13 report, correctness asserts pass.
+- `just test-ci` unaffected (`testpaths=["tests"]`, coverage omits `benchmarks/*`).
+- `just lint-ci` clean.
+
+The third remaining axis — concurrent / free-threaded throughput — is **not**
+here: it needs a custom N-thread ops/sec harness (pytest-benchmark measures only
+single-thread wall time), a separate build with its own measurement-shape
+decisions. Tracked in `deferred.md`.

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -109,6 +109,32 @@ path is higher-risk for a conservative library.
 child-build dominates a realistic request cycle enough to justify hot-path branches. Measure net,
 both tiers (guard `G6b` + comparative `C4`), before shipping.
 
+## Concurrent / free-threaded throughput benchmark — needs a custom harness — from 2026-07-19 remaining-axes eval
+
+The 2026-07-19 benchmark-axes evaluation shipped cold (G8/C5), context (G9/C6), validate (G10/G11),
+override (G12), and teardown (G13). The one axis **not** delivered is concurrent-resolution
+throughput: how resolution scales across threads, and how much the double-checked singleton-creation
+lock (`CacheItem.get_or_create`) contends — the forward-looking differentiator vs lock-free rivals
+(that-depends' lock-free slot) under free-threading (PEP 703). It is the real competitive story on
+3.14t, and modern-di already supports free-threading at Beta ([`concurrency.md`](../architecture/concurrency.md)).
+
+**Why it is not a quick add:** `pytest-benchmark` measures single-thread wall time only. Throughput
+needs a **custom harness** — N worker threads behind a start barrier, each resolving from one shared
+warm container, measuring aggregate ops/sec — run under both the GIL and free-threaded 3.14t (CI has
+the `3.14t` job). Two sub-cases matter: (a) concurrent resolve of an already-**cached** singleton
+(read-mostly; should scale near-linearly on 3.14t if no false contention), and (b) concurrent
+**first** resolve of a singleton (the double-checked lock's contention window). Throughput numbers are
+noisy; the harness must control for that (fixed op count, warmup, median of repeats). A comparative
+version is hard — each framework's thread-safety contract differs — so **guard-tier first**.
+
+**Revisit trigger:** free-threading promoted past Beta, a user-reported contention issue, or a rival
+publishing free-threaded throughput numbers. Guard-tier custom harness first; comparative only if the
+contracts can be mapped fairly. See the [nogil-support research](audits/2026-07-17-nogil-support-research-report.md).
+
+The other two evaluated axes were **declined** (not deferred): a *comparative* override scenario
+(each framework's override/mock API differs too much to compare; G12 covers modern-di) and a larger
+async-teardown scenario beyond G13's 10 resources (G13's LIFO loop already captures the scaling).
+
 ## Opt-in DEBUG resolution tracing (ERR-8) — from 2026-07-05 3.0 UX research
 
 A module-level `logging.getLogger("modern_di")` narrating resolution at DEBUG level: resolve start


### PR DESCRIPTION
## What

Delivers two of the three remaining unmeasured axes from the 2026-07-19 axes evaluation (both had no blocker — over-deferred, now shipped):

- **G12 override-active resolve** — a depth-6 chain resolved with one *unrelated* override active, so `has_overrides` is True and every node pays a `fetch_override` lookup. This is the per-node tax a mock-heavy test suite (the `modern-di-pytest` path) hits on every resolve. **~3.5 µs vs ~1.3 µs plain** — the tax is visible.
- **G13 teardown at scale** — the per-request cycle finalizing **10** cached REQUEST resources via `close_sync`, exercising the LIFO close loop (`reversed(_creation_order)`) that G7's single finalizer doesn't. **~26 µs.**

## Third axis: banked, not skipped

**Concurrent / free-threaded throughput** is genuinely different — `pytest-benchmark` measures single-thread wall time only; throughput needs a custom N-thread ops/sec harness (start barrier, shared warm container, GIL vs free-threaded 3.14t, cached-hit vs first-resolve-contention sub-cases). Recorded in [`deferred.md`](planning/deferred.md) with the measurement-shape notes and a revisit trigger, since it's the real forward-looking differentiator (locked singleton creation vs lock-free rivals under PEP 703).

## Testing

- `just bench` — guard tier, **14 pass** (G12 ~3.5 µs, G13 ~26 µs), correctness asserts pass.
- `just test-ci` unaffected (`testpaths=tests`, coverage omits `benchmarks/*`); `just lint-ci` clean.

Benchmarks only — no `modern_di/` change. Rationale: [`planning/changes/2026-07-19.06-override-and-teardown-benchmarks.md`](planning/changes/2026-07-19.06-override-and-teardown-benchmarks.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)