### PR TITLE
docs(concurrency): record free-threaded scaling diagnosis (not liftable)

### DIFF
--- a/architecture/concurrency.md
+++ b/architecture/concurrency.md
@@ -79,6 +79,13 @@ not **Stable**. See the report for the full argument.
   lock; racing them against live `resolve()` is inherently unordered (it always
   was, GIL or not). `close` / `open` are the same: tear a container down only
   after concurrent resolution has stopped.
-- **Performance, not correctness, is the open question.** Whether the
-  per-container lock contends under heavy parallel first-resolution is unmeasured
-  and out of scope for the Beta claim (report §7).
+- **Thread-safe, but resolve throughput does not scale across cores.** Measured
+  (guard benchmarks G14/G15): concurrent resolution is correct and per-op latency
+  is competitive, but adding threads does not raise throughput on a free-threaded
+  build — it tracks the GIL. The cause is CPython's atomic reference counting of
+  the objects every resolve shares (the returned singleton value, the provider
+  objects, the compiled-resolver closures and their captured cells), not the
+  per-container lock and not anything modern-di can remove without immortalizing
+  those objects (no public CPython API). It is a CPython-level limitation that its
+  own expanding deferred reference counting (PEP 703) will lift for free as it
+  reaches ordinary instances. See the [free-threaded scaling diagnosis](../planning/deferred.md).

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -122,15 +122,40 @@ access to shared hot-path objects (registry resolver/cache dicts, container, cac
 refcounting + per-object dict synchronization under free-threading), not the GIL. First-resolve also
 serializes on the double-checked creation lock ([`concurrency.md`](../architecture/concurrency.md)).
 
-**The open work:** whether resolve throughput *can* scale free-threaded without breaking the
-zero-dependency, single-source-of-truth design — e.g. immortalizing shared providers/resolvers to cut
-refcount traffic, per-thread caches, or reducing shared-dict touches on the read path. Each trades
-against the conservative-feature-set and the shared-registry model; measure against G14/G15 before
-committing. A comparative version (vs that-depends' lock-free slot) stays out until the contracts map
-fairly. This is the forward-looking differentiator, so it matters if free-threading adoption grows.
+**Diagnosed (2026-07-19): not liftable by modern-di — it is CPython refcount contention, not the
+lock.** A thread-isolation sweep (fixed total work split across 4 threads on 3.14t, GIL confirmed
+off; speedup = t1/t4, ceiling ~3.8x from a pure-compute control) pinned exactly what serializes:
 
-**Revisit trigger:** free-threading promoted past Beta, a user reporting that resolution does not use
-their cores, or a rival publishing free-threaded scaling numbers. See the
+| case | what is shared across threads | 4-thread speedup |
+|---|---|---|
+| pure compute | nothing | 3.8x (ceiling) |
+| fully thread-local (distinct provider + container + value) | module globals only | 2.17x |
+| distinct container per thread | + the **provider** object | 0.92x |
+| distinct value, shared container | + provider + machinery | 0.84x |
+| same singleton (the G14 case) | + the **returned value** | 0.64x |
+| raw `dict.get` -> one shared value | just the value's refcount | 0.28x |
+
+The read path is bounded by atomic reference counting on the objects every resolve shares: most
+sharply the **returned singleton value** (a singleton *is* a shared object — inherent), then the
+shared **provider** objects (distinct-container 0.92x vs thread-local 2.17x is the provider), then
+the compiled-resolver closures and their captured cells (every `LOAD_DEREF` of a shared capture
+increfs it). The per-container lock is *not* the bottleneck.
+
+A throwaway **immortalization experiment** (ctypes set of `ob_ref_local` on the free-threaded build,
+offset verified against a known-immortal object) confirmed the cause *and* quantified the ceiling:
+transitively immortalizing the shared hot-path objects lifts the same-singleton case from **~0.6x to
+~2.5x** (median of 3 runs; ≈68% of the ~3.7x machine ceiling). So it is squarely refcounting, and it
+*is* recoverable in principle — but the only lever is unshippable. There is **no public API** to
+immortalize user objects (PEP 683 is internal C-API); the `ctypes` poke is free-threaded-build-specific
+and unsafe; and part of the win requires immortalizing the user's **singleton value**, which then is
+never freed — a memory leak, unacceptable for a general container. So this stays off the table for a
+conservative zero-dep library. **The fix is CPython's**, not ours: deferred reference counting (PEP 703)
+expanding to ordinary instances/cells lifts this for free, no code change.
+
+**Revisit trigger:** CPython deferred reference counting expands to cover instances/cells (retest
+G14/G15 — should scale for free), or a user reports a real resolve-throughput bottleneck (unlikely;
+resolution is a tiny fraction of request work). A comparative version (vs that-depends' lock-free
+slot) stays out until the contracts map fairly. See the
 [nogil-support research](audits/2026-07-17-nogil-support-research-report.md) and G14/G15.
 
 The other two evaluated axes were **declined** (not deferred): a *comparative* override scenario


### PR DESCRIPTION
## What

Answers "can we lift the free-threaded scaling limitation?" (from #353) with a diagnosis, and records it in the truth home. **No `modern_di/` change** — docs only.

## The diagnosis

A thread-isolation sweep (fixed total work split across 4 threads, 3.14t, GIL confirmed off; speedup = t1/t4, ~3.8x pure-compute ceiling) pinned exactly what serializes resolution:

| case | what's shared | 4-thread speedup |
|---|---|---|
| pure compute | nothing | 3.8x (ceiling) |
| fully thread-local (distinct provider+container+value) | module globals | 2.17x |
| distinct container | + the **provider** | 0.92x |
| distinct value, shared container | + provider + machinery | 0.84x |
| same singleton (G14) | + the **returned value** | 0.64x |
| raw `dict.get` → one shared value | just the value's refcount | 0.28x |

It's **atomic reference counting of shared objects** — the returned singleton value, the provider objects, the resolver closures + captured cells — not the per-container lock.

## The immortalization experiment (throwaway, unshippable)

Confirmed the cause *and* quantified the ceiling: transitively immortalizing the shared hot-path objects (ctypes `ob_ref_local` set, offset verified against a known-immortal object) lifts the worst case from **~0.6x → ~2.5x** (median of 3 runs, ≈68% of the machine ceiling). So it *is* refcounting and *is* recoverable in principle — but only via an unshippable lever:

- No public API to immortalize user objects (PEP 683 is internal C-API).
- Part of the win needs immortalizing the user's **singleton value**, which then is never freed — a memory leak.
- The refcount-field offset is free-threaded-build-specific.

Off the table for a conservative zero-dep library. **The fix is CPython's** — deferred reference counting (PEP 703) expanding to ordinary instances/cells lifts this for free, no code change.

## Changes

- `architecture/concurrency.md` — the "performance is the open question" caveat becomes the measured finding (thread-safe, doesn't scale, CPython-bound).
- `planning/deferred.md` — the entry goes from "open work: can it scale?" to the diagnosis + evidence table + immortalization ceiling; revisit trigger is now CPython deferred refcounting expanding (retest G14/G15).

`just lint-ci` clean; `architecture/` is not in the published docs site, and the `../planning/...` cross-link matches the existing convention in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)