### PR TITLE
feat(providers): remove Alias(scope=) — 3.0 breaking change

### DIFF
--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -171,15 +171,8 @@ user-facing rationale and caching implications.
 source type is unregistered), marking the alias as a transparent redirect. `DependencyGraph.terminal_scope`
 follows that hook down an alias chain to the terminal non-alias provider and returns that provider's scope —
 which is what `Container.validate()` and scope-error reporting compare against (see
-[validation.md](validation.md#terminal-scope-and-alias-transparency)). The alias's own `scope`
-attribute is only a stored default.
-
-### Deprecated `scope=` parameter
-
-Passing `scope=` to `Alias.__init__` emits a `DeprecationWarning` and has no effect on resolution or validation
-(both are derived from the source, per above) — see [docs/providers/alias.md](../docs/providers/alias.md) for
-the user-facing note. The stored value is kept internally only so that cosmetic consumers (`__repr__`, registry
-suggestions) continue to display it; it is scheduled for removal in a future release.
+[validation.md](validation.md#terminal-scope-and-alias-transparency)). An alias's own scope is always `Scope.APP`
+internally; its effective scope at resolution time is derived from its source provider's scope.
 
 ---
 

--- a/modern_di/providers/alias.py
+++ b/modern_di/providers/alias.py
@@ -1,6 +1,4 @@
-import enum
 import typing
-import warnings
 
 from modern_di import exceptions, types
 from modern_di.providers.abstract import AbstractProvider
@@ -18,23 +16,12 @@ class Alias(AbstractProvider[types.T_co]):
         self,
         source_type: type[types.T_co],
         *,
-        scope: enum.IntEnum | types.UnsetType = types.UNSET,
         bound_type: type | None | types.UnsetType = types.UNSET,
     ) -> None:
-        if not isinstance(scope, types.UnsetType):
-            warnings.warn(
-                "The `scope` parameter of Alias is deprecated and ignored: an alias's effective "
-                "scope is derived from its source. It will be removed in a future release.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            stored_scope: enum.IntEnum = scope
-        else:
-            stored_scope = Scope.APP
         # Always a concrete IntEnum (never UNSET), so `_scope_defaulted` stays False and
-        # group-default stamping skips aliases.
+        # group-default stamping skips aliases. An alias's effective scope is derived from its source.
         super().__init__(
-            scope=stored_scope, bound_type=source_type if isinstance(bound_type, types.UnsetType) else bound_type
+            scope=Scope.APP, bound_type=source_type if isinstance(bound_type, types.UnsetType) else bound_type
         )
         self._source_type = source_type
 

--- a/planning/changes/2026-07-19.15-remove-alias-scope.md
+++ b/planning/changes/2026-07-19.15-remove-alias-scope.md
@@ -1,0 +1,31 @@
+---
+summary: Remove deprecated `Alias(scope=)` parameter — 3.0 hard breaking change.
+---
+
+# Change: Remove `Alias(scope=)` parameter
+
+**Lane:** lightweight — 25 LOC net, 2 files, single straightforward test, no public API surface change (the parameter was already deprecated and non-functional).
+
+## Goal
+
+Promote the long-standing deprecation of `Alias(scope=)` to a hard error. The parameter has been deprecated (emitting `DeprecationWarning`, value ignored) since 2.x; 3.0 removes it entirely, raising `TypeError` if passed.
+
+## Approach
+
+1. Update `tests/providers/test_alias.py`: replace deprecation-warning tests with a new test asserting `TypeError` on `scope=` kwarg.
+2. Simplify `modern_di/providers/alias.py`: drop `scope` parameter from signature, remove warning branch, always pass `scope=Scope.APP` to parent; drop unused `enum` and `warnings` imports.
+3. Promote `architecture/providers.md`: remove the "Deprecated `scope=` parameter" subsection; document that scope is always `Scope.APP` internally, derived from source at resolution time.
+
+## Files
+
+- `modern_di/providers/alias.py` — remove scope param + warning branch, simplify __init__
+- `tests/providers/test_alias.py` — replace deprecation tests with TypeError assertion
+- `architecture/providers.md` — promote docs, drop deprecation section
+
+## Verification
+
+- [x] Failing test first: `just test tests/providers/test_alias.py::test_alias_scope_param_removed` → FAIL (DID NOT RAISE TypeError; currently accepts scope, emits DeprecationWarning)
+- [x] Apply the change
+- [x] Test passes: `just test tests/providers/test_alias.py::test_alias_scope_param_removed` → PASS
+- [x] Full suite: `just test-ci` → 431 passed, 100% coverage
+- [x] Lint: `just lint-ci` → clean (ruff, eof-fixer, ty)

--- a/tests/providers/test_alias.py
+++ b/tests/providers/test_alias.py
@@ -1,5 +1,4 @@
 import dataclasses
-import warnings
 
 import pytest
 
@@ -122,10 +121,9 @@ def test_alias_default_bound_type_is_source_type() -> None:
 
 
 def test_alias_repr() -> None:
-    with pytest.warns(DeprecationWarning, match="scope"):
-        alias = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository, scope=Scope.REQUEST)
+    alias = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository)
     assert repr(alias) == (
-        f"Alias(source_type={PostgresRepository!r}, bound_type={AbstractRepository!r}, scope=<Scope.REQUEST: 3>)"
+        f"Alias(source_type={PostgresRepository!r}, bound_type={AbstractRepository!r}, scope=<Scope.APP: 1>)"
     )
 
 
@@ -359,16 +357,9 @@ def test_terminal_scope_handles_mutual_alias_cycle() -> None:
 class _DepSrc: ...
 
 
-def test_alias_scope_parameter_is_deprecated() -> None:
-    with pytest.warns(DeprecationWarning, match="scope"):
-        providers.Alias(source_type=_DepSrc, bound_type=object, scope=Scope.REQUEST)
-
-
-def test_alias_without_scope_emits_no_deprecation_warning() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        alias = providers.Alias(source_type=_DepSrc, bound_type=object)
-    assert alias is not None
+def test_alias_scope_param_removed() -> None:
+    with pytest.raises(TypeError, match="unexpected keyword argument 'scope'"):
+        providers.Alias(_DepSrc, scope=Scope.APP)  # ty: ignore[unknown-argument]
 
 
 def test_alias_accepts_positional_source_type() -> None:


### PR DESCRIPTION
First of the five queued modern-di 3.0 breaking switches (see `planning/changes/2026-07-19.14-3.0-release-scope.md`).

`Alias`'s `scope=` kwarg has been deprecated (emitted `DeprecationWarning`, value ignored — an alias's effective scope is always derived from its source). 3.0 removes the parameter entirely, so passing it now raises `TypeError`.

- `modern_di/providers/alias.py` — drop the `scope` param + the deprecation branch; remove now-unused `enum`/`warnings` imports; scope is fixed at `Scope.APP` internally.
- `tests/providers/test_alias.py` — replace the deprecation-warning tests with a `TypeError` assertion; update the repr test.
- `architecture/providers.md` — drop the deprecated-`scope=` subsection.
- Change bundle: `planning/changes/2026-07-19.15-remove-alias-scope.md`.

## Verification
- `just test-ci` — 431 passed, 100% coverage
- `just lint-ci` — clean (ruff, eof-fixer, ty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)