### PR TITLE
refactor: cleanup readability findings (registry setup, gap note, wiring seam)

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -101,13 +101,7 @@ class Container:
         self.context_registry = ContextRegistry(context=context or {})
         self.providers_registry: ProvidersRegistry
         self.overrides_registry: OverridesRegistry
-        if parent_container:
-            self.providers_registry = parent_container.providers_registry
-            self.overrides_registry = parent_container.overrides_registry
-        else:
-            self.providers_registry = ProvidersRegistry()
-            self.providers_registry.register(Container, container_provider)
-            self.overrides_registry = OverridesRegistry()
+        self._setup_registries(parent_container)
         if groups:
             all_providers: list[AbstractProvider[typing.Any]] = []
             for one_group in groups:
@@ -125,6 +119,20 @@ class Container:
                 exceptions.UnvalidatedContainerWarning,
                 stacklevel=2,
             )
+
+    def _setup_registries(self, parent_container: "typing_extensions.Self | None") -> None:
+        """Share the parent's providers/overrides registries, or create fresh ones on a root.
+
+        A root seeds its providers registry with ``container_provider`` so ``Container``
+        resolves to the resolving container.
+        """
+        if parent_container:
+            self.providers_registry = parent_container.providers_registry
+            self.overrides_registry = parent_container.overrides_registry
+        else:
+            self.providers_registry = ProvidersRegistry()
+            self.providers_registry.register(Container, container_provider)
+            self.overrides_registry = OverridesRegistry()
 
     def build_child_container(
         self,

--- a/modern_di/types_parser.py
+++ b/modern_di/types_parser.py
@@ -61,7 +61,9 @@ def _parse_parameter(
 ) -> SignatureItem | None:
     if param.kind is inspect.Parameter.POSITIONAL_ONLY:
         if param.default is not param.empty:
-            return None  # cannot be passed by keyword; the default applies
+            # None is a signal, not "no item": parse_creator reads it as a positional-only gap
+            # (drops the param and sets has_positional_only_gap); the creator's own default fills it.
+            return None
         raise exceptions.UnsupportedCreatorParameterError(
             creator=creator,
             parameter_name=param_name,

--- a/modern_di/wiring.py
+++ b/modern_di/wiring.py
@@ -109,7 +109,53 @@ class WiringPlan:
         registry: "ProvidersRegistry",
         owner: "Factory[typing.Any]",
     ) -> "WiringPlan":
-        """Partition *parsed_kwargs* into wiring buckets. Never raises."""
+        """Partition *parsed_kwargs* into wiring buckets. Never raises.
+
+        Two phases: a by-type pass over ``parsed_kwargs``, then an overlay pass for any
+        explicit ``kwargs={...}`` entries — each bucketing into the same four dicts.
+        """
+        provider_kwargs, static_kwargs, context_kwargs, unwireable = cls._wire_by_type(
+            parsed_kwargs=parsed_kwargs,
+            kwargs=kwargs,
+            registry=registry,
+            owner=owner,
+        )
+
+        if kwargs:
+            cls._apply_overlay(
+                kwargs=kwargs,
+                parsed_kwargs=parsed_kwargs,
+                provider_kwargs=provider_kwargs,
+                static_kwargs=static_kwargs,
+                context_kwargs=context_kwargs,
+            )
+
+        return cls(
+            provider_kwargs=provider_kwargs,
+            static_kwargs=static_kwargs,
+            context_kwargs=context_kwargs,
+            unwireable=unwireable,
+            pure_provider=not static_kwargs and not context_kwargs,
+        )
+
+    @staticmethod
+    def _wire_by_type(
+        *,
+        parsed_kwargs: dict[str, SignatureItem],
+        kwargs: dict[str, typing.Any] | None,
+        registry: "ProvidersRegistry",
+        owner: "Factory[typing.Any]",
+    ) -> tuple[
+        dict[str, "AbstractProvider[typing.Any]"],
+        dict[str, typing.Any],
+        dict[str, "tuple[ContextProvider[typing.Any], SignatureItem]"],
+        "list[tuple[str, SignatureItem]]",
+    ]:
+        """Bucket each parsed parameter by resolving its type; the overlay pass runs after.
+
+        Returns the four buckets ``(provider, static, context, unwireable)``. A name also present
+        in explicit ``kwargs={...}`` is skipped here — ``_apply_overlay`` owns it.
+        """
         provider_kwargs: dict[str, AbstractProvider[typing.Any]] = {}
         static_kwargs: dict[str, typing.Any] = {}
         context_kwargs: dict[str, tuple[ContextProvider[typing.Any], SignatureItem]] = {}
@@ -117,7 +163,7 @@ class WiringPlan:
 
         for name, item in parsed_kwargs.items():
             if kwargs and name in kwargs:
-                continue  # supplied as a static kwarg below
+                continue  # supplied as a static kwarg by the overlay pass
 
             provider = find_dep_provider(registry, owner, item)
             if provider is not None:
@@ -136,22 +182,7 @@ class WiringPlan:
             # UNWIRABLE: record the (name, item) pair but do not raise
             unwireable.append((name, item))
 
-        if kwargs:
-            cls._apply_overlay(
-                kwargs=kwargs,
-                parsed_kwargs=parsed_kwargs,
-                provider_kwargs=provider_kwargs,
-                static_kwargs=static_kwargs,
-                context_kwargs=context_kwargs,
-            )
-
-        return cls(
-            provider_kwargs=provider_kwargs,
-            static_kwargs=static_kwargs,
-            context_kwargs=context_kwargs,
-            unwireable=unwireable,
-            pure_provider=not static_kwargs and not context_kwargs,
-        )
+        return provider_kwargs, static_kwargs, context_kwargs, unwireable
 
     @staticmethod
     def _apply_overlay(

--- a/planning/changes/2026-07-19.10-audit-cleanups.md
+++ b/planning/changes/2026-07-19.10-audit-cleanups.md
@@ -1,0 +1,58 @@
+---
+summary: Three behavior-preserving readability cleanups (registry-setup extraction, positional-only-gap note, wiring two-phase seam) from the 2026-07-19 audit's cleanup bucket.
+---
+
+# Design: Cleanup readability findings from the perf+readability audit
+
+## Summary
+
+Land the three `cleanup` findings from the
+[2026-07-19 perf+readability audit](../audits/2026-07-19-perf-readability-audit-report.md).
+All are pure clarity, off the resolve hot path, and behavior-preserving — the
+existing suite at 100% coverage is the gate (no new test).
+
+## Motivation
+
+The audit's cleanup bucket flagged three low-risk clarity gaps: a duplicated
+root-vs-child branch inlined in `Container.__init__`, an undocumented dual-exit
+contract in `_parse_parameter`, and a two-phase `WiringPlan.build` whose phases
+blend with no seam. None touch an invariant.
+
+## Design
+
+- **`container.py`** — extract `_setup_registries(parent_container)` so `__init__`
+  states the share-vs-create intent once; the helper carries the "root seeds
+  `container_provider`" note. Pure code-move.
+- **`types_parser.py`** — a two-line note at the positional-only `return None`
+  site explaining that `None` is a *signal* read by `parse_creator` as a
+  positional-only gap (drops the param, sets `has_positional_only_gap`), the
+  creator's own default filling the slot. Comment-only.
+- **`wiring.py`** — extract the by-type pass out of `build()` into a
+  `_wire_by_type()` static method mirroring the existing `_apply_overlay()`, so
+  the by-type-then-overlay design is explicit. `_wire_by_type` *owns and returns*
+  its four buckets (rather than mutating passed-in dicts) — this keeps it to four
+  parameters (under the PLR0913 limit) and reads as "build these buckets", with
+  `build` unpacking them and the overlay pass mutating them after.
+
+No capability contract moves — behavior is identical, so no `architecture/`
+promotion.
+
+## Non-goals
+
+- No behavior change; no public-API change. If any of these altered semantics it
+  would be out of scope for a readability cleanup.
+- Not touching the resolve hot path (`resolver_compiler.py`) — its deliberate
+  inlining is settled.
+
+## Testing
+
+- `just test-ci` — 432 passed, 100% coverage (behavior preserved, no new test).
+- `just lint-ci` — clean (ruff, ty, planning).
+
+## Risk
+
+Low. All three are code-moves / comments verified behavior-identical by the
+unchanged suite at full coverage. The only judgment call — `_wire_by_type`
+returning its buckets vs. mutating in place — was taken to avoid a PLR0913
+suppression and reads more clearly; `build` still constructs the final
+`WiringPlan` from the same four buckets.


### PR DESCRIPTION
The three `cleanup` items from the [2026-07-19 perf+readability audit](https://github.com/modern-python/modern-di/blob/main/planning/audits/2026-07-19-perf-readability-audit-report.md). All off the resolve hot path and behavior-preserving; see the change bundle `planning/changes/2026-07-19.10-audit-cleanups.md`.

- **container.py** — extract `_setup_registries(parent_container)` so `__init__` states the share-vs-create intent once.
- **types_parser.py** — a two-line note that `_parse_parameter`'s `None` return is a *signal* read by `parse_creator` as a positional-only gap (drops the param, sets `has_positional_only_gap`), not "no item".
- **wiring.py** — extract the by-type pass into `_wire_by_type()` mirroring the existing `_apply_overlay()`, making `build()`'s by-type-then-overlay design explicit. `_wire_by_type` owns and returns its four buckets (keeps it under PLR0913 and reads as "build these buckets"); `build` unpacks them and the overlay pass mutates them after.

No capability contract moves — behavior is identical.

## Verification
- `just test-ci` — 432 passed, 100% coverage (behavior preserved, no new test)
- `just lint-ci` — clean (ruff, ty, planning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)