### PR TITLE
test(benchmarks): add concurrency throughput scenarios (G14, G15)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,6 +23,8 @@ cost. Runs in CI (informational, non-gating) and locally via `just bench`.
 | G11 | `validate()` on a wide 10-sibling graph (isolated via `pedantic`) | graph-validation traversal, fan-out |
 | G12 | Resolve a depth-6 chain with one unrelated override active | override front-guard (`fetch_override`) tax |
 | G13 | Per-request cycle finalizing 10 cached resources (`close_sync`) | LIFO teardown at scale |
+| G14 | Concurrent cached-hit throughput, N threads (lock-free read) | free-threaded read scaling |
+| G15 | Concurrent first-resolve, N threads (double-checked creation lock) | free-threaded creation-lock contention |
 
 **Rules.** Containers are built/warmed in setup, never inside the timed call —
 **except G8**, the cold scenario, which builds the root container *inside* the
@@ -36,6 +38,27 @@ round runs the full graph walk. Every benchmark asserts the resolved graph is
 correct. G7 is wall-clock only — instruction-count tooling cannot measure the
 awaited teardown, and a single reused event loop keeps loop overhead out of the
 signal as far as practical.
+
+### Concurrency (G14/G15)
+
+G14/G15 use a custom N-thread harness (`test_guard_concurrency.py`) — pytest-benchmark
+times a parallel batch of worker threads released together behind a barrier,
+parametrized over thread count `{1, 2, 4}` so the scaling trend shows within one run.
+The GIL vs free-threaded (PEP 703) comparison comes from running the file under each
+build (same version/arch):
+
+```
+uv run --python 3.14t --with pytest-benchmark pytest benchmarks/test_guard_concurrency.py
+```
+
+CI's guard-bench runs one GIL interpreter, so the free-threaded numbers are a manual
+run. **Finding:** resolution is thread-safe but its throughput **does not scale** with
+threads on a free-threaded build — cached-hit batch time is flat-to-worse as threads
+rise and matches the GIL, while a pure-compute control on the same harness scales
+~3.5x at 4 threads. The bottleneck is concurrent access to shared hot-path objects
+(registry resolver/cache dicts, container, cached value), not the GIL; first-resolve
+additionally serializes on the double-checked creation lock. Read the thread-count
+*trend*, not absolutes — throughput benches are noisy and guard-bench is non-gating.
 
 ## Comparative tier (`benchmarks/comparative/`, isolated project)
 

--- a/benchmarks/test_guard_concurrency.py
+++ b/benchmarks/test_guard_concurrency.py
@@ -1,0 +1,109 @@
+# ruff: noqa: ANN001, ANN201
+"""Guard tier — concurrent-resolution throughput (custom N-thread harness).
+
+pytest-benchmark measures single-thread wall time, so these time a *parallel batch* (N worker
+threads released together behind a barrier) as one unit, parametrized over thread count so the
+scaling curve is visible **within a single interpreter run** (no cross-interpreter comparison
+needed). Two sub-cases:
+
+- G14 concurrent cached-hit: a fixed total number of reads of a warm cached singleton, split
+  across N threads. The cached-hit path is lock-free, so on a free-threaded build (PEP 703) the
+  batch time should *drop* as N rises (throughput scales); under the GIL it stays flat.
+- G15 concurrent first-resolve: N threads each race to resolve the *same* K cold singletons, so
+  they contend on the double-checked creation lock (`CacheItem.get_or_create`). Singleton
+  creation is serialized by design, so this is expected *not* to scale even free-threaded — the
+  measured cost is the contention itself (the known trade-off vs lock-free-slot rivals).
+
+Read the batch-time-vs-thread-count trend, not the absolutes. The GIL vs free-threaded comparison
+comes from running the whole file under each build (same version/arch), e.g.:
+
+    uv run --python 3.14t --with pytest-benchmark pytest benchmarks/test_guard_concurrency.py
+
+CI's guard-bench runs one GIL interpreter. Throughput benchmarks are noisier than the single-thread
+guards; treat them as guidance. See benchmarks/README.md.
+"""
+
+import dataclasses
+import threading
+
+import pytest
+
+from modern_di import Container, Group, Scope, providers
+
+
+_THREAD_COUNTS = [1, 2, 4]
+
+
+def _run_parallel(worker, n_threads: int) -> None:
+    # Release all threads together (barrier) so the work overlaps maximally.
+    barrier = threading.Barrier(n_threads)
+
+    def _target() -> None:
+        barrier.wait()
+        worker()
+
+    threads = [threading.Thread(target=_target) for _ in range(n_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+# --- G14: concurrent cached-hit (lock-free read path, fixed total work) -----
+@dataclasses.dataclass(slots=True)
+class CachedSingleton:
+    pass
+
+
+class CachedGroup(Group):
+    obj = providers.Factory(creator=CachedSingleton, scope=Scope.APP, cache=True)
+
+
+_TOTAL_READS = 8000
+
+
+@pytest.mark.parametrize("n_threads", _THREAD_COUNTS)
+def test_g14_concurrent_cached_hit(benchmark, n_threads):
+    # Fixed total reads split across N threads: batch time drops with N iff the read path scales.
+    container = Container(scope=Scope.APP, groups=[CachedGroup], validate=False)
+    warm = container.resolve_provider(CachedGroup.obj)
+    reads_per_thread = _TOTAL_READS // n_threads
+
+    def _worker() -> None:
+        for _ in range(reads_per_thread):
+            container.resolve_provider(CachedGroup.obj)
+
+    benchmark(_run_parallel, _worker, n_threads)
+    assert container.resolve_provider(CachedGroup.obj) is warm  # same cached instance
+
+
+# --- G15: concurrent first-resolve (creation under the double-checked lock) --
+_K_COLD = 50
+_COLD_TYPES = [type(f"Cold{i}", (), {}) for i in range(_K_COLD)]
+_COLD_GROUP = type(
+    "ColdGroup",
+    (Group,),
+    {f"c{i}": providers.Factory(creator=t, scope=Scope.APP, cache=True) for i, t in enumerate(_COLD_TYPES)},
+)
+_COLD_PROVIDERS = [getattr(_COLD_GROUP, f"c{i}") for i in range(_K_COLD)]
+
+
+@pytest.mark.parametrize("n_threads", _THREAD_COUNTS)
+def test_g15_concurrent_first_resolve(benchmark, n_threads):
+    # All N threads race to first-resolve the SAME K cold singletons -> contention on each
+    # creation lock. Fresh container per round (untimed setup) so every round actually creates.
+    check = Container(scope=Scope.APP, groups=[_COLD_GROUP], validate=False)
+    assert all(check.resolve_provider(p) is not None for p in _COLD_PROVIDERS)
+
+    def _setup() -> "tuple[tuple[Container], dict[str, object]]":
+        container = Container(scope=Scope.APP, groups=[_COLD_GROUP], validate=False)
+        return (container,), {}
+
+    def _batch(container) -> None:
+        def _worker() -> None:
+            for provider in _COLD_PROVIDERS:
+                container.resolve_provider(provider)
+
+        _run_parallel(_worker, n_threads)
+
+    benchmark.pedantic(_batch, setup=_setup, rounds=120, iterations=1)

--- a/planning/changes/2026-07-19.07-concurrency-benchmarks.md
+++ b/planning/changes/2026-07-19.07-concurrency-benchmarks.md
@@ -1,0 +1,87 @@
+---
+summary: Add guard concurrency-throughput benchmarks (G14 cached-hit, G15 first-resolve) with a custom N-thread harness; finding — resolve throughput does not scale under free-threading (shared hot-path objects serialize it, not the GIL).
+---
+
+# Design: Concurrent-resolution throughput benchmarks
+
+## Summary
+
+The last remaining unmeasured axis from the 2026-07-19 evaluation: how resolution
+throughput behaves across threads, and how the double-checked singleton-creation
+lock contends, under the GIL vs a free-threaded build (PEP 703). `pytest-benchmark`
+can't measure this, so this adds a custom N-thread harness (two guard scenarios,
+G14/G15) parametrized over thread count so the scaling curve is visible within one
+interpreter run. **Guard-only** — rivals' thread-safety contracts don't map cleanly.
+
+**Headline finding:** modern-di's concurrent resolve **does not scale** on a
+free-threaded build. Cached-hit batch time is flat-to-worse as threads rise and is
+identical GIL vs free-threaded, while a pure-compute control on the same
+harness/machine scales ~3.5x at 4 threads. Resolution is thread-**safe**, but its
+throughput is bounded by concurrent access to shared hot-path objects (the registry
+resolver/cache dicts, the container, the cached value) — atomic refcounting and
+per-object dict synchronization under free-threading — not by the GIL. First-resolve
+additionally serializes on the creation lock, by design.
+
+## Motivation
+
+Free-threading is the forward-looking competitive axis (lock-free-slot rivals like
+that-depends), and modern-di supports it at Beta ([`concurrency.md`](../architecture/concurrency.md)).
+The nogil research (audit 2026-07-17) established correctness; this measures
+throughput and gives an honest, guarded answer: correctness holds, scaling does not.
+Without this benchmark, a future change that *did* improve free-threaded scaling
+(immortalizing shared providers, cutting shared-object touches on the read path)
+would have nothing to show it.
+
+## Design
+
+New file `benchmarks/test_guard_concurrency.py`. A `_run_parallel(worker, n)` helper
+releases N threads together behind a `threading.Barrier` and joins them; the timed
+unit is one parallel batch. Both scenarios are `@pytest.mark.parametrize`d over
+`n_threads ∈ {1, 2, 4}`.
+
+- **G14 cached-hit** — a *fixed total* of reads of one warm cached singleton, split
+  across N threads. Lock-free read path; batch time should drop with N iff it scales.
+- **G15 first-resolve** — N threads each race to resolve the *same* K=50 cold
+  singletons (fresh container per round via `pedantic` setup), contending on each
+  creation lock.
+
+The GIL-vs-free-threaded comparison comes from running the file under each build
+(same version/arch): `uv run --python 3.14t --with pytest-benchmark pytest
+benchmarks/test_guard_concurrency.py`. The harness was validated against a
+pure-compute control that scales ~3.5x on 3.14t, confirming it can detect scaling.
+
+Measured (median batch ms, 3.14 GIL vs 3.14t free-threaded, M2, guidance only):
+
+| scenario | 1 thr | 2 thr | 4 thr |
+|---|---|---|---|
+| G14 cached-hit, GIL | 3.55 | 5.10 | 5.31 |
+| G14 cached-hit, 3.14t | 3.54 | 5.03 | 5.44 |
+| G15 first-resolve, GIL | 0.47 | 0.66 | 1.03 |
+| G15 first-resolve, 3.14t | 0.47 | 0.66 | 0.99 |
+| pure-compute control, 3.14t | (1.0x) | ~2.0x | ~3.5x |
+
+## Non-goals
+
+- **No comparative tier** — each framework's thread-safety contract differs too much
+  to map fairly; guard-only, as decided.
+- **Not fixing the scaling** — this measures it. Reducing shared-object contention on
+  the read path is a separate, larger design question, banked in `deferred.md`.
+- **Not run under 3.14t in CI** — guard-bench uses one GIL interpreter; the
+  free-threaded numbers come from a manual run (documented). Adding a 3.14t
+  guard-bench job is a possible follow-up.
+
+## Testing
+
+- `just bench` — guard tier runs; G14/G15 (×3 thread counts) report, correctness
+  asserts pass under the GIL env.
+- Verified under `--python 3.14t` (GIL confirmed off via `sys._is_gil_enabled()`),
+  plus the pure-compute control (scales ~3.5x, harness validated).
+- `just test-ci` unaffected; `just lint-ci` clean.
+
+## Risk
+
+- **Throughput benchmarks are noisy** (thread scheduling, machine load). Read the
+  thread-count *trend* within a run, not absolutes; guard-bench is non-gating.
+- **Finding could be misread as "modern-di is slow concurrently."** It is not —
+  resolution is thread-safe and the per-op cost is competitive; it just does not gain
+  from more cores. Stated explicitly in the README and docstring.

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -109,27 +109,29 @@ path is higher-risk for a conservative library.
 child-build dominates a realistic request cycle enough to justify hot-path branches. Measure net,
 both tiers (guard `G6b` + comparative `C4`), before shipping.
 
-## Concurrent / free-threaded throughput benchmark — needs a custom harness — from 2026-07-19 remaining-axes eval
+## Free-threaded resolve throughput does not scale — from 2026-07-19 concurrency benchmark (G14/G15)
 
-The 2026-07-19 benchmark-axes evaluation shipped cold (G8/C5), context (G9/C6), validate (G10/G11),
-override (G12), and teardown (G13). The one axis **not** delivered is concurrent-resolution
-throughput: how resolution scales across threads, and how much the double-checked singleton-creation
-lock (`CacheItem.get_or_create`) contends — the forward-looking differentiator vs lock-free rivals
-(that-depends' lock-free slot) under free-threading (PEP 703). It is the real competitive story on
-3.14t, and modern-di already supports free-threading at Beta ([`concurrency.md`](../architecture/concurrency.md)).
+The 2026-07-19 benchmark-axes evaluation shipped **all** the pytest-benchmarkable axes: cold (G8/C5),
+context (G9/C6), validate (G10/G11), override (G12), teardown (G13), and now concurrency (G14/G15,
+change [`2026-07-19.07`](changes/2026-07-19.07-concurrency-benchmarks.md), guard-only custom N-thread
+harness). What the concurrency benchmark **revealed** is the real deferred item: modern-di's concurrent
+resolve is thread-**safe** but its throughput **does not scale** with threads on a free-threaded build
+(PEP 703). Cached-hit batch time is flat-to-worse as threads rise and matches the GIL, while a
+pure-compute control on the same harness scales ~3.5x at 4 threads — so the bottleneck is concurrent
+access to shared hot-path objects (registry resolver/cache dicts, container, cached value: atomic
+refcounting + per-object dict synchronization under free-threading), not the GIL. First-resolve also
+serializes on the double-checked creation lock ([`concurrency.md`](../architecture/concurrency.md)).
 
-**Why it is not a quick add:** `pytest-benchmark` measures single-thread wall time only. Throughput
-needs a **custom harness** — N worker threads behind a start barrier, each resolving from one shared
-warm container, measuring aggregate ops/sec — run under both the GIL and free-threaded 3.14t (CI has
-the `3.14t` job). Two sub-cases matter: (a) concurrent resolve of an already-**cached** singleton
-(read-mostly; should scale near-linearly on 3.14t if no false contention), and (b) concurrent
-**first** resolve of a singleton (the double-checked lock's contention window). Throughput numbers are
-noisy; the harness must control for that (fixed op count, warmup, median of repeats). A comparative
-version is hard — each framework's thread-safety contract differs — so **guard-tier first**.
+**The open work:** whether resolve throughput *can* scale free-threaded without breaking the
+zero-dependency, single-source-of-truth design — e.g. immortalizing shared providers/resolvers to cut
+refcount traffic, per-thread caches, or reducing shared-dict touches on the read path. Each trades
+against the conservative-feature-set and the shared-registry model; measure against G14/G15 before
+committing. A comparative version (vs that-depends' lock-free slot) stays out until the contracts map
+fairly. This is the forward-looking differentiator, so it matters if free-threading adoption grows.
 
-**Revisit trigger:** free-threading promoted past Beta, a user-reported contention issue, or a rival
-publishing free-threaded throughput numbers. Guard-tier custom harness first; comparative only if the
-contracts can be mapped fairly. See the [nogil-support research](audits/2026-07-17-nogil-support-research-report.md).
+**Revisit trigger:** free-threading promoted past Beta, a user reporting that resolution does not use
+their cores, or a rival publishing free-threaded scaling numbers. See the
+[nogil-support research](audits/2026-07-17-nogil-support-research-report.md) and G14/G15.
 
 The other two evaluated axes were **declined** (not deferred): a *comparative* override scenario
 (each framework's override/mock API differs too much to compare; G12 covers modern-di) and a larger


### PR DESCRIPTION
## What

The last unmeasured axis — concurrent-resolution throughput under the GIL vs a free-threaded build (PEP 703). `pytest-benchmark` can't measure this, so a **custom N-thread harness** (`test_guard_concurrency.py`) times a parallel batch of worker threads released together behind a barrier, parametrized over thread count `{1, 2, 4}` so the scaling trend shows within one interpreter run. **Guard-only** — rivals' thread-safety contracts don't map fairly.

- **G14 concurrent cached-hit** — fixed total reads of a warm cached singleton split across N threads (lock-free read path).
- **G15 concurrent first-resolve** — N threads race the same K=50 cold singletons through the double-checked creation lock.

## Finding (the valuable part)

**Resolution is thread-safe, but its throughput does not scale with threads on a free-threaded build.**

| scenario | 1 thr | 2 thr | 4 thr |
|---|---|---|---|
| G14 cached-hit, GIL 3.14 | 3.55 | 5.10 | 5.31 ms |
| G14 cached-hit, free-threaded 3.14t | 3.54 | 5.03 | 5.44 ms |
| pure-compute control, 3.14t | 1.0x | ~2.0x | ~3.5x |

Cached-hit batch time is **flat-to-worse** as threads rise and is **identical GIL vs free-threaded**, while a pure-compute control on the same harness/machine scales ~3.5x at 4 threads (proving the harness *can* detect scaling; GIL confirmed off via `sys._is_gil_enabled()`). The bottleneck is concurrent access to shared hot-path objects (registry resolver/cache dicts, container, cached value) — atomic refcounting + per-object dict synchronization under free-threading — **not** the GIL. First-resolve additionally serializes on the creation lock, by design.

This is an honest, guarded result: per-op cost is competitive and it's thread-safe, it just doesn't gain from more cores. The scaling limitation (and whether it can be lifted without breaking the zero-dep/shared-registry design) is banked in [`deferred.md`](planning/deferred.md) as the real follow-up.

## Testing

- `just bench` — guard tier, **20 pass** (G14/G15 × 3 thread counts), correctness asserts pass under the GIL env.
- Verified under `--python 3.14t` (GIL off) + a pure-compute control (~3.5x, harness validated).
- `just test-ci` unaffected; `just lint-ci` clean.

CI's guard-bench runs one GIL interpreter, so the free-threaded numbers are a manual run (documented in the README); a 3.14t guard-bench job is a possible follow-up.

Benchmarks only — no `modern_di/` change. Rationale: [`planning/changes/2026-07-19.07-concurrency-benchmarks.md`](planning/changes/2026-07-19.07-concurrency-benchmarks.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)