### PR TITLE
refactor: do-first readability findings (cycle rotation, union split)

### DIFF
--- a/modern_di/dependency_graph.py
+++ b/modern_di/dependency_graph.py
@@ -66,10 +66,10 @@ def build_cycle_error(
     rotation of the same ring is the same cycle — anchoring on a stable per-process id makes the
     rendered message path- and seed-independent.
     """
-    ring = providers[:-1]
-    anchor = min(range(len(ring)), key=lambda i: ring[i].provider_id)
-    rotated = [*ring[anchor:], *ring[:anchor]]
-    canonical = [*rotated, rotated[0]]
+    ring = providers[:-1]  # drop the repeated first node to get the bare cycle
+    lead = min(range(len(ring)), key=lambda i: ring[i].provider_id)  # lowest-id node becomes the canonical lead
+    rotated = [*ring[lead:], *ring[:lead]]
+    canonical = [*rotated, rotated[0]]  # re-close the ring on the lead node
     return exceptions.CircularDependencyError(
         steps=[
             exceptions.ResolutionStep(scope=p.scope, name=p.display_name, location=p.definition_site) for p in canonical

--- a/modern_di/types_parser.py
+++ b/modern_di/types_parser.py
@@ -33,15 +33,15 @@ class SignatureItem:
 
         # union type
         if isinstance(type_, types.UnionType) or typing.get_origin(type_) is typing.Union:
-            args = [typing.get_origin(x) or x for x in typing.get_args(type_)]
-            if types.NoneType in args:
+            union_members = [typing.get_origin(x) or x for x in typing.get_args(type_)]
+            non_none_members = [member for member in union_members if member is not types.NoneType]
+            if len(non_none_members) != len(union_members):
                 result["is_nullable"] = True
-                args.remove(types.NoneType)
 
-            if len(args) > 1:
-                result["args"] = args
-            elif args:
-                result["arg_type"] = args[0]
+            if len(non_none_members) > 1:
+                result["args"] = non_none_members
+            elif non_none_members:
+                result["arg_type"] = non_none_members[0]
 
         # generic — parameterized generics are not resolvable by type
         elif typing.get_origin(type_) is not None:

--- a/planning/changes/2026-07-19.09-do-first-readability-refactors.md
+++ b/planning/changes/2026-07-19.09-do-first-readability-refactors.md
@@ -1,0 +1,38 @@
+---
+summary: Two behavior-preserving readability refactors (cycle-rotation naming, union-member split) from the 2026-07-19 perf+readability audit's do-first bucket.
+---
+
+# Change: Do-first readability refactors from the perf+readability audit
+
+**Lane:** lightweight — ~15 LOC net across 2 files, no new file, no public-API
+change, no new test (behavior-preserving; the existing suite at 100% coverage is
+the gate).
+
+## Goal
+
+Land the two `do-first` findings from the
+[2026-07-19 perf+readability audit](../audits/2026-07-19-perf-readability-audit-report.md):
+dense list-mechanics that obscure their intent, both off the resolve hot path.
+
+## Approach
+
+Pure clarity, no behavior change (verified: `just test-ci` stays 432-green at
+100% coverage).
+
+- `dependency_graph.py` cycle→canonical rotation: rename `anchor` → `lead` and
+  add one-line notes so the ring/lead/re-close steps read as the algorithm.
+- `types_parser.py` union decomposition: replace the in-place `args.remove(NoneType)`
+  with an up-front filter into `union_members` / `non_none_members`, so nullable
+  detection and single-vs-multi branching read off immutable lists. The
+  `is_nullable` key is still added only when nullable (dataclass default is
+  `False`), keeping the built `result` dict identical.
+
+## Files
+
+- `modern_di/dependency_graph.py` — cycle-rotation naming + comments
+- `modern_di/types_parser.py` — union-member split, no in-place mutation
+
+## Verification
+
+- [x] `just test-ci` — 432 passed, 100% coverage (behavior preserved, no new test).
+- [x] `just lint-ci` — clean (ruff, ty, planning).


### PR DESCRIPTION
The two `do-first` items from the [2026-07-19 perf+readability audit](https://github.com/modern-python/modern-di/blob/main/planning/audits/2026-07-19-perf-readability-audit-report.md). Both are off the resolve hot path and behavior-preserving; see the change bundle `planning/changes/2026-07-19.09-do-first-readability-refactors.md`.

- **dependency_graph.py** — name the cycle→canonical rotation steps (`anchor` → `lead`, plus one-line notes) so it reads as its algorithm rather than list slicing.
- **types_parser.py** — split union decomposition into `union_members` / `non_none_members`, dropping the in-place `args.remove(NoneType)`; `is_nullable` is still set only when nullable, so the built `SignatureItem` is identical.

The audit's three performance findings were all correctly gated to `already-settled` against the `child-lazy-alloc-declined` ruling — there was no hot-path work to do.

## Verification
- `just test-ci` — 432 passed, 100% coverage (behavior preserved, no new test)
- `just lint-ci` — clean (ruff, ty, planning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)