### PR TITLE
docs(decisions): decline child-container lazy-allocation (measured)

### DIFF
--- a/planning/decisions/2026-07-19-child-lazy-alloc-declined.md
+++ b/planning/decisions/2026-07-19-child-lazy-alloc-declined.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+summary: Decline lazy-allocating the child-container RLock/CacheRegistry/ContextRegistry — measured saving is ~0 for realistic caching request cycles and ~2-3.5% only for a narrow no-cache child, not worth a resolve hot-path branch plus re-introducing the singleton-creation race.
+supersedes: null
+superseded_by: null
+---
+
+# Decline lazy-allocation of child-container registries
+
+**Decision:** Keep `Container.__init__` eagerly building the per-child `RLock`,
+`CacheRegistry`, and `ContextRegistry`. Do not lazy-allocate them.
+
+## Context
+
+After the `_next_deeper` memo (`2026-07-19.02`, #348) took ~40% off default
+child-build, the remaining per-child cost was three eager allocations —
+`RLock` (~195-214 ns), `CacheRegistry` (~217 ns), `ContextRegistry` (~189 ns).
+Deferred work proposed lazy-allocating them (construct on first use) to cut
+construction cost, with the net (construction saving vs a resolve hot-path
+branch) left "untested." This settles it, starting with the strongest candidate,
+the `RLock` (REQUEST children rarely create singletons, so it is the allocation
+most often wasted).
+
+## Decision & rationale
+
+Measured ceiling (current `use_lock=True` vs `False`, which already skips the
+RLock alloc; py3.10, guidance):
+
+- Isolated child build: RLock alloc ≈ **195 ns/child**.
+- **Realistic *caching* request cycle** (build child → resolve a REQUEST-cached
+  resource → close, the C4/G7 shape): saving ≈ **0 (0.4%)** — a caching child
+  *uses* the lock, so lazy only defers the allocation, and adds a `None`-check.
+- Narrow **no-cache child** (transient/APP deps only, no request caching, no
+  context): saving ≈ **67 ns (3.5%)** — and this is the ceiling, before any cost.
+
+So the best case is ~0 for the workloads that matter. Real integration request
+children inject context (uses `ContextRegistry`) and cache a request-scoped
+resource (uses `CacheRegistry` and the `RLock`) — the C4/G7/G9 scenarios all do —
+so the trio is *used*, and lazy-allocation saves nothing there while taxing the
+hot path. Against a ~0-to-3.5% narrow win, lazy-allocation costs:
+
+1. A `None`-check on the cached-resolve hot path plus a `_use_lock` slot.
+2. **Re-introducing the singleton-creation race the lock exists to prevent** —
+   lazy lock creation must itself be atomic, so it needs a guard lock or a
+   CAS-style publish, a new concurrency-correctness surface against the freshly
+   documented Beta contract ([`concurrency.md`](../../architecture/concurrency.md)).
+
+The `CacheRegistry`/`ContextRegistry` variants are *weaker* still: they are used
+more often in realistic children, so they save even less. Net negative for a
+conservative, zero-dependency library. Decline all three.
+
+## Revisit trigger
+
+A profile of a *realistic* request cycle (with context + caching) showing
+child-container construction — specifically these allocations, not `_next_deeper`
+— dominating, or a user-reported per-request construction bottleneck in a
+build-heavy, cache-free workload (deeply nested short-lived scopes). Re-measure
+the net against `G6b` + `G1-G3` + `C4/G7/G9`, and solve the lazy-lock atomicity,
+before reopening.

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -86,29 +86,6 @@ table, consistent with the uniform dispatch-floor win. **The one clear gap — C
 behind the slot-memoized rivals (dependency-injector 61 ns C-slot, that-depends 83 ns, wireup 95 ns) — is
 what the dropped C2 lever targeted, and stays open by design** (closing it was ruled not worth the machinery).
 
-## Child-container construction: lazy-allocation leads — from 2026-07-19 P2 measurement
-
-Profiling per-request child-container construction (the cost center of the C4 request-lifecycle
-scenario, "dominated by container construction, not the memo") found the default
-`build_child_container()` (auto-increment) path at ~2983 ns/child, of which **~44% (1319 ns) was
-`_next_deeper` re-sorting the enum on every call**. That was fixed by memoizing `_next_deeper`
-(change [`2026-07-19.02`](changes/2026-07-19.02-memoize-next-deeper.md), ~−40% on the default
-path). The remaining measured per-child allocations were **not** actioned:
-
-- `threading.RLock()` — ~214 ns/child. A child gets a fresh lock even though most REQUEST children
-  cache nothing (caching is usually APP-scoped) and many request paths are single-threaded.
-- `CacheRegistry()` — ~217 ns/child (dataclass + dict + list).
-- `ContextRegistry(context or {})` — ~189 ns/child (+~52 ns for the empty dict when no context).
-
-Lazy-allocating any of these (construct on first use) would cut construction cost but adds a branch
-on the resolve/cache **hot path** — so the win is not construction-side-only; the net (construction
-saving vs per-resolve branch cost) must be measured before committing, and touching the resolve hot
-path is higher-risk for a conservative library.
-
-**Revisit trigger:** a user-reported per-request construction bottleneck, or a benchmark showing
-child-build dominates a realistic request cycle enough to justify hot-path branches. Measure net,
-both tiers (guard `G6b` + comparative `C4`), before shipping.
-
 ## Free-threaded resolve throughput does not scale — from 2026-07-19 concurrency benchmark (G14/G15)
 
 The 2026-07-19 benchmark-axes evaluation shipped **all** the pytest-benchmarkable axes: cold (G8/C5),


### PR DESCRIPTION
## What

Settles the one open performance lever from the 2026-07-19 axes evaluation — lazy-allocating the per-child `RLock` / `CacheRegistry` / `ContextRegistry` — with a measurement, and records the decline as a decision so it isn't re-litigated. **Docs only, no `modern_di/` change.**

## The measurement (starting with the RLock, the strongest candidate)

Ceiling via current `use_lock=True` vs `False` (which already skips the RLock alloc), py3.10, guidance:

| case | RLock saving |
|---|---|
| isolated child build | ~195 ns/child |
| **realistic caching request cycle** (build → resolve REQUEST-cached → close; C4/G7 shape) | **~0 (0.4%)** — the child *uses* the lock, so lazy only defers the alloc |
| narrow no-cache child (transient/APP only, no context) | ~67 ns (3.5%) — and this is the ceiling, before any cost |

## Why decline

Best case is **~0 for the workloads that matter**: real integration request children inject context (`ContextRegistry`) and cache a request-scoped resource (`CacheRegistry` + `RLock`) — G9/C4/G7 all do — so the trio is *used* and lazy-allocation saves nothing while adding cost. Against a ~0-to-3.5% narrow win, it would add:

1. a `None`-check on the cached-resolve **hot path** + a `_use_lock` slot;
2. **re-introduction of the singleton-creation race** the lock prevents — lazy lock init must itself be atomic (guard lock / CAS), a new concurrency-correctness surface against the just-documented Beta contract.

`CacheRegistry`/`ContextRegistry` are weaker still (used more often in real children). Net negative for a conservative zero-dep library.

## Changes

- `planning/decisions/2026-07-19-child-lazy-alloc-declined.md` — the decision with the evidence table and a concrete revisit trigger (a realistic-cycle profile showing these allocations dominating, or a build-heavy cache-free bottleneck).
- `planning/deferred.md` — remove the now-decided "lazy-allocation leads" entry (promoted to the decision).

`just lint-ci` clean; the decision appears in `just index`.

## Bottom line on performance

With this, the perf field is fully swept: cold `inspect.signature` shipped (#349), dispatch-floor (#347) and `_next_deeper` (#348) shipped, C2 memo-swap tried-and-dropped, codegen rejected by stance, free-threaded scaling diagnosed as CPython-bound (#354), and child lazy-alloc now declined with numbers. Nothing high-value remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)