### PR TITLE
feat(providers): unset ContextProvider direct-resolve raises — 3.0 breaking change

### DIFF
--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -126,16 +126,16 @@ happens next depends on **how** the value is fetched — direct resolve vs. as a
 and the two paths are independent:
 
 - **Direct resolve** (`container.resolve(HttpRequest)` / `container.resolve_provider(the_provider)` →
-  `ContextProvider.resolve`): if no value was supplied (the key is absent), it emits
-  `ContextValueNoneWarning` (a `DeprecationWarning` naming the context type and scope) and
-  returns `None`. modern-di 3.0 raises `ContextValueNotSetError` here instead of warning —
-  see the [migration guide](../docs/migration/to-3.x.md). Escalate the warning now to catch unset-context bugs
-  ahead of the 3.0 upgrade: `warnings.filterwarnings("error", category=exceptions.ContextValueNoneWarning)`.
+  `ContextProvider.resolve`): if no value was supplied (the key is absent), it raises
+  `ContextValueNotSetError`, naming the context type and the resolving container's scope — see
+  [Migration: To 3.x](../docs/migration/to-3.x.md#5-direct-resolve-of-an-unset-contextprovider-raises).
+  `ContextValueNoneWarning` still exists in `exceptions.py` (retained so existing
+  `filterwarnings` configs don't break) but nothing raises it any more.
 - **As a dependent parameter** of another provider (e.g. a `Factory` constructor argument typed as the context
-  type): unchanged by the above — `Factory` reads the value via `fetch_context_value` (not `resolve`), so no
-  warning fires on this path. `Factory._resolve_context_value` handles the absent-context case live via the
+  type): unaffected by the above — `Factory` reads the value via `fetch_context_value` (not `resolve`), so no
+  exception is raised on this path. `Factory._resolve_context_value` handles the absent-context case live via the
   shared `absent_disposition` helper: if the dependent parameter has a default or is nullable it is silently
-  satisfied; otherwise an `ArgumentResolutionError` is raised, exactly as before this warning was added.
+  satisfied; otherwise an `ArgumentResolutionError` is raised.
 
 Either **declaration route** reaches that dependent-parameter path: matched by type from the registry, or
 passed explicitly as `Factory(creator, kwargs={"request": the_provider})`. `WiringPlan.build` buckets both
@@ -144,9 +144,9 @@ parameter is a declaration detail, not a behavior switch.
 
 The one exception is a `ContextProvider` passed via `kwargs={...}` for a parameter with **no parsed
 `SignatureItem`** — a `**kwargs` creator, or `skip_creator_parsing=True`. There is no default or nullability
-to consult, so it stays on the direct-resolve path above and warns accordingly. Treating it as required would
-raise where 2.x returns `None`; treating it as nullable would silently swallow the unset-context signal that
-3.0 turns into `ContextValueNotSetError`.
+to consult, so it stays on the direct-resolve path above and raises `ContextValueNotSetError` when unset.
+Treating it as required would raise where the parameter itself has no such constraint declared; treating it
+as nullable would silently swallow the unset-context signal — so it keeps direct-resolve semantics instead.
 
 `ContextProvider` also accepts an optional `bound_type` that overrides the inferred bound type.
 

--- a/docs/providers/context.md
+++ b/docs/providers/context.md
@@ -65,7 +65,8 @@ The provider is bound to a [scope](scopes.md) (here `Scope.REQUEST`) and the val
 
 A `ContextProvider` reads its value from the context of the container at its bound scope. If nothing was supplied, behavior depends on the call path:
 
-- Resolving it **directly** (`container.resolve(CustomContext)`) returns `None`.
+- Resolving it **directly** (`container.resolve(CustomContext)`) raises `ContextValueNotSetError` (see
+  [Migration: direct resolve of an unset `ContextProvider` raises](../migration/to-3.x.md#5-direct-resolve-of-an-unset-contextprovider-raises)).
 - Injecting it into a `Factory` parameter that is **not** `Optional`/defaulted raises `ArgumentResolutionError`.
 
 Annotate the consuming parameter as `X | None` (or give it a default) if the value can legitimately be absent. See [ContextProvider has no value](../troubleshooting/context-not-set.md).

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -113,11 +113,9 @@ the same `dependency_path` — the breadcrumb machinery is shared, not duplicate
   `skip_creator_parsing` mismatch). Exceptions raised *inside* the creator body propagate unchanged,
   never wrapped. The binding `TypeError` is preserved on `.original_error` (and as the `__cause__`).
   See [Troubleshooting: CreatorCallError](../troubleshooting/creator-call-error.md).
-- **`ContextValueNotSetError`** — raised in modern-di **3.0** when an unset `ContextProvider` is
-  resolved *directly* (`container.resolve(SomeContextType)` with no value set). Until then that
-  resolve emits **`ContextValueNoneWarning`** (a `DeprecationWarning`) and returns `None` —
-  escalate it today via the
-  [readiness recipe](../migration/to-3.x.md#readiness-recipe-escalating-warnings-to-errors-with-filterwarnings).
+- **`ContextValueNotSetError`** — raised when an unset `ContextProvider` is resolved *directly*
+  (`container.resolve(SomeContextType)` with no value set); there is no fallback. See
+  [Migration: To 3.x](../migration/to-3.x.md#5-direct-resolve-of-an-unset-contextprovider-raises).
   Only the direct-resolve path is affected — a `Factory` parameter backed by the same
   `ContextProvider` keeps following its own default/nullable/required disposition. Inspect
   `.context_type`. See [Troubleshooting: Context not set](../troubleshooting/context-not-set.md).

--- a/docs/troubleshooting/context-not-set.md
+++ b/docs/troubleshooting/context-not-set.md
@@ -1,6 +1,6 @@
 # ContextProvider has no value
 
-A `ContextProvider(SomeType)` resolves by looking up `SomeType` in the container's context registry. If no value was registered, the outcome depends on how the provider is consumed: resolving it directly returns `None`, while injecting it into a `Factory` parameter that has no value raises `ArgumentResolutionError` — **unless** that parameter has a default (the default is used; `None` is not injected) or is nullable `X | None` (then `None` is injected).
+A `ContextProvider(SomeType)` resolves by looking up `SomeType` in the container's context registry. If no value was registered, the outcome depends on how the provider is consumed: resolving it directly raises `ContextValueNotSetError`, while injecting it into a `Factory` parameter that has no value raises `ArgumentResolutionError` — **unless** that parameter has a default (the default is used; `None` is not injected) or is nullable `X | None` (then `None` is injected).
 
 ## Understanding the error
 

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -1,6 +1,5 @@
 import enum
 import typing
-import warnings
 
 from modern_di import exceptions, types
 from modern_di.providers.abstract import AbstractProvider
@@ -15,9 +14,9 @@ class ContextProvider(AbstractProvider[types.T_co]):
 
     The value is passed via ``build_child_container(context={SomeType: value})``
     and looked up from the context registry at this provider's bound scope.
-    Resolving it directly when no value is set emits :class:`~modern_di.exceptions.ContextValueNoneWarning`
-    and returns ``None``; injecting it into a non-nullable, no-default ``Factory``
-    parameter instead raises ``ArgumentResolutionError``.
+    Resolving it directly when no value is set raises ``ContextValueNotSetError``;
+    injecting it into a non-nullable, no-default ``Factory`` parameter instead
+    raises ``ArgumentResolutionError``.
     """
 
     __slots__ = ("context_type",)
@@ -37,18 +36,11 @@ class ContextProvider(AbstractProvider[types.T_co]):
     def __repr__(self) -> str:
         return f"ContextProvider(context_type={self.context_type!r}, scope={self.scope!r})"
 
-    def resolve(self, container: "Container") -> types.T_co | None:
+    def resolve(self, container: "Container") -> types.T_co:
         value = self.fetch_context_value(container)
         if value is types.UNSET:
-            warnings.warn(
-                f"No context value is set for {self.context_type!r} (scope {self.scope.name}); returning None. "
-                "modern-di 3.0 raises ContextValueNotSetError here. Pass context={...} to the container or call "
-                "set_context(). See: https://modern-di.modern-python.org/migration/to-3.x/"
-                "#5-direct-resolve-of-an-unset-contextprovider-raises",
-                exceptions.ContextValueNoneWarning,
-                stacklevel=2,
-            )
-            return None
+            resolving = container.find_container(self.scope)
+            raise exceptions.ContextValueNotSetError(context_type=self.context_type, scope_name=resolving.scope.name)
         return typing.cast(types.T_co, value)
 
     def fetch_context_value(self, container: "Container") -> types.T_co | object:

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -309,8 +309,8 @@ def _compile_container_provider() -> "typing.Callable[[Container], typing.Any]":
 def _compile_context_provider(cp: "ContextProvider[typing.Any]") -> "typing.Callable[[Container], typing.Any]":
     """Front-guard the override, then delegate to the bound `ContextProvider.resolve`.
 
-    Reuses the bound method so the unset-value `ContextValueNoneWarning` (text + stacklevel)
-    stays identical, not reimplemented.
+    Reuses the bound method so the unset-value `ContextValueNotSetError` stays identical, not
+    reimplemented.
     """
     pid = cp.provider_id
     resolve_bound = cp.resolve

--- a/planning/changes/2026-07-19.18-unset-context-raises.md
+++ b/planning/changes/2026-07-19.18-unset-context-raises.md
@@ -1,0 +1,62 @@
+---
+summary: Direct resolve of an unset `ContextProvider` raises `ContextValueNotSetError` — 3.0 switch 5 of 5. Landed; `just test-ci` 426 passed, 100% coverage.
+---
+
+# Change: Direct resolve of an unset `ContextProvider` raises
+
+**Lane:** lightweight — 1 file of production code (~10 LOC net removed), test file updated, no new
+public API surface (`ContextValueNotSetError` already existed, built for this switch).
+
+## Goal
+
+This is switch 5 of the five queued 3.0 breaking changes scoped in
+[2026-07-19.14-3.0-release-scope](2026-07-19.14-3.0-release-scope.md). In 2.x, `container.resolve(SomeContextType)`
+on an unset `ContextProvider` emits `ContextValueNoneWarning` and returns `None`. 3.0 raises
+`ContextValueNotSetError` instead — a silently-`None` value hides a missing `context={...}`/
+`set_context()` call instead of surfacing it. Only the *direct*-resolve path changes; a `Factory`
+parameter backed by the same `ContextProvider` keeps its own default/nullable/required disposition
+(that path reads the value via `fetch_context_value`/`_resolve_context_value`, never `resolve`).
+
+## Approach
+
+`ContextProvider.resolve()` (`modern_di/providers/context_provider.py`) now raises
+`exceptions.ContextValueNotSetError(context_type=self.context_type, scope_name=resolving.scope.name)`
+when the context registry has no value, instead of `warnings.warn(...)` + `return None`. The
+compiled resolver (`resolver_compiler._compile_context_provider`) calls `cp.resolve` unchanged, so
+the raise reaches every direct-resolve caller with no other source-code call site to touch —
+including the one path that also routes through `resolve()`: a `ContextProvider` passed via
+`kwargs={...}` for a parameter with no parsed `SignatureItem` (a `**kwargs` creator), which
+`WiringPlan._apply_overlay` buckets as a plain provider dependency, not a context kwarg. `warnings`
+import removed from `context_provider.py`. `ContextValueNoneWarning` stays in `exceptions.py`,
+unused, so an existing `filterwarnings` config doesn't break at import time.
+
+## Files
+
+- `modern_di/providers/context_provider.py` — `resolve()` raises instead of warn+`None`; drop
+  `warnings` import; update class docstring.
+- `modern_di/resolver_compiler.py` — update `_compile_context_provider`'s docstring (no longer
+  reuses `ContextProvider.resolve` to keep warning text/stacklevel identical — there's no warning).
+- `tests/providers/test_context_provider.py` — replace the warn-and-return-None test with
+  `test_direct_resolve_unset_context_raises`; update three other tests that also exercised the
+  unset direct-resolve path (`test_context_provider_not_found`,
+  `test_context_provider_reads_registry_at_its_own_scope_not_resolving_container`,
+  `test_kwargs_context_provider_without_parsed_signature_keeps_direct_resolve`) to assert the raise;
+  add `test_kwargs_context_provider_without_parsed_signature_injects_present_value` to keep the
+  no-parsed-signature creator covered now that the unset path no longer calls it.
+- `architecture/providers.md` — promote the `ContextProvider` direct-resolve section.
+- `docs/providers/context.md`, `docs/providers/errors-and-exceptions.md`,
+  `docs/troubleshooting/context-not-set.md` — flip "returns `None`" / "until 3.0" phrasing to
+  describe the raise as current, unconditional behavior (same treatment switch 1 gave its docs).
+
+## Verification
+
+- [x] Failing test first: `just test tests/providers/test_context_provider.py -k unset` →
+      4 failed (DID NOT RAISE ContextValueNotSetError), 32 passed — the three collateral tests
+      found by inspecting every direct-resolve call site, not just the brief's one test.
+- [x] Apply the change.
+- [x] Tests pass: `just test tests/providers/test_context_provider.py` → 36 passed.
+- [x] `just test-ci` → 426 passed, 100.00% line coverage (one line — the no-parsed-signature
+      creator body — went uncovered until the new present-value test was added; no
+      `# pragma: no cover` needed).
+- [x] `just lint-ci` → eof-fixer, `ruff format --check`, `ruff check --no-fix`, `ty check`,
+      `planning/index.py --check` all clean.

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -5,7 +5,7 @@ import warnings
 import pytest
 
 from modern_di import Container, Group, Scope, providers
-from modern_di.exceptions import ArgumentResolutionError, ContainerClosedError, ContextValueNoneWarning
+from modern_di.exceptions import ArgumentResolutionError, ContainerClosedError, ContextValueNotSetError
 
 
 request_context_provider = providers.ContextProvider(scope=Scope.REQUEST, context_type=datetime.datetime)
@@ -40,8 +40,9 @@ def test_context_provider_set_context_after_creation() -> None:
 
 def test_context_provider_not_found() -> None:
     app_container = Container()
-    with pytest.warns(ContextValueNoneWarning):
-        assert app_container.resolve_provider(MyGroup.context_provider) is None
+    with pytest.raises(ContextValueNotSetError) as exc_info:
+        app_container.resolve_provider(MyGroup.context_provider)
+    assert exc_info.value.context_type is datetime.datetime
 
 
 def test_context_provider_not_found_but_required() -> None:
@@ -178,8 +179,9 @@ def test_context_provider_reads_registry_at_its_own_scope_not_resolving_containe
     app = Container(scope=Scope.APP, groups=[_ScopedCtxGroup])
     request = app.build_child_container(scope=Scope.REQUEST, context={_ScopedCtx: _ScopedCtx()})
     # context set on the CHILD must be invisible to an APP-scoped provider
-    with pytest.warns(ContextValueNoneWarning):
-        assert request.resolve(_ScopedCtx) is None
+    with pytest.raises(ContextValueNotSetError) as exc_info:
+        request.resolve(_ScopedCtx)
+    assert exc_info.value.context_type is _ScopedCtx
     # context set on the container at the provider's scope is what counts
     app.set_context(_ScopedCtx, value)
     assert request.resolve(_ScopedCtx) is value
@@ -294,21 +296,11 @@ def test_cached_factory_injects_present_context_at_cold_build() -> None:
     assert svc.ctx is ctx
 
 
-def test_unset_context_provider_direct_resolve_warns_and_returns_none() -> None:
+def test_direct_resolve_unset_context_raises() -> None:
     app_container = Container(groups=[MyGroup], validate=False)
-    with pytest.warns(ContextValueNoneWarning, match="modern-di 3.0 raises ContextValueNotSetError"):
-        assert app_container.resolve_provider(MyGroup.context_provider) is None
-
-
-def test_unset_context_provider_warning_links_migration_guide_anchor() -> None:
-    # The trailer names the section covering this specific switch, not just the guide's landing page.
-    app_container = Container(groups=[MyGroup], validate=False)
-    with pytest.warns(
-        ContextValueNoneWarning,
-        match=r"See: https://modern-di\.modern-python\.org/migration/to-3\.x/"
-        r"#5-direct-resolve-of-an-unset-contextprovider-raises$",
-    ):
+    with pytest.raises(ContextValueNotSetError) as exc_info:
         app_container.resolve_provider(MyGroup.context_provider)
+    assert exc_info.value.context_type is datetime.datetime
 
 
 def test_set_context_provider_direct_resolve_does_not_warn() -> None:
@@ -333,8 +325,8 @@ def test_context_provider_rejects_context_type_passed_twice() -> None:
 
 def test_context_provider_override_direct_short_circuits() -> None:
     # Overriding a ContextProvider and resolving it DIRECTLY exercises the compiled context-provider
-    # resolver's own override front-guard: the override wins with no ContextValueNoneWarning, even
-    # though no value is set in the context registry.
+    # resolver's own override front-guard: the override wins with no ContextValueNotSetError raised,
+    # even though no value is set in the context registry.
     override_value = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     app_container = Container(groups=[MyGroup], validate=False)
     app_container.override(MyGroup.context_provider, override_value)
@@ -401,8 +393,18 @@ class _KwargsCtxNoSignatureGroup(Group):
 
 def test_kwargs_context_provider_without_parsed_signature_keeps_direct_resolve() -> None:
     # A **kwargs creator parses no SignatureItem for `ctx`, so there is no default to honor and
-    # nothing to fix: it keeps resolving through the provider bucket, warning as before. Routing it
-    # as required would raise where 2.x returns None; as nullable would drop the 3.0 signal.
+    # nothing to fix: it keeps resolving through the provider bucket, the same path a direct resolve
+    # takes. Routing it as required would raise where 2.x returns None; as nullable would drop the
+    # 3.0 signal — so it stays on the direct-resolve path, which now raises when unset.
     app_container = Container(groups=[_KwargsCtxNoSignatureGroup], validate=False)
-    with pytest.warns(ContextValueNoneWarning):
-        assert app_container.resolve_provider(_KwargsCtxNoSignatureGroup.out) == "ctx=None"
+    with pytest.raises(ContextValueNotSetError) as exc_info:
+        app_container.resolve_provider(_KwargsCtxNoSignatureGroup.out)
+    assert exc_info.value.context_type is datetime.datetime
+
+
+def test_kwargs_context_provider_without_parsed_signature_injects_present_value() -> None:
+    # Same no-parsed-signature routing as above, but with a value present: the direct-resolve path
+    # returns it normally and the creator runs.
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    app_container = Container(groups=[_KwargsCtxNoSignatureGroup], context={datetime.datetime: now}, validate=False)
+    assert app_container.resolve_provider(_KwargsCtxNoSignatureGroup.out) == f"ctx={now!r}"


### PR DESCRIPTION
Fourth of the five queued modern-di 3.0 breaking switches (see `planning/changes/2026-07-19.14-3.0-release-scope.md`).

In 2.x, `container.resolve(SomeContextType)` with no value set emitted `ContextValueNoneWarning` and returned `None`. In 3.0 it raises `ContextValueNotSetError`. This affects only a **direct** resolve of the context type — a `Factory` parameter backed by the same `ContextProvider` still follows its own default/nullable/required disposition (proven by a retained test).

- `modern_di/providers/context_provider.py` — `resolve()` raises `ContextValueNotSetError(context_type=..., scope_name=...)` on unset; drop the `warnings` import; docstring updated.
- `ContextValueNoneWarning` class retained (unused) so filterwarnings configs don't break.
- Docs: `docs/providers/context.md`, `errors-and-exceptions.md`, `docs/troubleshooting/context-not-set.md`, `architecture/providers.md`.
- Change bundle: `planning/changes/2026-07-19.18-unset-context-raises.md`.

## Verification
- `just test-ci` — 426 passed, 100% coverage
- `just lint-ci` — clean; `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)