### PR TITLE
refactor: inline _setup_registries back into __init__

### DIFF
--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -101,7 +101,15 @@ class Container:
         self.context_registry = ContextRegistry(context=context or {})
         self.providers_registry: ProvidersRegistry
         self.overrides_registry: OverridesRegistry
-        self._setup_registries(parent_container)
+        # Inlined, not a helper: __init__ is on the per-request child-build path, so avoid the extra
+        # call frame. A root seeds container_provider so `Container` resolves to the resolving container.
+        if parent_container:
+            self.providers_registry = parent_container.providers_registry
+            self.overrides_registry = parent_container.overrides_registry
+        else:
+            self.providers_registry = ProvidersRegistry()
+            self.providers_registry.register(Container, container_provider)
+            self.overrides_registry = OverridesRegistry()
         if groups:
             all_providers: list[AbstractProvider[typing.Any]] = []
             for one_group in groups:
@@ -119,20 +127,6 @@ class Container:
                 exceptions.UnvalidatedContainerWarning,
                 stacklevel=2,
             )
-
-    def _setup_registries(self, parent_container: "typing_extensions.Self | None") -> None:
-        """Share the parent's providers/overrides registries, or create fresh ones on a root.
-
-        A root seeds its providers registry with ``container_provider`` so ``Container``
-        resolves to the resolving container.
-        """
-        if parent_container:
-            self.providers_registry = parent_container.providers_registry
-            self.overrides_registry = parent_container.overrides_registry
-        else:
-            self.providers_registry = ProvidersRegistry()
-            self.providers_registry.register(Container, container_provider)
-            self.overrides_registry = OverridesRegistry()
 
     def build_child_container(
         self,

--- a/planning/changes/2026-07-19.11-inline-registry-setup.md
+++ b/planning/changes/2026-07-19.11-inline-registry-setup.md
@@ -1,0 +1,37 @@
+---
+summary: Inline _setup_registries back into Container.__init__ to avoid a call frame per child build; keeps the per-request construction path lean.
+---
+
+# Change: Inline registry setup back into `Container.__init__`
+
+**Lane:** lightweight — one file, no public-API change, no new test (behavior
+identical; the existing suite at 100% coverage is the gate).
+
+## Goal
+
+Reverse the `container.py` part of change
+[`2026-07-19.10`](2026-07-19.10-audit-cleanups.md): fold `_setup_registries()`
+back inline. A perf review of PR #357 found the extraction added one Python
+call frame to every `Container.__init__`, which is on the **per-request
+child-build path** (`build_child_container` → `__init__`) and the cold-start
+path — a path deliberately kept lean (#348 memoized `_next_deeper` for ~40%,
+#355 declined child-lazy-alloc on measurement). The cost is below the
+guard-bench noise floor, but there is no reason to spend a frame there for a
+readability nicety. The other two cleanups in `.10` (the `types_parser` comment,
+the `wiring` compile-time extraction) carry zero runtime cost and stay.
+
+## Approach
+
+Inline the share-vs-create `if/else` back into `__init__` and delete the
+`_setup_registries` helper. Add a two-line note at the site stating it is
+inlined *on purpose* (per-request path, avoid the call frame) so a future
+refactor or audit does not re-extract it.
+
+## Files
+
+- `modern_di/container.py` — inline the registry-setup branch; drop the helper.
+
+## Verification
+
+- [x] `just test-ci` — 432 passed, 100% coverage (behavior identical).
+- [x] `just lint-ci` — clean (ruff, ty, planning).


### PR DESCRIPTION
A perf review of #357 found the `_setup_registries()` extraction added one Python call frame to every `Container.__init__` — which is on the **per-request child-build path** (`build_child_container` → `__init__`) and cold start, a path deliberately kept lean (#348 memoized `_next_deeper` for ~40%, #355 declined child-lazy-alloc on measurement). The cost is below the guard-bench noise floor, but there's no reason to spend a frame there for a readability nicety.

This folds the share-vs-create branch back inline, with a two-line note that it's inlined *on purpose* so a future refactor/audit doesn't re-extract it. The other two cleanups from #357 (the `types_parser` comment, the `wiring` compile-time extraction) carry zero runtime cost and stay.

See `planning/changes/2026-07-19.11-inline-registry-setup.md`.

## Verification
- `just test-ci` — 432 passed, 100% coverage (behavior identical)
- `just lint-ci` — clean (ruff, ty, planning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)