### PR TITLE
feat(container): closed container raises ContainerClosedError — 3.0 breaking change

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -57,9 +57,8 @@ Rules:
   the parent, **not** `value + 1`, so non-contiguous custom enums (`TENANT=6, JOB=10`) work; if the parent is
   already at the deepest member, `MaxScopeReachedError` is raised. See
   [scopes.md](scopes.md#the-scope-algebra).
-- Building a child from a closed container is transitional until modern-di 3.0: it emits
-  `ContainerClosedWarning` and self-reopens the container instead of raising `ContainerClosedError`
-  (see [Lifecycle: close and reopen](#lifecycle-close-and-reopen) below).
+- Building a child from a closed container raises `ContainerClosedError` (see
+  [Lifecycle: close and reopen](#lifecycle-close-and-reopen) below).
 
 The child gets its own, independent `_scope_map` dict that includes all ancestors plus itself,
 enabling `find_container(scope)` to walk up to any ancestor scope in O(1).
@@ -133,12 +132,10 @@ The rest of this section documents what that close performs and how reopen works
    `AsyncFinalizerInSyncCloseError`; those items are left in `_creation_order` so a subsequent
    `close_async()` can clean them up.
 
-2. **`closed = True`** — always set in a `finally` block, even if finalizers raised. Until modern-di
-   3.0, a subsequent `resolve_provider` / `build_child_container` (or a nested provider resolving at
-   a closed ancestor scope) emits a `ContainerClosedWarning` and **self-reopens** the container, then
-   proceeds — preserving pre-2.16 "close then resolve" code. Escalate the warning
-   (`warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)`) to opt into the
-   strict behavior early. In 3.0 these paths raise `ContainerClosedError` instead.
+2. **`closed = True`** — always set in a `finally` block, even if finalizers raised. A subsequent
+   `resolve_provider` / `build_child_container` (or a nested provider resolving at a closed ancestor
+   scope) raises `ContainerClosedError` — there is no self-heal. Re-enter the container via
+   `with`/`async with`, or call `container.open()`, before reusing it.
 
 Additionally, when `close_sync()` or `close_async()` is called on a **root** container (one with
 no `parent_container`), all overrides are cleared from the shared `OverridesRegistry` before the

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -172,10 +172,9 @@ from whichever it dispatches to. `FromDI` is spelled in PascalCase (with
 ## Lifecycle rules
 
 - **Reopen the root container on startup.** A container that was closed on
-  shutdown emits a `ContainerClosedWarning` (and, in 3.0, raises
-  `ContainerClosedError`) if reused without reopening. Reopening on each
-  startup lets a second lifespan cycle (test client re-entry, broker restart)
-  work.
+  shutdown raises `ContainerClosedError` if reused without reopening. Reopening
+  on each startup lets a second lifespan cycle (test client re-entry, broker
+  restart) work.
     - With a context-manager lifespan: `async with fetch_di_container(app): yield`
       — `__aenter__` reopens, `__aexit__` closes. Compose *around* any existing
       lifespan rather than replacing it.
@@ -392,8 +391,8 @@ Each official integration is its own repository and PyPI package, mirroring the
 - [ ] `fetch_di_container` reads the root container back out of framework state.
 - [ ] A per-unit-of-work builder opens a child container at the right scope,
       injects the connection as context, and closes it in `finally`.
-- [ ] Root container **reopens on startup** so restarts don't emit a
-      `ContainerClosedWarning` (or, in 3.0, raise `ContainerClosedError`).
+- [ ] Root container **reopens on startup** so restarts don't raise
+      `ContainerClosedError`.
 - [ ] `close_async` / `close_sync` matches the framework's async-ness.
 - [ ] `FromDI` accepts `AbstractProvider[T] | type[T]` and resolves it via
       `resolve_dependency` — use `modern_di.integrations.from_di` (or a

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -71,12 +71,10 @@ Catch `ContainerError` for any container/scope failure.
 - **`InvalidScopeTypeError`** — raised by the `Container` constructor when `scope` is not an
   `enum.IntEnum`. See
   [Troubleshooting: InvalidScopeTypeError](../troubleshooting/invalid-scope-type-error.md).
-- **`ContainerClosedError`** — raised in modern-di **3.0** when you resolve from, or build a child
-  of, a closed container. Until then that reuse emits a **`ContainerClosedWarning`** (a
-  `DeprecationWarning`) and the container self-reopens — see
-  [Lifecycle: closing and reopening](lifecycle.md#closing-and-reopening). Escalate the warning
-  today via the
-  [readiness recipe](../migration/to-3.x.md#readiness-recipe-escalating-warnings-to-errors-with-filterwarnings).
+- **`ContainerClosedError`** — raised when you resolve from, or build a child of, a closed
+  container; there is no self-heal. Re-enter the container via `with`/`async with`, or call
+  `container.open()`, before reusing it — see
+  [Lifecycle: closing and reopening](lifecycle.md#closing-and-reopening).
   See [Troubleshooting: ContainerClosedError](../troubleshooting/container-closed-error.md).
 - **`ValidationFailedError`** — raised by `Container.validate()` (and `Container(..., validate=True)`)
   when the graph has problems. Catch this for validation results; its `.errors` attribute holds the

--- a/docs/providers/lifecycle.md
+++ b/docs/providers/lifecycle.md
@@ -109,11 +109,10 @@ Entering `with container:` (or `async with`) opens the container; exiting calls
 `close_sync()` / `close_async()`, which run the finalizers (in reverse-creation order, as
 above) and mark the container closed.
 
-While a container is closed, resolving a dependency — or building a child container — emits a
-`ContainerClosedWarning` and reopens the container so the call succeeds (transitional; modern-di
-3.0 will raise `ContainerClosedError` instead — see
+While a container is closed, resolving a dependency — or building a child container — raises
+`ContainerClosedError` (see
 [Migration: To 3.x](../migration/to-3.x.md#1-closed-containers-raise-instead-of-self-healing)).
-Re-entering `with container:` reopens it cleanly, without a warning, and resolution works again:
+Re-entering `with container:` reopens it cleanly, and resolution works again:
 
 ```python
 container = Container(groups=[Dependencies], validate=True)
@@ -122,7 +121,7 @@ with container:
     container.resolve(Settings)
 # closed here — finalizers ran
 
-# container.resolve(Settings)  -> warns (ContainerClosedWarning) and self-reopens
+# container.resolve(Settings)  -> raises ContainerClosedError
 
 with container:                 # reopened
     container.resolve(Settings)
@@ -137,8 +136,8 @@ How a cached instance survives this cycle depends on its `CacheSettings`:
   re-run on later closes). Use this for a shared resource whose identity must stay stable
   across restarts.
 - Overrides are not part of this survival — closing a root container resets its
-  overrides registry, and self-reopen does not restore overrides set beforehand; only
-  cached instances (with `clear_cache=False`) survive close→reopen.
+  overrides registry, and reopening (via `with`/`open()`) does not restore overrides set
+  beforehand; only cached instances (with `clear_cache=False`) survive close→reopen.
 
 !!! caution "The context manager is not reference-counted"
     Nesting `with container:` on the **same** object closes it on the inner `with` exit,

--- a/docs/troubleshooting/container-closed-error.md
+++ b/docs/troubleshooting/container-closed-error.md
@@ -7,8 +7,8 @@ Raised when resolving from, or building a child of, a container after it was clo
 **Cause**
 
 `container.close_sync()` / `close_async()` (or exiting a `with container:` block) marks the container
-closed. In modern-di **3.0**, any further `resolve()`, `resolve_provider()`, or
-`build_child_container()` call on that container raises this error instead of quietly working.
+closed. Any further `resolve()`, `resolve_provider()`, or `build_child_container()` call on that
+container raises this error — there is no self-heal.
 
 **Fix**
 
@@ -26,12 +26,6 @@ with container:                 # reopened cleanly
 Or call `container.open()` explicitly if a context manager doesn't fit your flow. Build a fresh
 container per unit of work (e.g. one per request) instead of trying to reuse a closed one across
 units of work.
-
-**Escape hatches**
-
-Today (2.x), this reuse doesn't raise yet — it emits `ContainerClosedWarning` and self-reopens the
-container so the call still succeeds. Escalate that warning to an error now to catch the pattern
-before upgrading, using the readiness recipe on the migration page below.
 
 ## See also
 

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -134,7 +134,7 @@ class Container:
         scope: enum.IntEnum | None = None,
         context: dict[type[typing.Any], typing.Any] | None = None,
     ) -> "typing_extensions.Self":
-        self._warn_and_reopen_if_closed()
+        self._raise_if_closed()
 
         if scope is None:
             # `_next_deeper` is the smallest member deeper than this one, so non-contiguous
@@ -199,7 +199,7 @@ class Container:
 
     def resolve_provider(self, provider: "AbstractProvider[types.T]") -> types.T:
         """Resolve a specific provider by reference via its compiled resolver."""
-        self._warn_and_reopen_if_closed()
+        self._raise_if_closed()
         try:
             return self.providers_registry.resolver_for(provider)(self)
         except RecursionError as exc:
@@ -327,25 +327,10 @@ class Container:
         """
         self.closed = False
 
-    def _warn_and_reopen_if_closed(self) -> None:
-        """Transitional shim for reuse of a closed container.
-
-        Emits :class:`~modern_di.exceptions.ContainerClosedWarning` and reopens.
-        Fires once per container transitioning from closed to reopened; an
-        already-open container emits none.
-        """
-        if not self.closed:
-            return
-        warnings.warn(
-            f"Container (scope {self.scope.name}) is closed; resolving from it or building a child "
-            "is deprecated and will raise ContainerClosedError in modern-di 3.0. Re-enter the "
-            "container with `with`/`async with`, or call `open()`, before reusing it. "
-            "See: https://modern-di.modern-python.org/migration/to-3.x/"
-            "#1-closed-containers-raise-instead-of-self-healing",
-            exceptions.ContainerClosedWarning,
-            stacklevel=2,
-        )
-        self.open()
+    def _raise_if_closed(self) -> None:
+        """Raise if this container is closed; callers reopen explicitly via `open()`/`with`."""
+        if self.closed:
+            raise exceptions.ContainerClosedError(container_scope=self.scope)
 
     def __enter__(self) -> "typing_extensions.Self":
         self.open()

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -53,5 +53,5 @@ class ContextProvider(AbstractProvider[types.T_co]):
 
     def fetch_context_value(self, container: "Container") -> types.T_co | object:
         container = container.find_container(self.scope)
-        container._warn_and_reopen_if_closed()  # noqa: SLF001
+        container._raise_if_closed()  # noqa: SLF001
         return container.context_registry.find_context(self.context_type)

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -98,7 +98,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
                     return override
             target = container if container.scope == scope else _navigate(container, scope, resolution_step)
             if target.closed:
-                target._warn_and_reopen_if_closed()  # noqa: SLF001
+                target._raise_if_closed()  # noqa: SLF001
             try:  # build the positional args from the dependency resolvers (a dependency can raise ResolutionError)
                 args = [r(target) for r in pos]
             except _STEP_ERRORS as exc:
@@ -124,7 +124,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
         # Navigate once; same-scope deps (the common case) skip the find_container call.
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
-            target._warn_and_reopen_if_closed()  # noqa: SLF001
+            target._raise_if_closed()  # noqa: SLF001
         try:  # build the kwargs dict from provider/static/context bindings
             kwargs = {name: r(target) for name, r in prov}
             if not pure:
@@ -216,7 +216,7 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
                 return override
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
-            target._warn_and_reopen_if_closed()  # noqa: SLF001
+            target._raise_if_closed()  # noqa: SLF001
         cache_item = target.cache_registry.fetch_cache_item(f)
         cached = cache_item.cache
         if cached is not types.UNSET:
@@ -258,7 +258,7 @@ def _compile_unwireable_factory(
                 return override
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
-            target._warn_and_reopen_if_closed()  # noqa: SLF001
+            target._raise_if_closed()  # noqa: SLF001
         error = build_error(arg_name=arg_name, item=item, registry=target.providers_registry)
         error.prepend_step(resolution_step())
         raise error

--- a/planning/changes/2026-07-19.17-closed-container-raises.md
+++ b/planning/changes/2026-07-19.17-closed-container-raises.md
@@ -1,0 +1,88 @@
+---
+summary: Closed-container reuse raises `ContainerClosedError` instead of self-reopening — 3.0 switch 1 of 5. Landed; `just test-ci` 426 passed, 100% coverage.
+---
+
+# Design: Closed containers raise instead of self-healing
+
+## Summary
+
+Replaces `Container._warn_and_reopen_if_closed` (emit `ContainerClosedWarning`, then silently
+reopen) with `Container._raise_if_closed` (raise `ContainerClosedError`, no reopen) at every call
+site that guards a closed container: `resolve_provider`, `build_child_container`,
+`ContextProvider.fetch_context_value`, and the four cross-scope-target guards compiled into
+`resolver_compiler.py`'s transient/cached/unwireable resolvers. Re-entering via `with`/`async with`
+or calling `container.open()` is unaffected — those still just clear `closed`.
+
+## Motivation
+
+This is switch 1 of the five queued 3.0 breaking changes scoped in
+[2026-07-19.14-3.0-release-scope](2026-07-19.14-3.0-release-scope.md). The self-heal has been
+warned against since 2.16 (`ContainerClosedWarning`, a `DeprecationWarning`) specifically to make
+this flip a no-op for any caller who escalated it. Silently reopening a closed container hides a
+lifecycle bug (resolving after the container's finalizers already ran) instead of surfacing it.
+
+## Design
+
+`Container._raise_if_closed(self) -> None` replaces `_warn_and_reopen_if_closed`:
+
+```python
+def _raise_if_closed(self) -> None:
+    """Raise if this container is closed; callers reopen explicitly via `open()`/`with`."""
+    if self.closed:
+        raise exceptions.ContainerClosedError(container_scope=self.scope)
+```
+
+`ContainerClosedError` already existed in `modern_di/exceptions.py` (built for this switch); no
+change there. `ContainerClosedWarning` is left in place, unused, so a caller's
+`filterwarnings(... category=exceptions.ContainerClosedWarning)` doesn't break at import time.
+
+**Call sites updated** — the brief named three (`resolve_provider`, `build_child_container`,
+`context_provider.fetch_context_value`), but the actual call-site count in the current tree is
+seven: those three, plus four in `resolver_compiler.py`'s compiled closures
+(`_compile_transient_factory`'s positional and kwargs paths, `_compile_cached_factory`, and
+`_compile_unwireable_factory`) — each navigates to a cross-scope target and guards `target.closed`
+before proceeding. All seven were updated; the `if target.closed:` micro-optimization in the
+compiled paths (skip the call in the common open case) is preserved, only the method name changed.
+
+`open()` / `__enter__` / `__aenter__` are unchanged — they unconditionally clear `closed`, both
+before and after this change.
+
+## Non-goals
+
+- No change to `open()`/`__enter__`/`__aenter__` semantics (a later task adds `validate()` there).
+- `ContainerClosedWarning` is not deleted (kept inert, per the maintainer's stance on not breaking
+  existing `filterwarnings` configs).
+- Switches 2-5 (already-landed `Alias(scope=)`/`Factory(cache_settings=)` removal; pending
+  validate-by-default and unset-`ContextProvider` raise) are out of scope here.
+
+## Testing
+
+- New: `test_resolve_on_closed_container_raises`, `test_build_child_on_closed_container_raises`,
+  `test_reenter_reopens_closed_container`, `test_closed_container_async_path_raises` in
+  `tests/test_container.py` — RED first (`uv run --no-sync pytest tests/test_container.py -k
+  "closed or reenter"` → 6 failed/2 passed against the old shim), then GREEN after the
+  implementation (8 passed).
+- Updated existing self-heal-asserting tests to assert the raise (or the explicit re-enter path)
+  instead, across `tests/test_container.py`, `tests/providers/test_singleton.py`,
+  `tests/providers/test_context_provider.py`, `tests/providers/test_factory.py`. Two tests that only
+  existed to characterize the warning mechanics (`test_reuse_warns_once_per_close_cycle`,
+  `test_strict_opt_in_reuse_raises`) were removed outright — there is no warning left to count or
+  escalate.
+- `just test-ci`: **426 passed, 100.00% line coverage** (no `# pragma: no cover` added or removed by
+  this change; the removed self-heal branch left no dead lines).
+- `just lint-ci`: eof-fixer, `ruff format --check`, `ruff check --no-fix`, `ty check`,
+  `planning/index.py --check` all clean.
+- `mkdocs build --strict`: clean (docs anchors intact).
+
+## Risk
+
+- **Missed call site**: the brief undercounted call sites (3 vs. the actual 7); a grep for
+  `_warn_and_reopen_if_closed` across `modern_di/` and `tests/` post-change confirms zero
+  remaining references outside the now-inert `ContainerClosedWarning` class definition.
+- **Docs drift**: pages describing the 2.x transitional behavior (self-heal + warning) needed
+  flipping to describe the raise as current, unconditional behavior — `docs/troubleshooting/
+  container-closed-error.md`, `docs/providers/lifecycle.md`, `docs/providers/errors-and-
+  exceptions.md`, `docs/integrations/writing-integrations.md`. `docs/migration/to-3.x.md` is
+  deliberately left as the permanent before/after migration record (precedent: switches 2 and 3
+  did the same), and `docs/integrations/arq.md`'s "reopens ... cleanly instead of raising" line
+  describes the *unaffected* explicit-`open()` pattern, not the removed shim, so it was left alone.

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -5,7 +5,7 @@ import warnings
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import ArgumentResolutionError, ContainerClosedWarning, ContextValueNoneWarning
+from modern_di.exceptions import ArgumentResolutionError, ContainerClosedError, ContextValueNoneWarning
 
 
 request_context_provider = providers.ContextProvider(scope=Scope.REQUEST, context_type=datetime.datetime)
@@ -153,14 +153,14 @@ def test_set_context_after_first_resolve_is_seen_by_later_resolves() -> None:
     assert second.ctx is value
 
 
-def test_context_provider_through_closed_owning_container_warns_and_reopens() -> None:
+def test_context_provider_through_closed_owning_container_raises() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app = Container(groups=[MyGroup], context={datetime.datetime: now})
     child = app.build_child_container(scope=Scope.REQUEST)
     app.close_sync()
-    with pytest.warns(ContainerClosedWarning):
-        assert child.resolve_provider(MyGroup.context_provider) == now
-    assert app.closed is False
+    with pytest.raises(ContainerClosedError):
+        child.resolve_provider(MyGroup.context_provider)
+    assert app.closed is True  # no self-heal: the owning ancestor stays closed
 
 
 # Q-12 — ContextProvider reads the registry at its OWN scope

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -940,27 +940,27 @@ def _build_closed_app_and_request(*group: type[Group]) -> tuple[Container, Conta
     return app, request
 
 
-def test_transient_positional_reopens_closed_cross_scope_target() -> None:
+def test_transient_positional_raises_for_closed_cross_scope_target() -> None:
     # A positional-eligible APP transient resolved from a REQUEST child whose APP target is closed:
-    # the positional resolver's own target.closed guard must warn+reopen the distinct target.
+    # the positional resolver's own target.closed guard must raise for the distinct target.
     class G(Group):
         leaf = providers.Factory(creator=_CovLeaf, scope=Scope.APP)
 
     _app, request = _build_closed_app_and_request(G)
-    with pytest.warns(exceptions.ContainerClosedWarning):
-        assert isinstance(request.resolve_provider(G.leaf), _CovLeaf)
+    with pytest.raises(exceptions.ContainerClosedError):
+        request.resolve_provider(G.leaf)
 
 
-def test_transient_kwargs_reopens_closed_cross_scope_target() -> None:
+def test_transient_kwargs_raises_for_closed_cross_scope_target() -> None:
     # The kwargs-path (keyword-only dep -> ineligible) mirror: the kwargs resolver's own
-    # target.closed guard fires for a cross-scope APP target that was independently closed.
+    # target.closed guard raises for a cross-scope APP target that was independently closed.
     class G(Group):
         dep = providers.Factory(creator=_CovLeaf, scope=Scope.APP)
         thing = providers.Factory(creator=_CovKwOnlyDep, scope=Scope.APP)
 
     _app, request = _build_closed_app_and_request(G)
-    with pytest.warns(exceptions.ContainerClosedWarning):
-        assert isinstance(request.resolve_provider(G.thing), _CovKwOnlyDep)
+    with pytest.raises(exceptions.ContainerClosedError):
+        request.resolve_provider(G.thing)
 
 
 class _CovKwOnlyBodyTypeError:
@@ -1078,14 +1078,15 @@ def test_unwireable_factory_override_short_circuits() -> None:
     assert container.resolve_provider(G.thing) is mock
 
 
-def test_unwireable_factory_reopens_closed_cross_scope_target() -> None:
+def test_unwireable_factory_raises_for_closed_cross_scope_target() -> None:
     # An unwireable APP factory resolved from a REQUEST child whose APP target is closed: the
-    # unwireable resolver navigates to the closed target, warns+reopens it, then raises.
+    # unwireable resolver navigates to the closed target and raises ContainerClosedError before it
+    # ever gets to build the ArgumentResolutionError.
     class G(Group):
         thing = providers.Factory(creator=SimpleCreator, bound_type=None, scope=Scope.APP)
 
     _app, request = _build_closed_app_and_request(G)
-    with pytest.warns(exceptions.ContainerClosedWarning), pytest.raises(ArgumentResolutionError):
+    with pytest.raises(exceptions.ContainerClosedError):
         request.resolve_provider(G.thing)
 
 

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import AsyncFinalizerInSyncCloseError, ContainerClosedWarning, FinalizerError
+from modern_di.exceptions import AsyncFinalizerInSyncCloseError, ContainerClosedError, FinalizerError
 from modern_di.types import UNSET
 
 
@@ -53,7 +53,7 @@ async def test_app_singleton() -> None:
     app_container.close_sync()
     assert sync_calls == [singleton1]  # finalizer ran once on close
 
-    with pytest.warns(ContainerClosedWarning):
+    with pytest.raises(ContainerClosedError):
         app_container.resolve_provider(LocalGroup.singleton)
 
     # clear_cache=False: the instance survives the close and is returned again after reopen,
@@ -83,7 +83,7 @@ def test_close_does_not_re_finalize_with_clear_cache_false() -> None:
     assert calls == ["r"]
 
 
-def test_closed_container_warns_and_reopens_with_clear_cache_true() -> None:
+def test_closed_container_raises_then_reopened_rebuilds_with_clear_cache_true() -> None:
     calls: list[str] = []
 
     class G(Group):
@@ -97,9 +97,10 @@ def test_closed_container_warns_and_reopens_with_clear_cache_true() -> None:
     container.resolve(str)
     container.close_sync()
     assert calls == ["r"]
-    with pytest.warns(ContainerClosedWarning):
-        # self-reopens and rebuilds, since clear_cache=True cleared the cache on close
+    with pytest.raises(ContainerClosedError):
         container.resolve(str)
+    container.open()
+    container.resolve(str)  # rebuilds, since clear_cache=True cleared the cache on close
     container.close_sync()
     assert calls == ["r", "r"]  # the rebuilt instance is finalized again on this second close
 
@@ -470,8 +471,8 @@ def test_persistent_provider_survives_close_reopen_cycle() -> None:
         svc1 = container.resolve(_EphemeralSvc)
     # exited → closed; finalizer ran once
     assert _cycle_events == ["broker-finalized"]
-    # resolving while closed warns and self-reopens (transitional; 3.0 restores the raise)
-    with pytest.warns(ContainerClosedWarning):
+    # resolving while closed raises: no self-heal
+    with pytest.raises(ContainerClosedError):
         container.resolve(_PersistentBroker)
     # re-enter → reopen
     with container:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -14,7 +14,6 @@ from modern_di.exceptions import (
     ChildContainerRegistrationError,
     CircularDependencyError,
     ContainerClosedError,
-    ContainerClosedWarning,
     DuplicateProviderTypeError,
     InvalidChildScopeError,
     InvalidScopeDependencyError,
@@ -403,32 +402,34 @@ def test_constructor_rejects_parent_with_non_increasing_scope() -> None:
         Container(scope=Scope.APP, parent_container=request)
 
 
-def test_container_closed_warning_links_migration_guide_anchor() -> None:
-    container = Container(scope=Scope.APP)
+def test_resolve_on_closed_container_raises() -> None:
+    container = Container(scope=Scope.APP, validate=False)
     container.close_sync()
-    with pytest.warns(
-        ContainerClosedWarning,
-        match=r"See: https://modern-di\.modern-python\.org/migration/to-3\.x/"
-        r"#1-closed-containers-raise-instead-of-self-healing$",
-    ):
+    with pytest.raises(ContainerClosedError):
         container.resolve(Container)
+    assert container.closed is True  # no self-heal: still closed after the raise
 
 
-def test_closed_container_warns_and_reopens_on_resolve_and_child_building() -> None:
-    container = Container(scope=Scope.APP)
+def test_build_child_on_closed_container_raises() -> None:
+    container = Container(scope=Scope.APP, validate=False)
     container.close_sync()
-    with pytest.warns(ContainerClosedWarning):
-        container.resolve(Container)
-    container.close_sync()
-    with pytest.warns(ContainerClosedWarning):
+    with pytest.raises(ContainerClosedError):
         container.build_child_container(scope=Scope.REQUEST)
+    assert container.closed is True  # no self-heal: still closed after the raise
 
 
-async def test_closed_container_async_path() -> None:
-    container = Container(scope=Scope.APP)
-    await container.close_async()
-    with pytest.warns(ContainerClosedWarning):
+def test_reenter_reopens_closed_container() -> None:
+    container = Container(scope=Scope.APP, validate=False)
+    container.close_sync()
+    with container:  # __enter__ -> open() clears closed
         assert container.resolve(Container) is container
+
+
+async def test_closed_container_async_path_raises() -> None:
+    container = Container(scope=Scope.APP, validate=False)
+    await container.close_async()
+    with pytest.raises(ContainerClosedError):
+        container.resolve(Container)
 
 
 class _PersistentBroker: ...
@@ -440,72 +441,33 @@ class _AppBrokerGroup(Group):
     )
 
 
-def test_resolving_through_closed_parent_via_open_child_warns_and_reopens() -> None:
-    app = Container(scope=Scope.APP, groups=[_AppBrokerGroup])
+def test_resolving_through_closed_parent_via_open_child_raises() -> None:
+    app = Container(scope=Scope.APP, groups=[_AppBrokerGroup], validate=False)
     child = app.build_child_container(scope=Scope.REQUEST)
     app.close_sync()
-    with pytest.warns(ContainerClosedWarning):
-        broker = child.resolve(_PersistentBroker)
-    assert isinstance(broker, _PersistentBroker)
-    assert app.closed is False
+    with pytest.raises(ContainerClosedError):
+        child.resolve(_PersistentBroker)
+    assert app.closed is True  # no self-heal: the ancestor stays closed
 
 
 async def test_async_context_manager_reopens() -> None:
-    container = Container(scope=Scope.APP)
+    container = Container(scope=Scope.APP, validate=False)
     async with container:
         pass
-    with pytest.warns(ContainerClosedWarning):
-        assert container.resolve(Container) is container
+    with pytest.raises(ContainerClosedError):
+        container.resolve(Container)
     async with container:
         assert container.resolve(Container) is container
 
 
 def test_open_reopens_closed_container() -> None:
-    container = Container(scope=Scope.APP)
+    container = Container(scope=Scope.APP, validate=False)
     container.close_sync()
-    with pytest.warns(ContainerClosedWarning):
-        assert container.resolve(Container) is container
+    with pytest.raises(ContainerClosedError):
+        container.resolve(Container)
     container.open()
     assert container.resolve(Container) is container
     assert container.build_child_container(scope=Scope.REQUEST).scope is Scope.REQUEST
-
-
-def test_reuse_after_close_warns_and_reopens() -> None:
-    container = Container(scope=Scope.APP)
-    container.close_sync()
-    with pytest.warns(ContainerClosedWarning):
-        resolved = container.resolve(Container)
-    assert resolved is container
-    assert container.closed is False
-
-
-def test_build_child_after_close_warns_and_reopens() -> None:
-    container = Container(scope=Scope.APP)
-    container.close_sync()
-    with pytest.warns(ContainerClosedWarning):
-        child = container.build_child_container(scope=Scope.REQUEST)
-    assert container.closed is False
-    assert child.scope is Scope.REQUEST
-
-
-def test_reuse_warns_once_per_close_cycle() -> None:
-    container = Container(scope=Scope.APP)
-    container.close_sync()
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        container.resolve(Container)
-        container.resolve(Container)
-    closed_warnings = [w for w in caught if issubclass(w.category, ContainerClosedWarning)]
-    assert len(closed_warnings) == 1
-
-
-def test_strict_opt_in_reuse_raises() -> None:
-    container = Container(scope=Scope.APP)
-    container.close_sync()
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", ContainerClosedWarning)
-        with pytest.raises(ContainerClosedWarning):
-            container.resolve(Container)
 
 
 def test_container_closed_error_message_and_attr() -> None:
@@ -913,10 +875,10 @@ def test_add_providers_on_closed_root_registers_fine() -> None:
     container.close_sync()
     str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
 
-    container.add_providers(str_factory)  # no ContainerClosedWarning: registration doesn't touch closed state
+    container.add_providers(str_factory)  # no ContainerClosedError: registration doesn't touch closed state
 
-    with pytest.warns(ContainerClosedWarning):
-        assert container.resolve(str) == "added"
+    with pytest.raises(ContainerClosedError):
+        container.resolve(str)
 
 
 def test_resolve_dependency_with_type_returns_same_instance_as_resolve() -> None:


### PR DESCRIPTION
Third of the five queued modern-di 3.0 breaking switches (see `planning/changes/2026-07-19.14-3.0-release-scope.md`).

In 2.x, resolving from — or building a child of — a closed container emitted `ContainerClosedWarning` and transparently reopened (self-healed). In 3.0 the same call raises `ContainerClosedError`. Re-entering via `with`/`async with`/`open()` before reuse still works.

- `modern_di/container.py` — `_warn_and_reopen_if_closed()` → `_raise_if_closed()` (raises `ContainerClosedError(container_scope=...)`).
- All **7** call sites converted: `resolve_provider`, `build_child_container`, `ContextProvider.fetch_context_value`, and the 4 compiled resolvers in `resolver_compiler.py` (the `if target.closed:` guard keeps the open-target hot path free of any extra call).
- `ContainerClosedWarning` class retained (unused) so existing `filterwarnings` configs don't break.
- Docs: `docs/providers/lifecycle.md`, `errors-and-exceptions.md`, `docs/troubleshooting/container-closed-error.md`, `docs/integrations/writing-integrations.md`, `architecture/containers.md` updated to the raise behavior.
- Change bundle: `planning/changes/2026-07-19.17-closed-container-raises.md`.

## Verification
- `just test-ci` — 426 passed, 100% coverage
- `just lint-ci` — clean (ruff, eof-fixer, ty); `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)