### PR TITLE
feat(container): validate by default, deferred to entry/first-resolve — 3.0 breaking change

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -30,17 +30,16 @@ instances. It also auto-registers `container_provider` (see [below](#container_p
 
 ### `validate`'s three states
 
-See [validation.md](validation.md) for what each state does and why. The container-specific wrinkle:
-child containers built via `build_child_container` never pass `validate` explicitly, so they always
-land on the unset (`None`) branch — but `UnvalidatedContainerWarning` additionally requires
-`parent_container is None`, which is false for every child. So children never warn, regardless of
-`validate`'s value.
-
-Escalate the warning to catch it in CI ahead of the 3.0 upgrade:
-
-```python
-warnings.filterwarnings("error", category=exceptions.UnvalidatedContainerWarning)
-```
+See [validation.md](validation.md) for what each state does and why. In short, validation is
+**both-deferred**: `validate=True` and the default (`None`) are identical — both enable validation and
+both defer it to container entry (`open()`/`with`) or first resolve — while `validate=False` disables it.
+`__init__` records this once as `self._validate_enabled = validate is not False and parent_container is
+None`. The `parent_container is None` conjunct is the container-specific wrinkle: only a **root**
+validates. A child built via `build_child_container` never passes `validate`, and even if it did the
+`parent_container is None` guard is false for every child, so `_validate_enabled` is always `False` on a
+child — children never validate, regardless of `validate`'s value. That is safe because the providers
+registry is shared tree-wide, so the root's single validation walk covers every child (see
+[Integration seam](#integration-seam)).
 
 ## Child containers
 
@@ -160,6 +159,11 @@ Concretely: using the same container object as a context manager a second time r
 close removed those cached values), and then closes it again on exit. Providers whose
 `CacheSettings.clear_cache` is `False` retain their cached instances across reopen cycles.
 
+`open()` also runs deferred validation, but **only once**: it calls `self.validate()` when
+`_validate_enabled and not self._validated`. `close()` leaves `_validated` untouched (it only sets
+`closed = True`), so the flag survives a close, and a plain close→reopen does **not** re-walk the graph.
+See [validation.md](validation.md#enabling-validation--deferred-by-default).
+
 Prefer the `with` form. `open()` is exposed as a public method for callback-style lifecycles that
 cannot wrap the container in a `with` block — for example a framework startup hook that must reopen
 the long-lived root container before serving the next request. The FastStream integration uses
@@ -168,7 +172,7 @@ exactly this: `app.on_startup(container.open)` paired with `app.after_shutdown(c
 ## `validate()`
 
 See [validation.md](validation.md) for what `container.validate()` checks, how it reports
-aggregated errors, and the pending 3.0 default flip.
+aggregated errors, and how validation runs deferred (once, at entry/first-resolve) by default.
 
 ## `set_context()`
 

--- a/architecture/validation.md
+++ b/architecture/validation.md
@@ -4,31 +4,41 @@
 is the authoritative catch-all for three classes of bug: **circular dependencies**, **inverted scope
 dependencies**, and **missing required dependencies**.
 
-## Enabling validation
+## Enabling validation — deferred by default
 
-Pass `validate=True` when constructing a container to run validation immediately after all groups are registered:
-
-```python
-container = Container(scope=Scope.APP, groups=[MyGroup], validate=True)
-```
-
-Or call `container.validate()` explicitly at any point after construction:
+Validation is enabled by default but runs **deferred**: not in `__init__`, but once at container entry
+(`open()` / `with`) or on the first `resolve`, whichever comes first.
 
 ```python
-container = Container(scope=Scope.APP, groups=[MyGroup])
-container.validate()  # raises ValidationFailedError if any issue found
+container = Container(scope=Scope.APP, groups=[MyGroup])  # __init__ does NOT validate
+with container:  # validation runs here, once
+    ...
 ```
 
 `validate` is tri-state (`bool | None`, default `None`) — see the [constructor table](containers.md#creating-a-root-container)
-for the full parameter reference. `validate=True` runs validation inside `__init__` (equivalent to
-`Container(...); container.validate()`); `validate=False` skips it silently with zero runtime cost;
-leaving it unset (`None`) also skips it but emits `UnvalidatedContainerWarning` on a **root**
-container, because **modern-di 3.0 runs `validate()` at root construction by default** — the
-current opt-in becomes opt-out. Pass `validate=True` now to adopt the 3.0 behavior early, or
-`validate=False` to keep it off permanently (that stays a supported no-warning choice after 3.0).
-See the [migration guide](../docs/migration/to-3.x.md) for the full readiness recipe. (Child
-containers never emit this warning regardless of `validate` — see
-[containers.md](containers.md#validates-three-states).)
+for the full parameter reference — and **both-deferred**: `validate=True` and the default (`None`) are
+identical, both enabling validation and both deferring it to entry/first-resolve. `validate=False`
+disables it entirely with zero runtime cost. There is no eager, construction-time validation and no
+`UnvalidatedContainerWarning`; for a construction-time check, call `container.validate()` explicitly:
+
+```python
+container = Container(scope=Scope.APP, groups=[MyGroup])
+container.validate()  # runs now; raises ValidationFailedError if any issue found
+```
+
+**Why deferred.** A framework integration typically registers its own context providers (e.g. the
+request object) *after* the user constructs the container, via [`add_providers`](containers.md#integration-seam).
+Eager validation at construction would fail on that still-incomplete graph. Deferring to the first
+`open()`/resolve means the whole graph — user groups plus integration-registered providers — is present
+before the single validation walk runs. Only a **root** container validates; children (built via
+`build_child_container`) never do, since the registry they share is validated tree-wide by the root.
+
+**Once only.** The per-container `_validate_enabled` flag (set in `__init__` to `validate is not False
+and parent_container is None`) gates whether validation runs at all; the `_validated` flag records that
+it has. Both `open()` and the first-resolve fallback in `resolve_provider` run `self.validate()` only
+`if self._validate_enabled and not self._validated`. Because `close()` leaves `_validated` untouched
+(it only sets `closed = True`), a plain close→reopen does **not** re-walk the graph — validation is
+paid exactly once over the container's lifetime.
 
 ## What validate() checks
 

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -76,13 +76,13 @@ Catch `ContainerError` for any container/scope failure.
   `container.open()`, before reusing it — see
   [Lifecycle: closing and reopening](lifecycle.md#closing-and-reopening).
   See [Troubleshooting: ContainerClosedError](../troubleshooting/container-closed-error.md).
-- **`ValidationFailedError`** — raised by `Container.validate()` (and `Container(..., validate=True)`)
-  when the graph has problems. Catch this for validation results; its `.errors` attribute holds the
-  list of individual issues (each itself a `ResolutionError` or `RegistrationError`), and `str()`
-  renders them all, grouped by error kind. Leaving `validate` unset on a root container skips the
-  check (as before) but emits **`UnvalidatedContainerWarning`** (a `FutureWarning`) — modern-di
-  **3.0** runs `validate()` at root construction by default; pass `validate=True` to adopt that now
-  or `validate=False` to keep validation off permanently. See
+- **`ValidationFailedError`** — raised by `Container.validate()` (and, deferred, by
+  `Container(..., validate=True)`) when the graph has problems. Catch this for validation results; its
+  `.errors` attribute holds the list of individual issues (each itself a `ResolutionError` or
+  `RegistrationError`), and `str()` renders them all, grouped by error kind. Both the default and
+  `validate=True` enable validation but run it **deferred** — at container entry (`open()`/`with`) or
+  first resolve, not at construction — so an integration's context providers registered after
+  construction are in the graph before the check runs. Pass `validate=False` to disable it. See
   [Migration: To 3.x](../migration/to-3.x.md) and
   [Troubleshooting: ValidationFailedError](../troubleshooting/validation-failed-error.md).
 

--- a/docs/providers/lifecycle.md
+++ b/docs/providers/lifecycle.md
@@ -165,7 +165,8 @@ Framework integrations handle this automatically: they build the REQUEST child c
 
 ## Validation
 
-`Container(groups=[...], validate=True)` runs the following checks at startup:
+`Container(groups=[...], validate=True)` runs the following checks — deferred, at container entry
+(`open()`/`with`) or first resolve, not at construction:
 
 - **Cycle detection.** Provider A depending on B depending on A raises `CircularDependencyError`
   (see [Troubleshooting: Circular dependency](../troubleshooting/circular-dependency.md)).

--- a/docs/recipes/good-and-bad-practices.md
+++ b/docs/recipes/good-and-bad-practices.md
@@ -34,18 +34,18 @@ dependencies — before the first request. Skipping it doesn't remove the bugs, 
 finding them to whichever resolve happens to hit one first.
 
 ```python
-# ❌ wiring bugs surface one at a time, in production, on whatever request trips them
-container = Container(groups=[Dependencies])
+# ❌ validation off: wiring bugs surface one at a time, in production, on whatever request trips them
+container = Container(groups=[Dependencies], validate=False)
 
-# ✅ every wiring bug in the graph is reported at startup, all at once
-container = Container(groups=[Dependencies], validate=True)
+# ✅ validation on (the default): every wiring bug is reported at once, at container entry / first resolve
+container = Container(groups=[Dependencies])
 ```
 
-**Caught by:** `validate=True` (or an explicit `container.validate()` call), which finds every
-issue in the graph up front instead of one at a time. An unvalidated cyclic graph still isn't a
-silent hang — see [the runtime cycle guard](../troubleshooting/circular-dependency.md#the-runtime-cycle-guard-without-validate).
-Leaving `validate` unset on a root container also emits `UnvalidatedContainerWarning`, since
-modern-di 3.0 turns validation on by default.
+**Caught by:** the default validation (equivalently `validate=True`), which runs deferred — once, at
+container entry (`open()`/`with`) or first resolve — and finds every issue in the graph up front
+instead of one at a time; call `container.validate()` explicitly for a construction-time check. Only
+`validate=False` opts out. An unvalidated cyclic graph still isn't a silent hang — see
+[the runtime cycle guard](../troubleshooting/circular-dependency.md#the-runtime-cycle-guard-without-validate).
 
 ## 3. A cached factory resolved before `set_context`
 

--- a/docs/troubleshooting/circular-dependency.md
+++ b/docs/troubleshooting/circular-dependency.md
@@ -39,11 +39,11 @@ in one pass (not just the one a particular resolve happens to hit) — prefer it
 ```python
 from modern_di import Container
 
-# Option 1: validate at creation
+# Option 1: enable validation (runs deferred, at container entry / first resolve)
 container = Container(groups=[MyGroup], validate=True)
 
-# Option 2: validate explicitly (validate=False silences the construction-time
-# UnvalidatedContainerWarning since validate() below runs the same check manually)
+# Option 2: validate explicitly at construction (validate=False disables the
+# deferred check; the validate() call below runs the same check immediately)
 container = Container(groups=[MyGroup], validate=False)
 container.validate()
 ```

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -55,6 +55,7 @@ class Container:
     __slots__ = (
         "_lock",
         "_scope_map",
+        "_validate_enabled",
         "_validated",
         "cache_registry",
         "closed",
@@ -76,14 +77,18 @@ class Container:
     ) -> None:
         """Build a container at ``scope``.
 
-        ``validate=True`` checks the provider graph (cycles plus scope ordering)
-        at construction time; ``validate=False`` skips the check silently.
-        Leaving ``validate`` unset (``None``, the default) skips the check but
-        warns with :class:`~modern_di.exceptions.UnvalidatedContainerWarning` on
-        a root container; child containers (with ``parent_container`` set) never
-        warn. ``context`` seeds this container's context registry. A root
-        container owns fresh registries; a child shares the parent's
-        providers/overrides registries and inherits its scope map.
+        ``validate`` enables the provider-graph check (cycles, scope ordering,
+        missing dependencies) but runs it **deferred**: ``True`` and the default
+        (``None``) both enable it, and it runs once at container entry
+        (:meth:`open`/``with``) or on the first resolve — never in ``__init__``.
+        Deferring lets a framework integration register its context providers
+        after construction and still have the complete graph validated.
+        ``validate=False`` disables the check entirely; call
+        :meth:`validate` explicitly for a construction-time check. Only a root
+        container validates; children (with ``parent_container`` set) never do.
+        ``context`` seeds this container's context registry. A root container
+        owns fresh registries; a child shares the parent's providers/overrides
+        registries and inherits its scope map.
         """
         if not isinstance(scope, enum.IntEnum):
             raise exceptions.InvalidScopeTypeError(scope_value=scope)
@@ -115,18 +120,10 @@ class Container:
             for one_group in groups:
                 all_providers.extend(one_group.get_providers())
             self.providers_registry.add_providers(*all_providers)
-        if validate:
-            self.validate()
-        elif validate is None and parent_container is None:
-            warnings.warn(
-                "This root container was created without an explicit `validate` argument. "
-                "modern-di 3.0 runs validate() at root construction by default. Pass validate=True "
-                "to adopt the 3.0 behavior now, or validate=False to keep validation off. "
-                "See: https://modern-di.modern-python.org/migration/to-3.x/"
-                "#4-validate-runs-by-default-at-root-construction",
-                exceptions.UnvalidatedContainerWarning,
-                stacklevel=2,
-            )
+        # Both-deferred: True and the default enable validation but run it at open()/first-resolve
+        # (root-only), so an integration's context providers registered after construction are in the
+        # graph before validation runs. False disables. Construction-time = call validate() explicitly.
+        self._validate_enabled = validate is not False and parent_container is None
 
     def build_child_container(
         self,
@@ -200,6 +197,8 @@ class Container:
     def resolve_provider(self, provider: "AbstractProvider[types.T]") -> types.T:
         """Resolve a specific provider by reference via its compiled resolver."""
         self._raise_if_closed()
+        if self._validate_enabled and not self._validated:
+            self.validate()  # first-resolve fallback for a container never entered via with/open()
         try:
             return self.providers_registry.resolver_for(provider)(self)
         except RecursionError as exc:
@@ -324,8 +323,13 @@ class Container:
         directly when a callback-style lifecycle (e.g. a startup hook) cannot
         wrap the container in a ``with`` block. Reopening an already-open
         container is a no-op.
+
+        If validation is enabled (``validate`` was not ``False``) and has not yet
+        run, it runs here — once; a plain close/reopen does not re-walk the graph.
         """
         self.closed = False
+        if self._validate_enabled and not self._validated:
+            self.validate()
 
     def _raise_if_closed(self) -> None:
         """Raise if this container is closed; callers reopen explicitly via `open()`/`with`."""

--- a/planning/changes/2026-07-19.19-validate-by-default-deferred.md
+++ b/planning/changes/2026-07-19.19-validate-by-default-deferred.md
@@ -1,0 +1,109 @@
+---
+summary: Validation is on by default but deferred — it runs once at container entry (`open()`/`with`) or first resolve, not at construction; 3.0 switch 5 of 5. Landed; `just test-ci` 430 passed, 100% coverage.
+---
+
+# Design: Validate by default, deferred (both-deferred)
+
+## Summary
+
+Makes graph validation **on by default** while moving *when* it runs from construction to container
+entry. `validate=True` and the default (`None`) now behave identically — both enable validation and
+both defer it to run **once** at `open()`/`with` or on the first `resolve`, whichever comes first.
+`validate=False` disables it. Construction-time validation is still available by calling
+`container.validate()` explicitly. This removes the eager `__init__` validation and the transitional
+`UnvalidatedContainerWarning` branch entirely. Switch 5 of the five 3.0 breaking changes scoped in
+[2026-07-19.14-3.0-release-scope](2026-07-19.14-3.0-release-scope.md).
+
+## Motivation
+
+The 2.x plan was to flip `validate` on by default and validate eagerly in `__init__`. But a framework
+integration typically registers *its own* context providers (the request object, the broker
+connection) **after** the user constructs the container, via `add_providers`. Eager construction-time
+validation would walk a still-incomplete graph and raise a false `ArgumentResolutionError` for every
+dependency the integration has not wired yet. The fix is to validate when the graph is fully
+assembled — at container entry — rather than at the moment the user calls `Container(...)`.
+
+## Design
+
+`Container.__init__` records one new slot:
+
+```python
+# root-only; True and the default enable validation, False disables it
+self._validate_enabled = validate is not False and parent_container is None
+```
+
+The eager `if validate: self.validate()` and the whole `elif validate is None ... warnings.warn(
+UnvalidatedContainerWarning)` branch are deleted. Nothing validates in `__init__` anymore.
+
+Two entry points run the deferred check, each a single guarded bool test:
+
+```python
+def open(self) -> None:
+    self.closed = False
+    if self._validate_enabled and not self._validated:
+        self.validate()
+
+def resolve_provider(self, provider):
+    self._raise_if_closed()
+    if self._validate_enabled and not self._validated:  # first-resolve fallback
+        self.validate()
+    ...
+```
+
+`open()` is called by `__enter__`/`__aenter__`, so `with`/`async with` validates on entry. The
+`resolve_provider` fallback covers a container resolved without ever being entered. It is **one**
+predictable bool check per top-level resolve — not per graph node; `validate()` itself short-circuits
+on the registry's `is_validated()` flag, and the compiled per-node resolvers are untouched.
+
+**Once only.** `_validate_enabled` gates *whether* validation runs; the existing `_validated` flag
+records that it *has*. `close()` leaves `_validated` untouched (it only sets `closed = True`), so a
+plain close→reopen does **not** re-walk the graph — validation is paid exactly once over a container's
+lifetime. Only a root validates: `parent_container is None` makes `_validate_enabled` always `False` on
+a child, which is safe because the providers registry is shared tree-wide and the root's single walk
+covers every child.
+
+**`add_providers` interaction (unchanged, now load-bearing).** `add_providers` re-validates only `if
+self._validated`. With deferred validation a not-yet-entered container has `_validated == False`, so
+`add_providers` skips re-validation and the later `open()` validates the complete graph. This is
+exactly what makes the integration pattern work: register a `ContextProvider` after construction, then
+`open()` validates clean.
+
+## Non-goals
+
+- No change to *what* `validate()` checks (cycles, inverted scope, missing deps) or how it aggregates.
+- `UnvalidatedContainerWarning` is left in `exceptions.py`, inert, so an existing
+  `filterwarnings(... category=exceptions.UnvalidatedContainerWarning)` config does not break at import.
+- `docs/migration/*` is deliberately not revised here (a later task owns the migration record).
+
+## Testing
+
+- New in `tests/test_container.py` (RED first, then GREEN after the mechanism): invalid graph does
+  **not** raise at construction but raises at `open()`; raises on the first `resolve` via the fallback;
+  raises via `with`-entry; a reopen counts exactly one `validate()` call
+  (`test_reopen_does_not_revalidate`); `validate=False` never validates; and the integration pattern —
+  a `Factory` depending by-type on a `ContextProvider` registered via `add_providers` **after**
+  construction validates clean at `open()`. Plus `test_default_and_true_both_enable_deferred_validation`
+  and `test_child_container_never_validates`.
+- Test churn (behavior genuinely changed): every test that expected `Container(..., validate=True)` to
+  raise **at construction** now triggers via `.open()`; tests exercising unvalidated resolve-time
+  behavior (runtime cycle guard, breadcrumb chains, did-you-mean suggestions, dangling-alias resolve)
+  now pass `validate=False` so the deferred walk does not intercept them; the six
+  `UnvalidatedContainerWarning`-specific tests and the pyproject `filterwarnings` entry that silenced it
+  were removed; the `add_providers`-on-validated-root tests now call `container.validate()` explicitly
+  to reach the validated state before adding.
+- `just test-ci`: **430 passed, 100.00% line coverage**.
+- `just lint-ci` (ruff format/check, `ty`, planning index) and `mkdocs build --strict`: clean.
+
+## Risk
+
+- **Broad test churn (32 pre-change failures across 9 files).** Because the default flips from
+  "no validation" to "deferred validation enabled", any test that constructed a broken graph and then
+  resolved got intercepted by the deferred walk. Each was fixed to assert real behavior — `validate=False`
+  where the test's point is the unvalidated resolve-time path, `.open()` where it asserts validation
+  fires. One coverage line (`_handle_recursion_error`'s no-static-cycle re-raise) moved branch because a
+  self-recursive creator's graph is now validated-then-resolved; its test now uses `validate=False` to
+  keep hitting that branch.
+- **Silent behavior change for callers relying on the old no-op default.** A caller who built a root
+  with unset `validate` and a broken graph previously got a filtered warning and no check; now the first
+  `open()`/resolve raises `ValidationFailedError`. This is the intended 3.0 semantics and the migration
+  guide (owned by a later task) documents it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,12 +79,7 @@ isort.no-lines-before = ["standard-library", "local-folder"]
 addopts = ""
 testpaths = ["tests"]
 asyncio_mode = "auto"
-# message-filter form on purpose: ignore::modern_di.exceptions.UnvalidatedContainerWarning
-# would import modern_di at pytest config time, before pytest-cov starts tracing, collapsing
-# coverage. Kept in sync by tests/test_container.py::test_unvalidated_warning_pyproject_filter_matches_live_message.
-filterwarnings = [
-    "ignore:This root container was created without an explicit `validate` argument:FutureWarning",
-]
+filterwarnings = []
 pythonpath = ["."]
 asyncio_default_fixture_loop_scope = "function"
 

--- a/tests/providers/test_alias.py
+++ b/tests/providers/test_alias.py
@@ -82,7 +82,8 @@ def test_alias_missing_source_raises_on_resolve() -> None:
     class G(Group):
         abstract = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository)
 
-    container = Container(groups=[G])
+    # validate=False: this exercises the resolve-time dangling-source error, not deferred validation.
+    container = Container(groups=[G], validate=False)
     with pytest.raises(AliasSourceNotRegisteredError, match="PostgresRepository") as exc:
         container.resolve(AbstractRepository)
     assert exc.value.source_type is PostgresRepository
@@ -92,7 +93,7 @@ def test_alias_missing_source_raises_on_validate_provider() -> None:
     class G(Group):
         abstract = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository)
 
-    container = Container(groups=[G])
+    container = Container(groups=[G], validate=False)
     with pytest.raises(AliasSourceNotRegisteredError, match="PostgresRepository"):
         container.resolve_provider(G.abstract)
 
@@ -108,8 +109,9 @@ def test_alias_participates_in_cycle_detection() -> None:
         concrete = providers.Factory(creator=Concrete)
         iface_alias = providers.Alias(source_type=Concrete, bound_type=Iface)
 
+    container = Container(groups=[G], validate=True)
     with pytest.raises(ValidationFailedError) as exc:
-        Container(groups=[G], validate=True)
+        container.open()  # deferred validation runs at entry
     [issue] = exc.value.errors
     assert isinstance(issue, CircularDependencyError)
     assert "Concrete" in str(issue)
@@ -149,8 +151,9 @@ class _DanglingAliasGroup(Group):
 
 
 def test_validate_aggregates_dangling_alias_into_validation_failed_error() -> None:
+    container = Container(scope=Scope.APP, groups=[_DanglingAliasGroup], validate=True)
     with pytest.raises(ValidationFailedError) as exc_info:
-        Container(scope=Scope.APP, groups=[_DanglingAliasGroup], validate=True)
+        container.open()  # deferred validation runs at entry
     errors = exc_info.value.errors
     assert any(isinstance(e, AliasSourceNotRegisteredError) for e in errors)
     min_expected_errors = 2
@@ -231,7 +234,7 @@ class _AliasChainErrGroup(Group):
 
 
 def test_alias_appears_in_resolution_error_chain() -> None:
-    container = Container(scope=Scope.APP, groups=[_AliasChainErrGroup])
+    container = Container(scope=Scope.APP, groups=[_AliasChainErrGroup], validate=False)
     with pytest.raises(exceptions.ArgumentResolutionError) as exc_info:
         container.resolve(_AliasTargetIface)
     rendered = str(exc_info.value)
@@ -252,7 +255,7 @@ class _NullBoundAliasGroup(Group):
 
 
 def test_alias_null_bound_type_resolution_error_uses_repr_fallback() -> None:
-    container = Container(scope=Scope.APP, groups=[_NullBoundAliasGroup])
+    container = Container(scope=Scope.APP, groups=[_NullBoundAliasGroup], validate=False)
     with pytest.raises(exceptions.ArgumentResolutionError) as exc_info:
         container.resolve_provider(_NullBoundAliasGroup.iface)
     rendered = str(exc_info.value)
@@ -277,8 +280,9 @@ class _XfourGroup(Group):
 
 
 def test_validate_flags_shallow_caller_depending_through_alias_on_deeper_source() -> None:
+    container = Container(scope=Scope.APP, groups=[_XfourGroup], validate=True)
     with pytest.raises(exceptions.ValidationFailedError) as exc_info:
-        Container(scope=Scope.APP, groups=[_XfourGroup], validate=True)
+        container.open()  # deferred validation runs at entry
     assert any(isinstance(e, exceptions.InvalidScopeDependencyError) for e in exc_info.value.errors)
     assert "REQUEST" in str(exc_info.value)
 
@@ -301,7 +305,7 @@ class _OkGroup(Group):
 
 
 def test_validate_allows_same_scope_caller_through_alias() -> None:
-    Container(scope=Scope.APP, groups=[_OkGroup], validate=True)  # must not raise
+    Container(scope=Scope.APP, groups=[_OkGroup], validate=True).open()  # deferred validation runs at entry
 
 
 class _ChainTerminal: ...
@@ -327,8 +331,9 @@ class _AliasOfAliasGroup(Group):
 
 def test_validate_follows_alias_of_alias_to_terminal_scope() -> None:
     # caller(APP) -> top(alias) -> mid(alias) -> terminal(REQUEST): effective scope follows 2 hops -> flagged
+    container = Container(scope=Scope.APP, groups=[_AliasOfAliasGroup], validate=True)
     with pytest.raises(exceptions.ValidationFailedError) as exc_info:
-        Container(scope=Scope.APP, groups=[_AliasOfAliasGroup], validate=True)
+        container.open()  # deferred validation runs at entry
     assert any(isinstance(e, exceptions.InvalidScopeDependencyError) for e in exc_info.value.errors)
     assert "REQUEST" in str(exc_info.value)
 

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -319,7 +319,8 @@ class _UnannotatedGroup(Group):
 def test_unannotated_param_error_explains_missing_annotation() -> None:
     sentinel = object()
     assert _unannotated_creator(sentinel) is sentinel  # exercise body for coverage
-    container = Container(scope=Scope.APP, groups=[_UnannotatedGroup])
+    # validate=False: this exercises the resolve-time argument error, not deferred validation.
+    container = Container(scope=Scope.APP, groups=[_UnannotatedGroup], validate=False)
     with pytest.raises(ArgumentResolutionError, match="has no usable type annotation"):
         container.resolve(object)
 
@@ -341,7 +342,7 @@ class _UnionGroup(Group):
 def test_union_param_error_names_the_union_members() -> None:
     dep = _UnionDep1()
     assert _union_creator(dep) == str(dep)  # exercise body for coverage
-    container = Container(scope=Scope.APP, groups=[_UnionGroup])
+    container = Container(scope=Scope.APP, groups=[_UnionGroup], validate=False)
     with pytest.raises(ArgumentResolutionError, match=r"_UnionDep1 \| _UnionDep2"):
         container.resolve(str)
 
@@ -625,7 +626,7 @@ def test_repeated_failing_resolve_breadcrumb_does_not_compound() -> None:
     …" on the third resolve).
     """
     factory: providers.Factory[_NeedsUnregistered] = providers.Factory(creator=_NeedsUnregistered, scope=Scope.APP)
-    container = Container(scope=Scope.APP)
+    container = Container(scope=Scope.APP, validate=False)  # exercise resolve-time breadcrumb, not validation
     container.providers_registry.register(_NeedsUnregistered, factory)
 
     def _grab() -> str:
@@ -662,7 +663,7 @@ def test_nested_then_direct_resolve_does_not_leak_parent_breadcrumb() -> None:
 
     leaf2: providers.Factory[_Leaf2] = providers.Factory(creator=_Leaf2, scope=Scope.APP)
     parent2: providers.Factory[_Parent2] = providers.Factory(creator=_Parent2, scope=Scope.APP)
-    c2 = Container(scope=Scope.APP)
+    c2 = Container(scope=Scope.APP, validate=False)  # exercise resolve-time breadcrumb, not validation
     c2.providers_registry.register(_Leaf2, leaf2)
     c2.providers_registry.register(_Parent2, parent2)
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,8 +1,6 @@
 import copy
 import dataclasses
 import inspect
-import pathlib
-import re
 import typing
 import warnings
 
@@ -135,16 +133,19 @@ class CycleGroup(Group):
     b = providers.Factory(creator=CycleB)
 
 
-def test_validate_on_creation() -> None:
+def test_validate_at_entry() -> None:
+    # 3.0: validate=True enables validation but defers it to container entry; it does not raise at __init__.
+    container = Container(groups=[CycleGroup], validate=True)
     with pytest.raises(ValidationFailedError) as exc:
-        Container(groups=[CycleGroup], validate=True)
+        container.open()
     [issue] = exc.value.errors
     assert isinstance(issue, CircularDependencyError)
 
 
 def test_cycle_path_carries_definition_sites() -> None:
+    container = Container(groups=[CycleGroup], validate=True)
     with pytest.raises(ValidationFailedError) as exc_info:
-        Container(groups=[CycleGroup], validate=True)
+        container.open()
     rendered = str(exc_info.value)
     lineno = inspect.getsourcelines(CycleA)[1]
     assert f"({CycleA.__module__}:{lineno})" in rendered
@@ -227,7 +228,7 @@ def test_validate_walks_deeper_scoped_providers() -> None:
     class G(Group):
         svc = providers.Factory(scope=Scope.REQUEST, creator=Service)
 
-    Container(groups=[G], validate=True)
+    Container(groups=[G], validate=True).open()  # deferred validation runs at entry; must not raise
 
 
 def test_validate_raises_on_inverted_scope_dependency() -> None:
@@ -352,7 +353,7 @@ def test_validate_handles_factory_with_static_kwargs() -> None:
     class G(Group):
         svc = providers.Factory(creator=Service, kwargs={"name": "static"})
 
-    Container(groups=[G], validate=True)
+    Container(groups=[G], validate=True).open()  # deferred validation runs at entry; must not raise
 
 
 def test_validation_failed_error_str_renders_inner_errors() -> None:
@@ -535,17 +536,21 @@ def test_resolve_emits_no_deprecation_warning() -> None:
         container.build_child_container(scope=Scope.REQUEST)
 
 
-def test_root_container_without_validate_arg_warns_about_3_0_default() -> None:
-    with pytest.warns(exceptions.UnvalidatedContainerWarning, match="modern-di 3.0 runs validate"):
-        Container(scope=Scope.APP)
+def test_default_and_true_both_enable_deferred_validation() -> None:
+    # 3.0 both-deferred: the default (None) and validate=True are identical — validation is enabled but
+    # runs at entry, so neither raises at construction; both raise at open().
+    default_container = Container(scope=Scope.APP, groups=[CycleGroup])  # no raise at __init__
+    with pytest.raises(ValidationFailedError):
+        default_container.open()
+    true_container = Container(scope=Scope.APP, groups=[CycleGroup], validate=True)  # no raise at __init__
+    with pytest.raises(ValidationFailedError):
+        true_container.open()
 
 
-def test_unvalidated_container_warning_links_migration_guide_anchor() -> None:
-    with pytest.warns(
-        exceptions.UnvalidatedContainerWarning,
-        match=r"See: https://modern-di\.modern-python\.org/migration/to-3\.x/"
-        r"#4-validate-runs-by-default-at-root-construction$",
-    ):
+def test_root_without_validate_arg_does_not_warn() -> None:
+    # 3.0 removed UnvalidatedContainerWarning: constructing a root with unset validate is silent.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         Container(scope=Scope.APP)
 
 
@@ -555,21 +560,7 @@ def test_explicit_validate_false_never_warns() -> None:
         Container(scope=Scope.APP, validate=False)
 
 
-def test_explicit_validate_true_validates_and_never_warns() -> None:
-    @dataclasses.dataclass(kw_only=True, slots=True)
-    class Missing:
-        pass
-
-    @dataclasses.dataclass(kw_only=True, slots=True)
-    class BrokenService:
-        missing: Missing
-
-    class BrokenGroup(Group):
-        svc = providers.Factory(creator=BrokenService)
-
-    with pytest.raises(ValidationFailedError):
-        Container(scope=Scope.APP, groups=[BrokenGroup], validate=True)
-
+def test_valid_graph_validates_clean_at_entry_without_warning() -> None:
     @dataclasses.dataclass(kw_only=True, slots=True)
     class Dep:
         pass
@@ -584,10 +575,11 @@ def test_explicit_validate_true_validates_and_never_warns() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        Container(scope=Scope.APP, groups=[ValidGroup], validate=True)
+        with Container(scope=Scope.APP, groups=[ValidGroup], validate=True):  # validates clean at entry
+            pass
 
 
-def test_unset_validate_warns_but_does_not_validate() -> None:
+def test_deferred_validation_raises_on_first_resolve_not_construction() -> None:
     @dataclasses.dataclass(kw_only=True, slots=True)
     class Missing:
         pass
@@ -599,43 +591,17 @@ def test_unset_validate_warns_but_does_not_validate() -> None:
     class G(Group):
         svc = providers.Factory(creator=Service)
 
-    with pytest.warns(exceptions.UnvalidatedContainerWarning):
-        Container(scope=Scope.APP, groups=[G])  # constructs fine; the broken graph is never checked
-
+    container = Container(scope=Scope.APP, groups=[G])  # constructs fine; broken graph not yet checked
     with pytest.raises(ValidationFailedError):
-        Container(scope=Scope.APP, groups=[G], validate=True)
+        container.resolve(Service)  # first-resolve fallback validates
 
 
-def test_child_container_does_not_warn_about_validate() -> None:
-    root = Container(scope=Scope.APP, validate=False)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        root.build_child_container(scope=Scope.REQUEST)
-
-
-def test_unvalidated_container_warning_is_escalatable() -> None:
-    with warnings.catch_warnings():
-        warnings.filterwarnings("error", category=exceptions.UnvalidatedContainerWarning)
-        with pytest.raises(exceptions.UnvalidatedContainerWarning):
-            Container(scope=Scope.APP)
-
-
-def test_unvalidated_warning_pyproject_filter_matches_live_message() -> None:
-    """The pyproject.toml filterwarnings message must keep matching the live warning text.
-
-    The filter is message-based on purpose (see the comment in pyproject.toml), so nothing
-    else ties it to the warning it silences. If the wording in container.py drifts, this test
-    catches it instead of the suite silently filling with warning noise.
-    """
-    with pytest.warns(exceptions.UnvalidatedContainerWarning) as record:
-        Container(scope=Scope.APP)
-
-    pyproject_path = pathlib.Path(__file__).resolve().parent.parent / "pyproject.toml"
-    raw = pyproject_path.read_text()
-    pattern = re.search(r'"ignore:(?P<message>[^"]+):FutureWarning"', raw)
-    assert pattern is not None, "no ignore:...:FutureWarning filter found in pyproject.toml filterwarnings"
-
-    assert re.compile(pattern.group("message")).match(str(record[0].message)) is not None
+def test_child_container_never_validates() -> None:
+    # Root-only: only a root gets _validate_enabled; a child never validates regardless of the root's setting.
+    root = Container(scope=Scope.APP, validate=True)
+    assert root._validate_enabled is True  # noqa: SLF001
+    child = root.build_child_container(scope=Scope.REQUEST)
+    assert child._validate_enabled is False  # noqa: SLF001
 
 
 def test_add_providers_registers_and_resolves_by_type_and_reference() -> None:
@@ -689,7 +655,8 @@ def test_add_providers_on_validated_root_reraises_validation_failure() -> None:
     class Broken:
         missing: Missing
 
-    container = Container(scope=Scope.APP, validate=True)
+    container = Container(scope=Scope.APP)
+    container.validate()  # deferred: validate explicitly so this root is validated before add_providers
     broken_factory = providers.Factory(creator=Broken)
 
     with pytest.raises(ValidationFailedError) as exc:
@@ -722,11 +689,12 @@ def test_add_providers_on_unset_validate_root_does_not_validate() -> None:
     class Broken:
         missing: Missing
 
-    with pytest.warns(exceptions.UnvalidatedContainerWarning):
-        container = Container(scope=Scope.APP)
+    # Unset validate defers validation, so _validated is still False at construction: add_providers skips
+    # re-validation and a later open() validates the completed graph. This is the integration seam.
+    container = Container(scope=Scope.APP)
     broken_factory = providers.Factory(creator=Broken)
 
-    container.add_providers(broken_factory)  # should not raise
+    container.add_providers(broken_factory)  # should not raise: not yet validated
 
 
 def test_add_providers_rolls_back_whole_batch_when_revalidation_fails() -> None:
@@ -745,7 +713,8 @@ def test_add_providers_rolls_back_whole_batch_when_revalidation_fails() -> None:
     class G(Group):
         original = providers.Factory(creator=Original)
 
-    container = Container(scope=Scope.APP, groups=[G], validate=True)
+    container = Container(scope=Scope.APP, groups=[G])
+    container.validate()  # deferred: validate explicitly so add_providers re-validates the batch
 
     valid_factory = providers.Factory(creator=lambda: "ok", bound_type=str)
     inner_factory = providers.Factory(scope=Scope.REQUEST, creator=Inner)
@@ -843,7 +812,8 @@ def test_add_providers_rebuilds_stale_wiring_plan_for_required_dependency() -> N
 
 def test_add_providers_rolls_back_on_any_exception_from_revalidation() -> None:
     """Rollback must not be tied to ValidationFailedError specifically — any exception rolls back."""
-    container = Container(scope=Scope.APP, validate=True)
+    container = Container(scope=Scope.APP)
+    container.validate()  # deferred: validate first so add_providers takes the re-validation branch
     str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
 
     def _boom(_self: Container) -> None:
@@ -861,7 +831,8 @@ def test_add_providers_rolls_back_on_any_exception_from_revalidation() -> None:
 
 def test_add_providers_on_validated_root_with_valid_batch_succeeds() -> None:
     """Positive branch: a validated root re-validates successfully and the batch resolves afterwards."""
-    container = Container(scope=Scope.APP, validate=True)
+    container = Container(scope=Scope.APP)
+    container.validate()  # deferred: validate first so add_providers exercises the success re-validation branch
     str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
 
     container.add_providers(str_factory)
@@ -1009,3 +980,94 @@ def test_resolve_provider_raises_for_unhandled_provider_type() -> None:
     container = Container(validate=False)
     with pytest.raises(TypeError, match="no compiled resolver for provider type _UnknownProvider"):
         container.resolve_provider(provider)
+
+
+# --- Deferred validate-by-default (3.0 both-deferred) ---------------------------------------------
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class _DeferMissing:
+    pass
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class _DeferBrokenService:
+    missing: _DeferMissing  # no provider registered for _DeferMissing -> validation fails
+
+
+class _DeferBrokenGroup(Group):
+    svc = providers.Factory(creator=_DeferBrokenService)
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class _DeferValidService:
+    pass
+
+
+class _DeferValidGroup(Group):
+    svc = providers.Factory(creator=_DeferValidService)
+
+
+class _DeferRequest: ...
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class _DeferReqDependent:
+    request: _DeferRequest
+
+
+class _DeferFactoryNeedingRequestGroup(Group):
+    # Depends by-type on _DeferRequest, whose ContextProvider an integration registers after construction.
+    dependent = providers.Factory(creator=_DeferReqDependent)
+
+
+def test_invalid_graph_does_not_raise_at_construction() -> None:
+    container = Container(scope=Scope.APP, groups=[_DeferBrokenGroup])  # no raise: validation is deferred
+    with pytest.raises(ValidationFailedError):
+        container.open()  # validation runs at container entry
+
+
+def test_deferred_validation_runs_on_first_resolve() -> None:
+    # Never entered via with/open(): the first-resolve fallback validates before dispatching, so a broken
+    # graph surfaces as ValidationFailedError (not the bare ArgumentResolutionError a raw resolve would give).
+    container = Container(scope=Scope.APP, groups=[_DeferBrokenGroup])
+    with pytest.raises(ValidationFailedError):
+        container.resolve(_DeferBrokenService)
+
+
+def test_deferred_validation_raises_via_context_manager_entry() -> None:
+    container = Container(scope=Scope.APP, groups=[_DeferBrokenGroup])
+    with pytest.raises(ValidationFailedError), container:
+        pass  # pragma: no cover -- __enter__ raises before the body runs
+
+
+def test_reopen_does_not_revalidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    container = Container(scope=Scope.APP, groups=[_DeferValidGroup])
+    calls = {"n": 0}
+    real = Container.validate
+
+    def counting(self: Container) -> None:
+        calls["n"] += 1
+        real(self)
+
+    monkeypatch.setattr(Container, "validate", counting)
+    with container:
+        container.resolve(_DeferValidService)
+    with container:  # reopen must not re-walk the graph
+        container.resolve(_DeferValidService)
+    assert calls["n"] == 1
+
+
+def test_validate_false_never_validates() -> None:
+    container = Container(scope=Scope.APP, groups=[_DeferBrokenGroup], validate=False)
+    with container:  # validation is off -> the broken graph is never checked
+        pass
+
+
+def test_integration_pattern_context_registered_after_construction() -> None:
+    # The root-cause scenario: an integration registers its ContextProvider AFTER the user constructs the
+    # container. With deferred validation the graph is complete before validation runs, so no false failure.
+    container = Container(scope=Scope.APP, groups=[_DeferFactoryNeedingRequestGroup])  # no raise
+    container.add_providers(providers.ContextProvider(_DeferRequest))  # integration wires it in
+    with container:  # graph now complete -> validates clean
+        pass

--- a/tests/test_dependency_graph_contract.py
+++ b/tests/test_dependency_graph_contract.py
@@ -66,6 +66,7 @@ def test_validate_is_free_when_already_validated(monkeypatch: pytest.MonkeyPatch
         x = Factory(scope=Scope.APP, creator=X)
 
     container = Container(scope=Scope.APP, groups=[G], validate=True)
+    container.validate()  # deferred: run validation once so the flag is set before we forbid re-walking
 
     def _explode(*_: object, **__: object) -> object:  # pragma: no cover
         msg = "re-walked"

--- a/tests/test_dependency_path.py
+++ b/tests/test_dependency_path.py
@@ -33,7 +33,8 @@ class IncompleteGroup(Group):
 
 
 def test_chain_appears_when_arg_unresolvable() -> None:
-    container = Container(groups=[IncompleteGroup])
+    # validate=False: this exercises the resolve-time dependency-chain breadcrumb, not deferred validation.
+    container = Container(groups=[IncompleteGroup], validate=False)
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(MyService)
 

--- a/tests/test_runtime_cycle_guard.py
+++ b/tests/test_runtime_cycle_guard.py
@@ -95,7 +95,7 @@ def test_unvalidated_cycle_raises_circular_dependency_error() -> None:
     # assertions after the `with` block) keeps this deterministic under coverage.py — see
     # `_SHALLOW_RECURSION_LIMIT` above. It mirrors the guard's own `except RecursionError` shape
     # in `resolve_provider`.
-    container = Container(groups=[CycleGroup])
+    container = Container(groups=[CycleGroup], validate=False)  # exercise the runtime guard, not validation
     original_limit = sys.getrecursionlimit()
     sys.setrecursionlimit(_SHALLOW_RECURSION_LIMIT)
     try:
@@ -126,7 +126,7 @@ def _assert_deep_chain_cycle_is_self_contained(exc: exceptions.CircularDependenc
 
 
 def test_deep_chain_cycle_is_self_contained() -> None:
-    container = Container(groups=[DeepCycleGroup])
+    container = Container(groups=[DeepCycleGroup], validate=False)  # exercise the runtime guard, not validation
     original_limit = sys.getrecursionlimit()
     sys.setrecursionlimit(_SHALLOW_RECURSION_LIMIT)
     try:
@@ -147,7 +147,9 @@ def test_self_recursing_creator_passes_through_recursion_error() -> None:
     class RecursiveGroup(Group):
         svc = providers.Factory(creator=recursive_creator, bound_type=str)
 
-    container = Container(groups=[RecursiveGroup])
+    # validate=False keeps the registry unvalidated, so the guard runs find_cycle_from (no static cycle ->
+    # re-raise) rather than short-circuiting on the validated flag.
+    container = Container(groups=[RecursiveGroup], validate=False)
     with pytest.raises(RecursionError):
         container.resolve(str)
 

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -168,7 +168,8 @@ def test_argument_resolution_subclass_suggestion() -> None:
         db = providers.Factory(creator=PostgresDatabase)
         service = providers.Factory(creator=Service)
 
-    container = Container(groups=[G])
+    # validate=False: this exercises the resolve-time did-you-mean suggestion, not deferred validation.
+    container = Container(groups=[G], validate=False)
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 
@@ -189,7 +190,7 @@ def test_argument_resolution_baseclass_suggestion() -> None:
         db = providers.Factory(creator=Database)
         service = providers.Factory(creator=Service)
 
-    container = Container(groups=[G])
+    container = Container(groups=[G], validate=False)
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 
@@ -211,7 +212,7 @@ def test_argument_resolution_typo_suggestion() -> None:
         repo = providers.Factory(creator=Repository)
         service = providers.Factory(creator=Service)
 
-    container = Container(groups=[G])
+    container = Container(groups=[G], validate=False)
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 
@@ -228,7 +229,7 @@ def test_argument_resolution_no_suggestions_when_nothing_matches() -> None:
     class G(Group):
         service = providers.Factory(creator=Service)
 
-    container = Container(groups=[G])
+    container = Container(groups=[G], validate=False)
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 


### PR DESCRIPTION
Fifth and last of the five queued modern-di 3.0 breaking switches (see `planning/changes/2026-07-19.14-3.0-release-scope.md`).

3.0 validates the provider graph by default — but **deferred** to container entry (`open()`/`with`) or first resolve, not at construction. This is the root-cause fix for the integration footgun: an integration registers its connection `ContextProvider`s *after* the user builds the container, so the graph is only complete at entry.

**Both-deferred semantics:** `validate=None` (default) and `validate=True` both enable validation, deferred; `validate=False` is off. For construction-time failure, call `container.validate()` explicitly.

- `modern_di/container.py` — `_validate_enabled` slot (root-only); `open()` and `resolve_provider` (first-resolve fallback, after `_raise_if_closed`) each run `validate()` once when enabled and `not _validated`. `_validated` persists across `close()`, so **a plain reopen never re-walks** (locked by a counting test). Eager `__init__` validation and the `UnvalidatedContainerWarning` branch removed.
- Integrations need **no changes** — they rely on the default, which now completes the graph before validating (verified by an `add_providers`-after-construction test).
- `UnvalidatedContainerWarning` class retained (unused). Docs (timing prose only) + `architecture/validation.md` + `containers.md` updated.
- Change bundle: `planning/changes/2026-07-19.19-validate-by-default-deferred.md`.

## Verification
- `just test-ci` — 430 passed, 100% coverage
- `just lint-ci` — clean; `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)