### PR TITLE
feat(container): mandatory-open lifecycle — a container must be opened before use — 3.0 breaking change

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -22,29 +22,55 @@ Constructor parameters:
 | `groups` | `None` | One or more `Group` subclasses whose providers are registered into `providers_registry`. |
 | `context` | `None` | Mapping of `type → object` pre-populated into `context_registry`. |
 | `use_lock` | `True` | Wraps resolution in a `threading.RLock`; set `False` for single-threaded use. |
-| `validate` | `None` | Tri-state, see below. |
+| `validate` | `True` | Enable the provider-graph check, run once at `open()`. `False` disables it. See below. |
 
 A root container (no `parent_container`) creates fresh `ProvidersRegistry` and `OverridesRegistry`
 instances. It also auto-registers `container_provider` (see [below](#container_provider)) under the
 `Container` type.
 
-### `validate`'s three states
+A freshly-constructed container starts **unopened** (`closed = True`) and must be entered before use —
+see [Mandatory-open lifecycle](#mandatory-open-lifecycle).
 
-See [validation.md](validation.md) for what each state does and why. In short, validation is
-**both-deferred**: `validate=True` and the default (`None`) are identical — both enable validation and
-both defer it to container entry (`open()`/`with`) or first resolve — while `validate=False` disables it.
-`__init__` records this once as `self._validate_enabled = validate is not False and parent_container is
-None`. The `parent_container is None` conjunct is the container-specific wrinkle: only a **root**
-validates. A child built via `build_child_container` never passes `validate`, and even if it did the
-`parent_container is None` guard is false for every child, so `_validate_enabled` is always `False` on a
-child — children never validate, regardless of `validate`'s value. That is safe because the providers
-registry is shared tree-wide, so the root's single validation walk covers every child (see
-[Integration seam](#integration-seam)).
+### `validate` (a plain bool)
+
+See [validation.md](validation.md) for what the check does and why. `validate` is a plain
+`bool = True`: the default and `True` enable the provider-graph check, which runs **once at `open()`**
+(never in `__init__`, never on resolve); `validate=False` disables it. `__init__` records this once as
+`self._validate_enabled = validate and parent_container is None`. The `parent_container is None`
+conjunct is the container-specific wrinkle: only a **root** validates. A child built via
+`build_child_container` never passes `validate`, and even if it did the `parent_container is None` guard
+is false for every child, so `_validate_enabled` is always `False` on a child — children never validate,
+regardless of `validate`'s value. That is safe because the providers registry is shared tree-wide, so
+the root's single validation walk covers every child (see [Integration seam](#integration-seam)).
+
+## Mandatory-open lifecycle
+
+A container must be **opened** before it can resolve or build children. Construction leaves it
+unopened (`closed = True`); calling `resolve` / `resolve_provider` / `resolve_dependency` /
+`build_child_container` on an unopened (or closed) container raises `ContainerClosedError`. Enter it
+via `with` / `async with`, or call `open()` directly:
+
+```python
+with Container(scope=Scope.APP, groups=[MyGroup]) as container:
+    container.resolve(...)          # opened -> usable; validated once on entry (root only)
+# exit closes it; re-entering reopens
+
+# callback-style lifecycle (no with-block available):
+container = Container(scope=Scope.APP, groups=[MyGroup])
+container.open()                     # opens + validates (root, once)
+```
+
+The full lifecycle is: **construct → (unopened: use raises) → `open()`/`with` (root validates once) →
+use → close → reopen**. `open()` is the single validation trigger — resolution never validates. Only a
+root validates; a child from `build_child_container` also starts unopened and must be entered, but its
+`open()` merely clears `closed` (children never validate). See
+[Lifecycle: close and reopen](#lifecycle-close-and-reopen) for close/reopen mechanics.
 
 ## Child containers
 
 ```python
-child = container.build_child_container(scope=Scope.REQUEST, context={MyRequest: request_obj})
+with container.build_child_container(scope=Scope.REQUEST, context={MyRequest: request_obj}) as child:
+    child.resolve(...)
 ```
 
 `build_child_container` creates a new `Container` whose `parent_container` is the current one.
@@ -56,8 +82,9 @@ Rules:
   the parent, **not** `value + 1`, so non-contiguous custom enums (`TENANT=6, JOB=10`) work; if the parent is
   already at the deepest member, `MaxScopeReachedError` is raised. See
   [scopes.md](scopes.md#the-scope-algebra).
-- Building a child from a closed container raises `ContainerClosedError` (see
-  [Lifecycle: close and reopen](#lifecycle-close-and-reopen) below).
+- Building a child requires the parent be **open**: `build_child_container` on an unopened or closed
+  parent raises `ContainerClosedError` (see [Lifecycle: close and reopen](#lifecycle-close-and-reopen)
+  below). The returned child itself starts unopened and must be entered before use.
 
 The child gets its own, independent `_scope_map` dict that includes all ancestors plus itself,
 enabling `find_container(scope)` to walk up to any ancestor scope in O(1).
@@ -149,30 +176,32 @@ After running a finalizer, `CacheItem._clear()` evicts the cached instance (and 
 only if `CacheSettings.clear_cache` is `True` (the default); otherwise the cached value survives
 close, ready to be returned again without re-running the creator.
 
-### Reopen (context-manager protocol)
+### Open and reopen (context-manager protocol)
 
 `Container` implements both sync (`__enter__` / `__exit__`) and async (`__aenter__` / `__aexit__`)
-context managers; `open()` (documented on the method itself) is the reopen primitive they call.
+context managers; `open()` (documented on the method itself) is the primitive they call — both to open
+a freshly-constructed container the first time and to reopen it on re-entry.
 
 Concretely: using the same container object as a context manager a second time reopens it (clears
 `closed`), resolves providers fresh if `clear_cache=True` was set on their `CacheSettings` (since
 close removed those cached values), and then closes it again on exit. Providers whose
 `CacheSettings.clear_cache` is `False` retain their cached instances across reopen cycles.
 
-`open()` also runs deferred validation, but **only once**: it calls `self.validate()` when
-`_validate_enabled and not self._validated`. `close()` leaves `_validated` untouched (it only sets
-`closed = True`), so the flag survives a close, and a plain close→reopen does **not** re-walk the graph.
-See [validation.md](validation.md#enabling-validation--deferred-by-default).
+`open()` also runs validation, but **only once**: it calls `self.validate()` when
+`_validate_enabled and not self._validated` (root only). `close()` leaves `_validated` untouched (it
+only sets `closed = True`), so the flag survives a close, and a plain close→reopen does **not** re-walk
+the graph. See [validation.md](validation.md#enabling-validation--deferred-by-default).
 
 Prefer the `with` form. `open()` is exposed as a public method for callback-style lifecycles that
-cannot wrap the container in a `with` block — for example a framework startup hook that must reopen
-the long-lived root container before serving the next request. The FastStream integration uses
-exactly this: `app.on_startup(container.open)` paired with `app.after_shutdown(container.close_async)`.
+cannot wrap the container in a `with` block — for example a framework startup hook that must open the
+long-lived root container before serving the first request (and reopen it after a shutdown). The
+FastStream integration uses exactly this: `app.on_startup(container.open)` paired with
+`app.after_shutdown(container.close_async)`.
 
 ## `validate()`
 
 See [validation.md](validation.md) for what `container.validate()` checks, how it reports
-aggregated errors, and how validation runs deferred (once, at entry/first-resolve) by default.
+aggregated errors, and how validation runs once at `open()` by default.
 
 ## `set_context()`
 

--- a/architecture/validation.md
+++ b/architecture/validation.md
@@ -4,10 +4,12 @@
 is the authoritative catch-all for three classes of bug: **circular dependencies**, **inverted scope
 dependencies**, and **missing required dependencies**.
 
-## Enabling validation — deferred by default
+## Enabling validation — at open(), once
 
-Validation is enabled by default but runs **deferred**: not in `__init__`, but once at container entry
-(`open()` / `with`) or on the first `resolve`, whichever comes first.
+Validation is enabled by default but runs **deferred to `open()`**: not in `__init__`, and not on
+resolve, but once when the container is entered (`open()` / `with` / `async with`). A container must be
+opened before use anyway (see the [mandatory-open lifecycle](containers.md#mandatory-open-lifecycle)),
+so `open()` is the single, guaranteed validation trigger.
 
 ```python
 container = Container(scope=Scope.APP, groups=[MyGroup])  # __init__ does NOT validate
@@ -15,30 +17,29 @@ with container:  # validation runs here, once
     ...
 ```
 
-`validate` is tri-state (`bool | None`, default `None`) — see the [constructor table](containers.md#creating-a-root-container)
-for the full parameter reference — and **both-deferred**: `validate=True` and the default (`None`) are
-identical, both enabling validation and both deferring it to entry/first-resolve. `validate=False`
-disables it entirely with zero runtime cost. There is no eager, construction-time validation and no
-`UnvalidatedContainerWarning`; for a construction-time check, call `container.validate()` explicitly:
+`validate` is a plain `bool` (default `True`) — see the [constructor table](containers.md#creating-a-root-container)
+for the full parameter reference. `True` (the default) enables validation at `open()`; `validate=False`
+disables it entirely with zero runtime cost. There is no eager, construction-time validation; for a
+construction-time check, call `container.validate()` explicitly:
 
 ```python
 container = Container(scope=Scope.APP, groups=[MyGroup])
 container.validate()  # runs now; raises ValidationFailedError if any issue found
 ```
 
-**Why deferred.** A framework integration typically registers its own context providers (e.g. the
-request object) *after* the user constructs the container, via [`add_providers`](containers.md#integration-seam).
-Eager validation at construction would fail on that still-incomplete graph. Deferring to the first
-`open()`/resolve means the whole graph — user groups plus integration-registered providers — is present
-before the single validation walk runs. Only a **root** container validates; children (built via
-`build_child_container`) never do, since the registry they share is validated tree-wide by the root.
+**Why at open() rather than __init__.** A framework integration typically registers its own context
+providers (e.g. the request object) *after* the user constructs the container, via
+[`add_providers`](containers.md#integration-seam). Eager validation at construction would fail on that
+still-incomplete graph. Deferring to `open()` means the whole graph — user groups plus
+integration-registered providers — is present before the single validation walk runs. Only a **root**
+container validates; children (built via `build_child_container`) never do, since the registry they
+share is validated tree-wide by the root.
 
-**Once only.** The per-container `_validate_enabled` flag (set in `__init__` to `validate is not False
-and parent_container is None`) gates whether validation runs at all; the `_validated` flag records that
-it has. Both `open()` and the first-resolve fallback in `resolve_provider` run `self.validate()` only
-`if self._validate_enabled and not self._validated`. Because `close()` leaves `_validated` untouched
-(it only sets `closed = True`), a plain close→reopen does **not** re-walk the graph — validation is
-paid exactly once over the container's lifetime.
+**Once only.** The per-container `_validate_enabled` flag (set in `__init__` to `validate and
+parent_container is None`) gates whether validation runs at all; the `_validated` flag records that it
+has. `open()` runs `self.validate()` only `if self._validate_enabled and not self._validated`.
+Because `close()` leaves `_validated` untouched (it only sets `closed = True`), a plain close→reopen
+does **not** re-walk the graph — validation is paid exactly once over the container's lifetime.
 
 ## What validate() checks
 

--- a/benchmarks/test_guard_cold.py
+++ b/benchmarks/test_guard_cold.py
@@ -56,8 +56,9 @@ class ChainGroup(Group):
 
 
 def _cold_build_and_resolve() -> C0:
-    # Fresh registry -> full compile every call: construction + first-resolve compile + resolve.
+    # Fresh registry -> full compile every call: construction + open + first-resolve compile + resolve.
     container = Container(scope=Scope.APP, groups=[ChainGroup], validate=False)
+    container.open()
     return container.resolve_provider(ChainGroup.c0)
 
 

--- a/benchmarks/test_guard_concurrency.py
+++ b/benchmarks/test_guard_concurrency.py
@@ -66,6 +66,7 @@ _TOTAL_READS = 8000
 def test_g14_concurrent_cached_hit(benchmark, n_threads):
     # Fixed total reads split across N threads: batch time drops with N iff the read path scales.
     container = Container(scope=Scope.APP, groups=[CachedGroup], validate=False)
+    container.open()
     warm = container.resolve_provider(CachedGroup.obj)
     reads_per_thread = _TOTAL_READS // n_threads
 
@@ -93,10 +94,12 @@ def test_g15_concurrent_first_resolve(benchmark, n_threads):
     # All N threads race to first-resolve the SAME K cold singletons -> contention on each
     # creation lock. Fresh container per round (untimed setup) so every round actually creates.
     check = Container(scope=Scope.APP, groups=[_COLD_GROUP], validate=False)
+    check.open()
     assert all(check.resolve_provider(p) is not None for p in _COLD_PROVIDERS)
 
     def _setup() -> "tuple[tuple[Container], dict[str, object]]":
         container = Container(scope=Scope.APP, groups=[_COLD_GROUP], validate=False)
+        container.open()
         return (container,), {}
 
     def _batch(container) -> None:

--- a/benchmarks/test_guard_lifecycle.py
+++ b/benchmarks/test_guard_lifecycle.py
@@ -25,6 +25,7 @@ class BuildGroup(Group):
 
 def test_g6_build_child_container(benchmark):
     app = Container(scope=Scope.APP, groups=[BuildGroup], validate=False)
+    app.open()
     result = benchmark(app.build_child_container, scope=Scope.REQUEST)
     assert result.scope is Scope.REQUEST
 
@@ -33,6 +34,7 @@ def test_g6b_build_child_container_auto_scope(benchmark):
     # Default path: no explicit scope -> auto-increment via _next_deeper. G6 passes an explicit
     # scope and never exercises it; this guards the memoized auto-increment step against regressing.
     app = Container(scope=Scope.APP, groups=[BuildGroup], validate=False)
+    app.open()
     result = benchmark(app.build_child_container)
     assert result.scope is Scope.SESSION
 
@@ -57,10 +59,12 @@ class LifecycleGroup(Group):
 
 def test_g7_request_lifecycle(benchmark):
     app = Container(scope=Scope.APP, groups=[LifecycleGroup], validate=False)
+    app.open()
     loop = asyncio.new_event_loop()
 
     async def _run() -> Connection:
         req = app.build_child_container(scope=Scope.REQUEST)
+        req.open()  # fresh child per request; part of the measured request cycle, like the close below
         conn = req.resolve_provider(LifecycleGroup.conn)
         await req.close_async()
         return conn
@@ -99,9 +103,11 @@ _TEARDOWN_PROVIDERS = [getattr(_TEARDOWN_GROUP, f"res{i}") for i in range(len(_R
 
 def test_g13_teardown_at_scale(benchmark):
     app = Container(scope=Scope.APP, groups=[_TEARDOWN_GROUP], validate=False)
+    app.open()
 
     def _one_request() -> Container:
         req = app.build_child_container(scope=Scope.REQUEST)
+        req.open()  # fresh child per request; part of the measured request cycle, like the close below
         for provider in _TEARDOWN_PROVIDERS:
             req.resolve_provider(provider)
         req.close_sync()  # finalizes all 10 in reverse creation order

--- a/benchmarks/test_guard_resolve.py
+++ b/benchmarks/test_guard_resolve.py
@@ -34,6 +34,7 @@ class SingletonGroup(Group):
 
 def test_g1_transient_resolve(benchmark):
     container = Container(scope=Scope.APP, groups=[TransientGroup], validate=False)
+    container.open()
     result = benchmark(container.resolve_provider, TransientGroup.svc)
     assert isinstance(result, Service)
     assert isinstance(result.dep, Dep)
@@ -41,6 +42,7 @@ def test_g1_transient_resolve(benchmark):
 
 def test_g2_cached_resolve(benchmark):
     container = Container(scope=Scope.APP, groups=[SingletonGroup], validate=False)
+    container.open()
     container.resolve_provider(SingletonGroup.svc)  # warm the cache
     result = benchmark(container.resolve_provider, SingletonGroup.svc)
     assert isinstance(result, Service)
@@ -88,6 +90,7 @@ class ChainGroup(Group):
 
 def test_g3_deep_chain(benchmark):
     container = Container(scope=Scope.APP, groups=[ChainGroup], validate=False)
+    container.open()
     result = benchmark(container.resolve_provider, ChainGroup.c0)
     assert isinstance(result, C0)
     assert isinstance(result.c1.c2.c3.c4.c5, C5)
@@ -174,6 +177,7 @@ class WideGroup(Group):
 
 def test_g4_wide_resolve(benchmark):
     container = Container(scope=Scope.APP, groups=[WideGroup], validate=False)
+    container.open()
     result = benchmark(container.resolve_provider, WideGroup.wide)
     assert isinstance(result, Wide)
     assert isinstance(result.l9, L9)
@@ -197,7 +201,9 @@ class CrossScopeGroup(Group):
 
 def test_g5_cross_scope(benchmark):
     app = Container(scope=Scope.APP, groups=[CrossScopeGroup], validate=False)
+    app.open()
     req = app.build_child_container(scope=Scope.REQUEST)
+    req.open()
     result = benchmark(req.resolve_provider, CrossScopeGroup.req_svc)
     assert isinstance(result, RequestService)
     assert isinstance(result.app, AppService)
@@ -230,7 +236,9 @@ def test_g9_context_resolve(benchmark):
     # Isolates the context-folding (non-pure kwargs) path C1-C5 never touch: a factory mixing a
     # runtime context value with a provider dep. Container + child built in setup; only resolve timed.
     app = Container(scope=Scope.APP, groups=[ContextGroup], validate=False)
+    app.open()
     req = app.build_child_container(scope=Scope.REQUEST, context={RequestObj: RequestObj()})
+    req.open()
     result = benchmark(req.resolve_provider, ContextGroup.handler)
     assert isinstance(result, Handler)
     assert isinstance(result.req, RequestObj)
@@ -256,6 +264,7 @@ def test_g12_override_active_resolve(benchmark):
     # Override front-guard tax: an UNRELATED override flips has_overrides True, so every node in the
     # depth-6 chain pays a fetch_override lookup per resolve (the path a test suite with mocks hits).
     container = Container(scope=Scope.APP, groups=[OverrideChainGroup], validate=False)
+    container.open()
     container.override(OverrideChainGroup.sentinel, Sentinel())
     container.resolve_provider(OverrideChainGroup.c0)  # warm
     result = benchmark(container.resolve_provider, OverrideChainGroup.c0)

--- a/benchmarks/test_guard_validate.py
+++ b/benchmarks/test_guard_validate.py
@@ -56,6 +56,7 @@ class ChainGroup(Group):
 
 def test_g10_validate_deep_chain(benchmark):
     good = Container(scope=Scope.APP, groups=[ChainGroup], validate=True)  # raises if invalid
+    good.open()
     assert isinstance(good.resolve_provider(ChainGroup.c0), C0)
     benchmark.pedantic(
         lambda c: c.validate(),
@@ -146,6 +147,7 @@ class WideGroup(Group):
 
 def test_g11_validate_wide(benchmark):
     good = Container(scope=Scope.APP, groups=[WideGroup], validate=True)  # raises if invalid
+    good.open()
     assert isinstance(good.resolve_provider(WideGroup.wide), Wide)
     benchmark.pedantic(
         lambda c: c.validate(),

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ class Dependencies(Group):
 
 # Pass validate=True to detect cycles and scope-chain errors at startup
 container = Container(groups=[Dependencies], validate=True)
+container.open()  # open before use; validates once (root). `with` does this for you (next section)
 settings = container.resolve(Settings)
 print(settings.database_url)
 ```

--- a/docs/introduction/resolving.md
+++ b/docs/introduction/resolving.md
@@ -38,6 +38,7 @@ class Dependencies(Group):
 
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 
 connection = container.resolve(DatabaseConnection)
 assert connection.config.host == "localhost"

--- a/docs/providers/alias.md
+++ b/docs/providers/alias.md
@@ -52,6 +52,7 @@ class Dependencies(Group):
 
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 
 concrete = container.resolve(PostgresRepository)
 abstract = container.resolve(Repository)

--- a/docs/providers/container.md
+++ b/docs/providers/container.md
@@ -22,6 +22,7 @@ class Dependencies(Group):
     my_factory = providers.Factory(my_creator, scope=Scope.APP)
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 result = container.resolve(str)
 # result: "Container scope: APP"
 ```
@@ -45,6 +46,7 @@ class Dependencies(Group):
     )
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 result = container.resolve(str)
 # result: "resolved from APP scope"
 ```
@@ -57,7 +59,9 @@ ran the resolve, so a `REQUEST` child resolves `Container` to *itself*:
 
 ```python
 app_container = Container(scope=Scope.APP, validate=True)
+app_container.open()
 request_container = app_container.build_child_container(scope=Scope.REQUEST)
+request_container.open()
 
 assert app_container.resolve(Container) is app_container
 assert request_container.resolve(Container) is request_container  # the child, not the APP root

--- a/docs/providers/context.md
+++ b/docs/providers/context.md
@@ -47,11 +47,13 @@ class Dependencies(Group):
 
 # Provide custom context when building the child container
 container = Container(groups=[Dependencies], validate=True)
+container.open()  # open the root before building children (validates once)
 custom_context = CustomContext(user_id="123", tenant_id="abc")
 request_container = container.build_child_container(
     scope=Scope.REQUEST,
     context={CustomContext: custom_context}
 )
+request_container.open()
 
 # Now resolve the factory — it will receive the custom context automatically
 user_info = request_container.resolve_provider(Dependencies.user_info)
@@ -82,6 +84,7 @@ Context never propagates between containers. A `ContextProvider` reads the conte
     # ❌ Broken: a REQUEST-scoped provider reads the REQUEST container's registry.
     # Setting it on the APP parent has no effect.
     app_container = Container(validate=True)
+    app_container.open()
     app_container.set_context(CustomContext, value)  # ignored for REQUEST-scoped providers
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
     ```
@@ -147,10 +150,12 @@ modern_di_fastapi.setup_di(app, container)
 # at runtime — never None.
 ```
 
-The `| None = None` on `request` is what keeps `validate=True` usable. `validate()`
-runs inside the `Container(...)` call, *before* `setup_di()` registers
-`fastapi.Request`'s `ContextProvider`; a required parameter with no provider would
-raise [`ArgumentResolutionError`](../troubleshooting/argument-resolution-error.md).
+The `| None = None` on `request` is what keeps `validate=True` usable. Validation is
+deferred to when the container is **opened** (the integration opens it as part of the
+app lifecycle); annotating `request` as optional means the check skips it regardless of
+whether `fastapi.Request`'s `ContextProvider` is registered by then — a required
+parameter with no provider would raise
+[`ArgumentResolutionError`](../troubleshooting/argument-resolution-error.md).
 A defaulted parameter is skipped by that check, and at runtime the integration has
 registered the provider and set the per-request context, so the real `Request` is
 injected — the parameter is `None` only when resolved with no context set, which the

--- a/docs/providers/factories.md
+++ b/docs/providers/factories.md
@@ -31,6 +31,7 @@ class Dependencies(Group):
 
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 # Resolve by provider reference
 instance = container.resolve_provider(Dependencies.independent_factory)
 assert isinstance(instance, IndependentFactory)
@@ -80,6 +81,7 @@ class Dependencies(Group):
 
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 singleton_instance1 = container.resolve_provider(Dependencies.singleton)
 singleton_instance2 = container.resolve_provider(Dependencies.singleton)
 
@@ -198,6 +200,7 @@ class Dependencies(Group):
 
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 service = container.resolve(Service)
 assert service.cache is None  # no Cache provider registered -> None injected
 ```
@@ -290,6 +293,7 @@ class Dependencies(Group):
 
 
 container = Container(groups=[Dependencies], validate=True)
+container.open()
 
 try:
     container.resolve(object)

--- a/docs/providers/lifecycle.md
+++ b/docs/providers/lifecycle.md
@@ -12,10 +12,11 @@ from modern_di import Container, Scope, providers, exceptions
 
 `modern-di` creates instances on first resolve. There is no `init_resources()` or "eager startup" call — if a provider is never resolved, its creator never runs.
 
-If you want a provider warmed up at startup (e.g. eager-connect the database engine), call `container.resolve(SomeType)` for it in your application's startup hook.
+If you want a provider warmed up at startup (e.g. eager-connect the database engine), call `container.resolve(SomeType)` for it in your application's startup hook — after opening the container.
 
 ```python
 container = Container(groups=[Dependencies], validate=True)
+container.open()  # required before resolving; also validates once (root)
 
 # Warm caches at startup
 container.resolve(AsyncEngine)
@@ -105,12 +106,12 @@ finalizer; the sync path is only a safety net.
 
 ## Closing and reopening
 
-Entering `with container:` (or `async with`) opens the container; exiting calls
-`close_sync()` / `close_async()`, which run the finalizers (in reverse-creation order, as
-above) and mark the container closed.
+A freshly-constructed container starts **unopened**: entering `with container:` (or `async with`, or
+a direct `container.open()`) opens it; exiting calls `close_sync()` / `close_async()`, which run the
+finalizers (in reverse-creation order, as above) and mark the container closed.
 
-While a container is closed, resolving a dependency — or building a child container — raises
-`ContainerClosedError` (see
+While a container is unopened or closed, resolving a dependency — or building a child container —
+raises `ContainerClosedError` (see
 [Migration: To 3.x](../migration/to-3.x.md#1-closed-containers-raise-instead-of-self-healing)).
 Re-entering `with container:` reopens it cleanly, and resolution works again:
 
@@ -150,6 +151,7 @@ Each container has its own finalizers — the ones for the providers it cached. 
 
 ```python
 app_container = Container(groups=[Dependencies], validate=True)
+app_container.open()  # open the root before building children (validates once)
 
 async with app_container.build_child_container(scope=Scope.REQUEST) as request_container:
     session = request_container.resolve(AsyncSession)
@@ -165,8 +167,8 @@ Framework integrations handle this automatically: they build the REQUEST child c
 
 ## Validation
 
-`Container(groups=[...], validate=True)` runs the following checks — deferred, at container entry
-(`open()`/`with`) or first resolve, not at construction:
+`Container(groups=[...], validate=True)` runs the following checks — once at container entry
+(`open()`/`with`), not at construction and not on resolve:
 
 - **Cycle detection.** Provider A depending on B depending on A raises `CircularDependencyError`
   (see [Troubleshooting: Circular dependency](../troubleshooting/circular-dependency.md)).

--- a/docs/providers/scopes.md
+++ b/docs/providers/scopes.md
@@ -29,6 +29,7 @@ from modern_di import Container, Scope
 
 
 app_container = Container(groups=[Dependencies], validate=True)     # APP scope
+app_container.open()                                               # open the root before use
 
 with app_container.build_child_container(scope=Scope.REQUEST) as request_container:
     ...
@@ -109,6 +110,7 @@ class MyGroup(Group):
 
 
 container = Container(groups=[MyGroup], validate=True)
+container.open()
 with container.build_child_container(scope=MyScope.TENANT) as tenant_container:
     tenant = tenant_container.resolve(TenantContext)
 ```
@@ -137,6 +139,7 @@ class RequestGroup(Group, scope=Scope.REQUEST):
 
 
 app_container = Container(groups=[RequestGroup], validate=True)
+app_container.open()
 with app_container.build_child_container(scope=Scope.REQUEST) as request_container:
     repo = request_container.resolve(UserRepository)
 ```

--- a/docs/recipes/good-and-bad-practices.md
+++ b/docs/recipes/good-and-bad-practices.md
@@ -19,8 +19,8 @@ class Dependencies(Group):
     user_cache = providers.Factory(UserCache, scope=Scope.REQUEST)
 ```
 
-**Caught by:** `Container(groups=[...], validate=True)` raises `InvalidScopeDependencyError` for
-this exact graph before anything is ever resolved — see
+**Caught by:** opening `Container(groups=[...], validate=True)` (the default) raises
+`InvalidScopeDependencyError` for this exact graph before anything is ever resolved — see
 [Scope chain violation](../troubleshooting/scope-chain.md). If the graph is never validated, the
 runtime failure is a `ScopeNotInitializedError`/`ScopeSkippedError` that (since the scope-error
 breadcrumb work) now names both the provider that captured the dependency and the one that
@@ -36,15 +36,17 @@ finding them to whichever resolve happens to hit one first.
 ```python
 # ❌ validation off: wiring bugs surface one at a time, in production, on whatever request trips them
 container = Container(groups=[Dependencies], validate=False)
+container.open()
 
-# ✅ validation on (the default): every wiring bug is reported at once, at container entry / first resolve
+# ✅ validation on (the default): every wiring bug is reported at once, at container entry
 container = Container(groups=[Dependencies])
+container.open()  # validates here — raises immediately if the graph is broken
 ```
 
-**Caught by:** the default validation (equivalently `validate=True`), which runs deferred — once, at
-container entry (`open()`/`with`) or first resolve — and finds every issue in the graph up front
-instead of one at a time; call `container.validate()` explicitly for a construction-time check. Only
-`validate=False` opts out. An unvalidated cyclic graph still isn't a silent hang — see
+**Caught by:** the default validation (equivalently `validate=True`), which runs deferred — once, when
+the container is entered (`open()`/`with`) — and finds every issue in the graph up front instead of one
+at a time; call `container.validate()` explicitly for a construction-time check. Only `validate=False`
+opts out. An unvalidated cyclic graph still isn't a silent hang — see
 [the runtime cycle guard](../troubleshooting/circular-dependency.md#the-runtime-cycle-guard-without-validate).
 
 ## 3. A cached factory resolved before `set_context`

--- a/docs/recipes/multi-group.md
+++ b/docs/recipes/multi-group.md
@@ -84,7 +84,7 @@ container = Container(groups=ALL_GROUPS, validate=True)
 
 - **Duplicate `bound_type` raises at container creation.** If two groups register providers for the same type (e.g. both bind to `AsyncSession`), `Container(groups=[...])` raises `DuplicateProviderTypeError` immediately. Fix by assigning distinct types — e.g. declare thin subclasses (`class WriteSession(AsyncSession): ...`) — or set `bound_type=None` on one provider and wire it explicitly via `kwargs`. See [Duplicate provider type](../troubleshooting/duplicate-type-error.md).
 - **Attribute-name collisions do not affect `Container`.** `Container` keys providers on their `bound_type`, not on the attribute name. Two groups can both have an attribute named `session` as long as their `bound_type`s differ — `Container` sees no conflict. The duplicate-name `ValueError` belongs to `modern-di-pytest`'s `expose(*groups)` helper (a separate package), which generates one pytest fixture per attribute name and does raise `ValueError` on duplicates. If you use `expose()`, ensure attribute names are unique across the groups you pass to it.
-- **Order in `groups=[...]` does not matter for resolution.** Validate at startup with `validate=True`.
+- **Order in `groups=[...]` does not matter for resolution.** Validate at startup — the integration opens the container, which runs the check.
 
 ## Auto-wiring with Litestar
 

--- a/docs/troubleshooting/child-container-registration-error.md
+++ b/docs/troubleshooting/child-container-registration-error.md
@@ -17,6 +17,7 @@ Call `add_providers()` on the root container instead:
 
 ```python
 app_container = Container(scope=Scope.APP, groups=[MyGroup])
+app_container.open()
 request_container = app_container.build_child_container(scope=Scope.REQUEST)
 
 # Wrong

--- a/docs/troubleshooting/container-closed-error.md
+++ b/docs/troubleshooting/container-closed-error.md
@@ -2,30 +2,33 @@
 
 **Symptom**
 
-Raised when resolving from, or building a child of, a container after it was closed.
+Raised when resolving from, or building a child of, a container that is **not open** — either one
+never opened, or one closed after use. The message reads: `Container (scope APP) is not open — enter
+it with with/async with or call open() ...`.
 
 **Cause**
 
-`container.close_sync()` / `close_async()` (or exiting a `with container:` block) marks the container
-closed. Any further `resolve()`, `resolve_provider()`, or `build_child_container()` call on that
-container raises this error — there is no self-heal.
+A container starts **unopened**: a freshly-constructed `Container(...)` must be entered before use.
+Entering it (`with` / `async with` / `container.open()`) opens it; `container.close_sync()` /
+`close_async()` (or exiting a `with container:` block) marks it closed again. While unopened or
+closed, any `resolve()`, `resolve_provider()`, or `build_child_container()` call raises this error —
+there is no self-heal.
 
 **Fix**
 
-Re-enter the container before reusing it:
+Open the container before using it:
 
 ```python
-with container:
+with container:                 # opens on enter, closes on exit
     container.resolve(Settings)
-# closed here
 
-with container:                 # reopened cleanly
+with container:                 # reopened cleanly for the next unit of work
     container.resolve(Settings)
 ```
 
-Or call `container.open()` explicitly if a context manager doesn't fit your flow. Build a fresh
-container per unit of work (e.g. one per request) instead of trying to reuse a closed one across
-units of work.
+Or call `container.open()` explicitly if a context manager doesn't fit your flow (e.g. a framework
+startup hook). Building a child requires the parent be open first, and the returned child must itself
+be opened before use. Build a fresh child container per unit of work (e.g. one per request).
 
 ## See also
 

--- a/docs/troubleshooting/group-instantiation-error.md
+++ b/docs/troubleshooting/group-instantiation-error.md
@@ -25,6 +25,7 @@ deps = Dependencies()             # raises GroupInstantiationError
 
 # Right
 container = Container(groups=[Dependencies])
+container.open()
 service = container.resolve_provider(Dependencies.service)
 ```
 

--- a/docs/troubleshooting/invalid-child-scope-error.md
+++ b/docs/troubleshooting/invalid-child-scope-error.md
@@ -19,9 +19,11 @@ Pass a scope whose value is strictly greater than the parent's:
 from modern_di import Scope
 
 app_container = Container(scope=Scope.APP, groups=[MyGroup])
+app_container.open()
 
 # Wrong: SESSION is not deeper than SESSION
 mid = app_container.build_child_container(scope=Scope.SESSION)
+mid.open()
 bad = mid.build_child_container(scope=Scope.SESSION)  # raises InvalidChildScopeError
 
 # Right

--- a/docs/troubleshooting/max-scope-reached-error.md
+++ b/docs/troubleshooting/max-scope-reached-error.md
@@ -32,6 +32,7 @@ class ExtendedScope(enum.IntEnum):
 
 
 step_container = Container(scope=ExtendedScope.STEP, parent_container=action_container)
+step_container.open()
 sub_container = step_container.build_child_container(scope=ExtendedScope.SUBSTEP)
 ```
 

--- a/docs/troubleshooting/scope-not-initialized-error.md
+++ b/docs/troubleshooting/scope-not-initialized-error.md
@@ -20,12 +20,14 @@ Build the deeper-scoped container before resolving from it:
 
 ```python
 app_container = Container(scope=Scope.APP, groups=[MyGroup], validate=True)
+app_container.open()
 
 # Wrong: no REQUEST container exists yet
 app_container.resolve(RequestScopedThing)  # raises ScopeNotInitializedError
 
 # Right
 request_container = app_container.build_child_container(scope=Scope.REQUEST)
+request_container.open()
 request_container.resolve(RequestScopedThing)
 ```
 

--- a/docs/troubleshooting/scope-skipped-error.md
+++ b/docs/troubleshooting/scope-skipped-error.md
@@ -21,14 +21,18 @@ straight to a deep one:
 
 ```python
 app_container = Container(scope=Scope.APP, groups=[MyGroup], validate=True)
+app_container.open()
 
 # Wrong: jumps straight past REQUEST
 action_container = app_container.build_child_container(scope=Scope.ACTION)
+action_container.open()
 action_container.resolve(RequestScopedThing)  # raises ScopeSkippedError
 
 # Right: build through REQUEST first
 request_container = app_container.build_child_container(scope=Scope.REQUEST)
+request_container.open()
 action_container = request_container.build_child_container(scope=Scope.ACTION)
+action_container.open()
 action_container.resolve(RequestScopedThing)
 ```
 

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -73,22 +73,25 @@ class Container:
         context: dict[type[typing.Any], typing.Any] | None = None,
         groups: list[type[Group]] | None = None,
         use_lock: bool = True,
-        validate: bool | None = None,
+        validate: bool = True,
     ) -> None:
         """Build a container at ``scope``.
 
-        ``validate`` enables the provider-graph check (cycles, scope ordering,
-        missing dependencies) but runs it **deferred**: ``True`` and the default
-        (``None``) both enable it, and it runs once at container entry
-        (:meth:`open`/``with``) or on the first resolve — never in ``__init__``.
-        Deferring lets a framework integration register its context providers
-        after construction and still have the complete graph validated.
-        ``validate=False`` disables the check entirely; call
-        :meth:`validate` explicitly for a construction-time check. Only a root
-        container validates; children (with ``parent_container`` set) never do.
-        ``context`` seeds this container's context registry. A root container
-        owns fresh registries; a child shares the parent's providers/overrides
-        registries and inherits its scope map.
+        A container starts **unopened** (``closed=True``): it must be entered via
+        :meth:`open` / ``with`` / ``async with`` before it can :meth:`resolve` or
+        :meth:`build_child_container`; using it before then raises
+        :class:`~modern_di.exceptions.ContainerClosedError`.
+
+        ``validate`` (default ``True``) enables the provider-graph check (cycles,
+        scope ordering, missing dependencies), which runs **once at open()** —
+        never in ``__init__`` and never on resolve. Deferring to ``open`` lets a
+        framework integration register its context providers after construction
+        and still have the complete graph validated. ``validate=False`` disables
+        the check entirely; call :meth:`validate` explicitly for a
+        construction-time check. Only a root container validates; children (with
+        ``parent_container`` set) never do. ``context`` seeds this container's
+        context registry. A root container owns fresh registries; a child shares
+        the parent's providers/overrides registries and inherits its scope map.
         """
         if not isinstance(scope, enum.IntEnum):
             raise exceptions.InvalidScopeTypeError(scope_value=scope)
@@ -96,7 +99,7 @@ class Container:
             raise exceptions.InvalidChildScopeError(parent_scope=parent_container.scope, child_scope=scope)
         self._lock = threading.RLock() if use_lock else None
         self._validated = False
-        self.closed = False
+        self.closed = True  # unopened: enter via open()/with before resolving or building children
         self.scope = scope
         self.parent_container = parent_container
         self._scope_map: dict[enum.IntEnum, typing_extensions.Self] = (
@@ -120,10 +123,10 @@ class Container:
             for one_group in groups:
                 all_providers.extend(one_group.get_providers())
             self.providers_registry.add_providers(*all_providers)
-        # Both-deferred: True and the default enable validation but run it at open()/first-resolve
-        # (root-only), so an integration's context providers registered after construction are in the
-        # graph before validation runs. False disables. Construction-time = call validate() explicitly.
-        self._validate_enabled = validate is not False and parent_container is None
+        # Root-only, run at open(): validation runs once when the container is entered, so an
+        # integration's context providers registered after construction are in the graph before it
+        # runs. False disables. Construction-time = call validate() explicitly.
+        self._validate_enabled = validate and parent_container is None
 
     def build_child_container(
         self,
@@ -197,8 +200,6 @@ class Container:
     def resolve_provider(self, provider: "AbstractProvider[types.T]") -> types.T:
         """Resolve a specific provider by reference via its compiled resolver."""
         self._raise_if_closed()
-        if self._validate_enabled and not self._validated:
-            self.validate()  # first-resolve fallback for a container never entered via with/open()
         try:
             return self.providers_registry.resolver_for(provider)(self)
         except RecursionError as exc:
@@ -317,15 +318,18 @@ class Container:
         return f"Container(scope={self.scope.name}, parent={parent}, providers={n_providers}, cached={n_cached})"
 
     def open(self) -> None:
-        """Reopen a closed container so it can resolve and build children again.
+        """Open the container so it can resolve and build children.
 
-        Called by ``__enter__``/``__aenter__`` to reopen on re-entry. Use it
-        directly when a callback-style lifecycle (e.g. a startup hook) cannot
-        wrap the container in a ``with`` block. Reopening an already-open
-        container is a no-op.
+        Mandatory: a freshly-constructed container starts unopened and must be
+        opened (here, or via ``with``/``async with`` which call this) before any
+        :meth:`resolve` or :meth:`build_child_container`. Also reopens a closed
+        container on re-entry. Use it directly when a callback-style lifecycle
+        (e.g. a startup hook) cannot wrap the container in a ``with`` block.
+        Opening an already-open container is a no-op.
 
-        If validation is enabled (``validate`` was not ``False``) and has not yet
-        run, it runs here — once; a plain close/reopen does not re-walk the graph.
+        If validation is enabled (``validate`` was not ``False``; root only) and
+        has not yet run, it runs here — once; a plain close/reopen does not
+        re-walk the graph.
         """
         self.closed = False
         if self._validate_enabled and not self._validated:

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -227,10 +227,11 @@ class InvalidScopeTypeError(ContainerError):
 
 
 class ContainerClosedError(ContainerError):
-    """Operation attempted on a closed container. Attr: ``container_scope``.
+    """Operation attempted on a container that is not open. Attr: ``container_scope``.
 
-    Raised in modern-di 3.0; until then reuse emits :class:`ContainerClosedWarning`
-    and self-reopens.
+    Covers both a never-opened container and one closed after use — a container
+    must be entered (``with``/``async with``/:meth:`~modern_di.Container.open`)
+    before it can resolve or build child containers.
     """
 
     docs_slug = "container-closed-error"
@@ -240,8 +241,8 @@ class ContainerClosedError(ContainerError):
     def __init__(self, *, container_scope: enum.IntEnum) -> None:
         self.container_scope = container_scope
         super().__init__(
-            f"Container (scope {container_scope.name}) is closed and can no longer resolve dependencies "
-            "or build child containers. Create a new container."
+            f"Container (scope {container_scope.name}) is not open — enter it with `with`/`async with` "
+            "or call `open()` before resolving or building child containers."
         )
 
 

--- a/planning/changes/2026-07-19.20-mandatory-open-lifecycle.md
+++ b/planning/changes/2026-07-19.20-mandatory-open-lifecycle.md
@@ -59,6 +59,12 @@ already using the context-manager form are unaffected. Unlike the validate
 deferral, this DOES require integration changes — verified at the `3.0.0rc1`
 smoke-test.
 
+The 5 `benchmarks/` guard files were missed in the initial pass (CI's
+guard-bench job caught it): each construct-then-resolve/build-child site there
+now calls `open()` in setup (or, for the G8 cold and G14/G15 pedantic-setup
+scenarios, inside the timed unit itself where construction already lived),
+keeping `validate=False` so `open()` stays a cheap flag flip.
+
 ## Testing
 
 Realized (all green): `just test-ci` **435 passed, 100% line coverage**; `just

--- a/planning/changes/2026-07-19.20-mandatory-open-lifecycle.md
+++ b/planning/changes/2026-07-19.20-mandatory-open-lifecycle.md
@@ -1,0 +1,102 @@
+---
+summary: 3.0 mandatory-open lifecycle — a container must be entered (open()/with) before it can resolve or build children; open() validates once; validate becomes a plain bool. Revises the 2026-07-19.14 validate mechanism.
+---
+
+# Design: Mandatory-open container lifecycle (3.0)
+
+## Summary
+
+A sixth 3.0 breaking change, from maintainer review of the validate-deferral: a
+container must be explicitly opened (via `open()` / `with` / `async with`) before
+it can `resolve` or `build_child_container`; using an unopened container raises
+`ContainerClosedError` (message broadened to cover the never-opened state).
+`open()` runs validation once (root only). This makes validation impossible to
+silently skip and the lifecycle explicit. `validate` becomes a plain
+`bool = True` — the `None` sentinel and the first-resolve fallback introduced in
+[2026-07-19.19](2026-07-19.19-validate-by-default-deferred.md) are removed.
+
+## Motivation
+
+The validate-deferral ([.19](2026-07-19.19-validate-by-default-deferred.md)) left
+a gap: a container constructed and resolved-from without ever being entered
+skipped validation via a first-resolve fallback that also taxed the resolve hot
+path. Making `open()` mandatory closes both — validation is guaranteed (you
+cannot use a container without opening it, and opening validates), and
+`resolve_provider` needs no validation check at all. Single explicit lifecycle
+trigger; `None`-vs-`True` ambiguity gone.
+
+## Design
+
+- `Container.__init__` starts `self.closed = True` (unopened). Signature
+  `validate: bool = True` (drop `bool | None` / the `None` sentinel).
+  `self._validate_enabled = validate and parent_container is None`.
+- `open()` / `__enter__` / `__aenter__`: set `closed = False`; then
+  `if self._validate_enabled and not self._validated: self.validate()` (once).
+- `resolve_provider` and `build_child_container` keep the `_raise_if_closed()`
+  guard (from [.17](2026-07-19.17-closed-container-raises.md)) — it now also fires
+  on a never-opened container. REMOVE the first-resolve validate fallback from
+  `resolve_provider`; validation lives only in `open()`.
+- Children also require open: a container returned by `build_child_container`
+  starts `closed=True` and must be entered before use. Children never validate
+  (root-only), so a child `open()` just clears `closed`.
+- `ContainerClosedError` message broadened to name the not-open state, e.g.
+  "Container (scope {name}) is not open — enter it with `with`/`async with` or
+  call `open()` before resolving or building child containers." Covers both
+  never-opened and closed-after-use.
+
+## Non-goals
+
+- Not changing what validation checks (cycles + scope order) — only when/whether
+  it runs.
+- No new exception class — reuse `ContainerClosedError` (maintainer decision).
+
+## Blast radius
+
+Every construct-then-use site must open. In this repo: all docs examples and the
+test suite. In the 12 sibling integration repos: any that build a root or a
+request-child and use it without `with`/`async with`/`open()`. Integrations
+already using the context-manager form are unaffected. Unlike the validate
+deferral, this DOES require integration changes — verified at the `3.0.0rc1`
+smoke-test.
+
+## Testing
+
+Realized (all green): `just test-ci` **435 passed, 100% line coverage**; `just
+lint-ci` clean (ruff + `ty` + planning validation); `mkdocs build --strict` clean.
+
+New/updated behaviour tests (in `tests/test_container.py` unless noted):
+
+- Unopened container: `resolve` (`test_unopened_container_resolve_raises`) and
+  `build_child_container` (`test_unopened_container_build_child_raises`) raise
+  `ContainerClosedError`; a fresh container reports `closed is True`
+  (`test_fresh_container_starts_unopened`).
+- Message names the not-open state — `test_container_closed_error_message_and_attr`
+  asserts `"not open"` and `"open()"`.
+- `open()` enables use and validates the root exactly once, and resolve no longer
+  validates (`test_open_enables_use_and_validates_root_once`); reopen does not
+  re-walk (`test_reopen_does_not_revalidate`).
+- A child from `build_child_container` starts unopened and requires open; child
+  `open()` does not validate
+  (`test_child_from_build_requires_open_and_does_not_validate`).
+- Validation lives only in `open()`: `test_validation_runs_at_open_not_resolve`
+  and `test_resolve_on_unopened_container_raises_before_validating` confirm resolve
+  no longer triggers validation (the old first-resolve fallback is gone).
+- `validate=False`: `open()` does not validate (`test_validate_false_never_validates`).
+- Integration seam preserved: `test_integration_pattern_context_registered_after_construction`.
+
+Test-suite churn: every construct-then-use site across the suite was wrapped to
+open its container before use (~196 test call-sites across 18 files). Two
+resolve-time-error tests in `tests/test_dependency_path.py`
+(`test_chain_includes_scope_name`, `test_captive_dependency_names_both_ends`)
+gained `validate=False` because their graphs are intentionally broken and are
+exercised at resolve time — with mandatory-open, `open()` would otherwise surface
+the graph error at entry.
+
+## Risk
+
+- Large mechanical churn (every construct-then-use site). Mitigated by uniform
+  `with`/`open()` adoption and the 100%-coverage gate.
+- Integration breakage for repos not using `with` — surfaces at the rc
+  smoke-test; those integrations must adopt `with`/`open()`.
+- Reusing `ContainerClosedError` for never-opened: "closed" naming is slightly
+  imprecise; mitigated by the broadened "not open" message.

--- a/tests/providers/test_alias.py
+++ b/tests/providers/test_alias.py
@@ -27,6 +27,7 @@ class MyGroup(Group):
 
 def test_alias_delegates_to_source() -> None:
     container = Container(groups=[MyGroup], validate=True)
+    container.open()
     concrete = container.resolve(PostgresRepository)
     abstract = container.resolve(AbstractRepository)
     assert isinstance(abstract, PostgresRepository)
@@ -39,6 +40,7 @@ def test_alias_without_caching_returns_fresh_instance_per_call() -> None:
         abstract = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository)
 
     container = Container(groups=[G])
+    container.open()
     a = container.resolve(AbstractRepository)
     b = container.resolve(PostgresRepository)
     assert isinstance(a, PostgresRepository)
@@ -52,16 +54,19 @@ def test_alias_respects_source_scope() -> None:
         abstract = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository)
 
     app_container = Container(groups=[G])
+    app_container.open()
     with pytest.raises(ScopeNotInitializedError):
         app_container.resolve(AbstractRepository)
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance = request_container.resolve(AbstractRepository)
     assert isinstance(instance, PostgresRepository)
 
 
 def test_alias_override_does_not_affect_source() -> None:
     container = Container(groups=[MyGroup])
+    container.open()
     mock = PostgresRepository(dsn="mock-alias")
     container.override(MyGroup.abstract_repo, mock)
 
@@ -71,6 +76,7 @@ def test_alias_override_does_not_affect_source() -> None:
 
 def test_source_override_propagates_through_alias() -> None:
     container = Container(groups=[MyGroup])
+    container.open()
     mock = PostgresRepository(dsn="mock-source")
     container.override(MyGroup.repo, mock)
 
@@ -84,6 +90,7 @@ def test_alias_missing_source_raises_on_resolve() -> None:
 
     # validate=False: this exercises the resolve-time dangling-source error, not deferred validation.
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(AliasSourceNotRegisteredError, match="PostgresRepository") as exc:
         container.resolve(AbstractRepository)
     assert exc.value.source_type is PostgresRepository
@@ -94,6 +101,7 @@ def test_alias_missing_source_raises_on_validate_provider() -> None:
         abstract = providers.Alias(source_type=PostgresRepository, bound_type=AbstractRepository)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(AliasSourceNotRegisteredError, match="PostgresRepository"):
         container.resolve_provider(G.abstract)
 
@@ -181,6 +189,7 @@ class _ChainGroup(Group):
 def test_alias_of_alias_resolves_to_source_and_validates() -> None:
     # all alias sources registered, so B-5 validate aggregation is not in play
     container = Container(scope=Scope.APP, groups=[_ChainGroup], validate=True)
+    container.open()
     impl = container.resolve(_ChainImpl)
     assert container.resolve(_ChainIfB) is impl
     assert container.resolve(_ChainIfA) is impl
@@ -188,8 +197,10 @@ def test_alias_of_alias_resolves_to_source_and_validates() -> None:
 
 def test_alias_resolved_from_child_returns_app_cached_singleton() -> None:
     container = Container(scope=Scope.APP, groups=[_ChainGroup])
+    container.open()
     app_instance = container.resolve(_ChainImpl)
     request = container.build_child_container(scope=Scope.REQUEST)
+    request.open()
     assert request.resolve(_ChainIfA) is app_instance
 
 
@@ -209,8 +220,10 @@ class _AliasScopeGroup(Group):
 
 def test_validate_does_not_flag_alias_whose_scope_is_shallower_than_source() -> None:
     app = Container(scope=Scope.APP, groups=[_AliasScopeGroup])
+    app.open()
     app.validate()  # must NOT raise for the alias->impl edge
     request = app.build_child_container(scope=Scope.REQUEST)
+    request.open()
     assert isinstance(request.resolve(_ShallowIface), _DeepImpl)  # resolution works
 
 
@@ -235,6 +248,7 @@ class _AliasChainErrGroup(Group):
 
 def test_alias_appears_in_resolution_error_chain() -> None:
     container = Container(scope=Scope.APP, groups=[_AliasChainErrGroup], validate=False)
+    container.open()
     with pytest.raises(exceptions.ArgumentResolutionError) as exc_info:
         container.resolve(_AliasTargetIface)
     rendered = str(exc_info.value)
@@ -256,6 +270,7 @@ class _NullBoundAliasGroup(Group):
 
 def test_alias_null_bound_type_resolution_error_uses_repr_fallback() -> None:
     container = Container(scope=Scope.APP, groups=[_NullBoundAliasGroup], validate=False)
+    container.open()
     with pytest.raises(exceptions.ArgumentResolutionError) as exc_info:
         container.resolve_provider(_NullBoundAliasGroup.iface)
     rendered = str(exc_info.value)
@@ -373,6 +388,7 @@ def test_alias_accepts_positional_source_type() -> None:
         abstract = providers.Alias(PostgresRepository, bound_type=AbstractRepository)
 
     container = Container(groups=[G], validate=True)
+    container.open()
     assert isinstance(container.resolve(AbstractRepository), PostgresRepository)
 
 

--- a/tests/providers/test_container_provider.py
+++ b/tests/providers/test_container_provider.py
@@ -3,9 +3,11 @@ from modern_di import Container, Group, Scope, providers
 
 def test_container_provider_direct_resolving() -> None:
     app_container = Container()
+    app_container.open()
     assert app_container.resolve(Container) is app_container
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     assert request_container.resolve_provider(providers.container_provider) is request_container
 
 
@@ -17,7 +19,9 @@ def test_container_provider_sub_dependency() -> None:
         factory = providers.Factory(scope=Scope.REQUEST, creator=creator)
 
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
 
     instance = request_container.resolve(Scope)
     assert instance == Scope.REQUEST
@@ -27,5 +31,6 @@ def test_container_provider_override_direct() -> None:
     # Overriding the container provider and resolving it directly exercises the compiled
     # container-provider resolver's own override front-guard (dispatch no longer checks centrally).
     app_container = Container()
+    app_container.open()
     app_container.override(providers.container_provider, "mock-container")
     assert app_container.resolve_provider(providers.container_provider) == "mock-container"

--- a/tests/providers/test_context_provider.py
+++ b/tests/providers/test_context_provider.py
@@ -24,6 +24,7 @@ class MyGroup(Group):
 def test_context_provider() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app_container = Container(groups=[MyGroup], context={datetime.datetime: now})
+    app_container.open()
     instance1 = app_container.resolve_provider(MyGroup.context_provider)
     instance2 = app_container.resolve_provider(MyGroup.context_provider)
     assert instance1 is instance2 is now
@@ -32,6 +33,7 @@ def test_context_provider() -> None:
 def test_context_provider_set_context_after_creation() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app_container = Container()
+    app_container.open()
     app_container.set_context(datetime.datetime, now)
     instance1 = app_container.resolve_provider(MyGroup.context_provider)
     instance2 = app_container.resolve_provider(MyGroup.context_provider)
@@ -40,6 +42,7 @@ def test_context_provider_set_context_after_creation() -> None:
 
 def test_context_provider_not_found() -> None:
     app_container = Container()
+    app_container.open()
     with pytest.raises(ContextValueNotSetError) as exc_info:
         app_container.resolve_provider(MyGroup.context_provider)
     assert exc_info.value.context_type is datetime.datetime
@@ -47,6 +50,7 @@ def test_context_provider_not_found() -> None:
 
 def test_context_provider_not_found_but_required() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     with pytest.raises(
         ArgumentResolutionError, match=r"Argument arg1 of type <class 'datetime.datetime'> cannot be resolved"
     ) as exc:
@@ -58,7 +62,9 @@ def test_context_provider_not_found_but_required() -> None:
 def test_context_provider_in_request_scope() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app_container = Container()
+    app_container.open()
     request_container = app_container.build_child_container(context={datetime.datetime: now}, scope=Scope.REQUEST)
+    request_container.open()
     instance1 = request_container.resolve_provider(request_context_provider)
     instance2 = request_container.resolve_provider(request_context_provider)
     assert instance1 is instance2 is now
@@ -84,6 +90,7 @@ def test_context_provider_returns_falsy_values(value: object) -> None:
     context_type = type(value)
     provider = providers.ContextProvider(scope=Scope.APP, context_type=context_type)
     app_container = Container(context={context_type: value})
+    app_container.open()
     assert app_container.resolve_provider(provider) == value
 
 
@@ -97,6 +104,7 @@ def test_factory_resolves_with_falsy_context_value() -> None:
         consumer = providers.Factory(creator=FlagConsumer)
 
     app_container = Container(groups=[FlagGroup], context={bool: False})
+    app_container.open()
     instance = app_container.resolve(FlagConsumer)
     assert instance.flag is False
 
@@ -111,6 +119,7 @@ def test_factory_resolves_with_none_context_value() -> None:
         holder = providers.Factory(creator=NoneHolder)
 
     app_container = Container(groups=[NoneGroup], context={datetime.datetime: None})
+    app_container.open()
     instance = app_container.resolve(NoneHolder)
     assert instance.value is None
 
@@ -127,6 +136,7 @@ def test_factory_uses_default_when_context_provider_value_unset() -> None:
         holder = providers.Factory(creator=TsHolder)
 
     app_container = Container(groups=[TsGroup])
+    app_container.open()
     instance = app_container.resolve(TsHolder)
     assert instance.ts == default
 
@@ -146,6 +156,7 @@ class _LateCtxGroup(Group):
 
 def test_set_context_after_first_resolve_is_seen_by_later_resolves() -> None:
     container = Container(scope=Scope.APP, groups=[_LateCtxGroup])
+    container.open()
     first = container.resolve(_NeedsLateCtx)
     assert first.ctx is None  # context unset, default applied
     value = _LateCtx()
@@ -157,7 +168,9 @@ def test_set_context_after_first_resolve_is_seen_by_later_resolves() -> None:
 def test_context_provider_through_closed_owning_container_raises() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app = Container(groups=[MyGroup], context={datetime.datetime: now})
+    app.open()
     child = app.build_child_container(scope=Scope.REQUEST)
+    child.open()
     app.close_sync()
     with pytest.raises(ContainerClosedError):
         child.resolve_provider(MyGroup.context_provider)
@@ -177,7 +190,9 @@ class _ScopedCtxGroup(Group):
 def test_context_provider_reads_registry_at_its_own_scope_not_resolving_container() -> None:
     value = _ScopedCtx()
     app = Container(scope=Scope.APP, groups=[_ScopedCtxGroup])
+    app.open()
     request = app.build_child_container(scope=Scope.REQUEST, context={_ScopedCtx: _ScopedCtx()})
+    request.open()
     # context set on the CHILD must be invisible to an APP-scoped provider
     with pytest.raises(ContextValueNotSetError) as exc_info:
         request.resolve(_ScopedCtx)
@@ -230,7 +245,9 @@ class _CrossRequiredGroup(Group):
 
 def test_late_app_context_seen_by_request_factory_defaulted_param() -> None:
     app = Container(scope=Scope.APP, groups=[_CrossDefaultGroup])
+    app.open()
     request = app.build_child_container(scope=Scope.REQUEST)
+    request.open()
     assert request.resolve(_CrossDefaultSvc).ctx is None  # context unset at first resolve
     value = _CrossCtx()
     app.set_context(_CrossCtx, value)
@@ -239,7 +256,9 @@ def test_late_app_context_seen_by_request_factory_defaulted_param() -> None:
 
 def test_late_app_context_seen_by_request_factory_nullable_param() -> None:
     app = Container(scope=Scope.APP, groups=[_CrossNullableGroup])
+    app.open()
     request = app.build_child_container(scope=Scope.REQUEST)
+    request.open()
     assert request.resolve(_CrossNullableSvc).ctx is None
     value = _CrossCtx()
     app.set_context(_CrossCtx, value)
@@ -248,7 +267,9 @@ def test_late_app_context_seen_by_request_factory_nullable_param() -> None:
 
 def test_late_app_context_required_param_raises_then_resolves_across_scopes() -> None:
     app = Container(scope=Scope.APP, groups=[_CrossRequiredGroup])
+    app.open()
     request = app.build_child_container(scope=Scope.REQUEST)
+    request.open()
     with pytest.raises(ArgumentResolutionError):
         request.resolve(_CrossRequiredSvc)
     value = _CrossCtx()
@@ -258,7 +279,9 @@ def test_late_app_context_required_param_raises_then_resolves_across_scopes() ->
 
 def test_override_of_context_param_applies_after_first_resolve_across_scopes() -> None:
     app = Container(scope=Scope.APP, groups=[_CrossDefaultGroup])
+    app.open()
     request = app.build_child_container(scope=Scope.REQUEST)
+    request.open()
     assert request.resolve(_CrossDefaultSvc).ctx is None
     override_value = _CrossCtx()
     app.override(_CrossDefaultGroup.ctx, override_value)
@@ -279,6 +302,7 @@ def test_late_context_does_not_rebuild_cached_singleton() -> None:
     # Documented limitation: a cached factory's instance is fixed at first build;
     # a later set_context does not retroactively rebuild it.
     app = Container(scope=Scope.APP, groups=[_CachedCtxGroup])
+    app.open()
     first = app.resolve(_CachedCtxSvc)
     assert first.ctx is None
     app.set_context(_CrossCtx, _CrossCtx())
@@ -290,6 +314,7 @@ def test_late_context_does_not_rebuild_cached_singleton() -> None:
 def test_cached_factory_injects_present_context_at_cold_build() -> None:
     # Context set before the first (cold) build is injected into the cached instance.
     app = Container(scope=Scope.APP, groups=[_CachedCtxGroup])
+    app.open()
     ctx = _CrossCtx()
     app.set_context(_CrossCtx, ctx)
     svc = app.resolve(_CachedCtxSvc)
@@ -298,6 +323,7 @@ def test_cached_factory_injects_present_context_at_cold_build() -> None:
 
 def test_direct_resolve_unset_context_raises() -> None:
     app_container = Container(groups=[MyGroup], validate=False)
+    app_container.open()
     with pytest.raises(ContextValueNotSetError) as exc_info:
         app_container.resolve_provider(MyGroup.context_provider)
     assert exc_info.value.context_type is datetime.datetime
@@ -306,6 +332,7 @@ def test_direct_resolve_unset_context_raises() -> None:
 def test_set_context_provider_direct_resolve_does_not_warn() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app_container = Container(groups=[MyGroup], context={datetime.datetime: now}, validate=False)
+    app_container.open()
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert app_container.resolve_provider(MyGroup.context_provider) is now
@@ -315,6 +342,7 @@ def test_context_provider_accepts_positional_context_type() -> None:
     provider = providers.ContextProvider(datetime.datetime)
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app_container = Container(context={datetime.datetime: now})
+    app_container.open()
     assert app_container.resolve_provider(provider) is now
 
 
@@ -329,6 +357,7 @@ def test_context_provider_override_direct_short_circuits() -> None:
     # even though no value is set in the context registry.
     override_value = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     app_container = Container(groups=[MyGroup], validate=False)
+    app_container.open()
     app_container.override(MyGroup.context_provider, override_value)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
@@ -356,6 +385,7 @@ def test_kwargs_context_provider_honors_creator_default_when_unset() -> None:
     # A ContextProvider passed explicitly via kwargs={...} must wire as a context kwarg, not a plain
     # provider: an unset value falls back to the creator's default rather than injecting None.
     app_container = Container(groups=[_KwargsCtxExplicitGroup], validate=False)
+    app_container.open()
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert app_container.resolve_provider(_KwargsCtxExplicitGroup.out) == "default-applied"
@@ -365,19 +395,23 @@ def test_kwargs_context_provider_matches_by_type_wiring() -> None:
     # The same creator wired both ways agrees: how the ContextProvider reaches the parameter is a
     # declaration detail, not a behavior switch.
     by_type = Container(groups=[_KwargsCtxByTypeGroup], validate=False)
+    by_type.open()
     explicit = Container(groups=[_KwargsCtxExplicitGroup], validate=False)
+    explicit.open()
     assert by_type.resolve_provider(_KwargsCtxByTypeGroup.out) == explicit.resolve_provider(_KwargsCtxExplicitGroup.out)
 
 
 def test_kwargs_context_provider_injects_present_value() -> None:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app_container = Container(groups=[_KwargsCtxExplicitGroup], context={datetime.datetime: now}, validate=False)
+    app_container.open()
     assert app_container.resolve_provider(_KwargsCtxExplicitGroup.out) == f"got {now!r}"
 
 
 def test_kwargs_context_provider_override_wins() -> None:
     override_value = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     app_container = Container(groups=[_KwargsCtxExplicitGroup], validate=False)
+    app_container.open()
     app_container.override(_KwargsCtxExplicitGroup.ctx, override_value)
     assert app_container.resolve_provider(_KwargsCtxExplicitGroup.out) == f"got {override_value!r}"
 
@@ -397,6 +431,7 @@ def test_kwargs_context_provider_without_parsed_signature_keeps_direct_resolve()
     # takes. Routing it as required would raise where 2.x returns None; as nullable would drop the
     # 3.0 signal — so it stays on the direct-resolve path, which now raises when unset.
     app_container = Container(groups=[_KwargsCtxNoSignatureGroup], validate=False)
+    app_container.open()
     with pytest.raises(ContextValueNotSetError) as exc_info:
         app_container.resolve_provider(_KwargsCtxNoSignatureGroup.out)
     assert exc_info.value.context_type is datetime.datetime
@@ -407,4 +442,5 @@ def test_kwargs_context_provider_without_parsed_signature_injects_present_value(
     # returns it normally and the creator runs.
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     app_container = Container(groups=[_KwargsCtxNoSignatureGroup], context={datetime.datetime: now}, validate=False)
+    app_container.open()
     assert app_container.resolve_provider(_KwargsCtxNoSignatureGroup.out) == f"ctx={now!r}"

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -50,6 +50,7 @@ class MyGroup(Group):
 
 def test_app_factory() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     instance1 = app_container.resolve_provider(MyGroup.app_factory)
     instance2 = app_container.resolve(dependency_type=SimpleCreator)
     assert isinstance(instance1, SimpleCreator)
@@ -59,6 +60,7 @@ def test_app_factory() -> None:
 
 def test_app_factory_skip_creator_parsing() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     with pytest.raises(
         exceptions.CreatorCallError,
         match=re.escape("SimpleCreator.__init__() missing 1 required keyword-only argument: 'dep1'"),
@@ -68,6 +70,7 @@ def test_app_factory_skip_creator_parsing() -> None:
 
 def test_app_factory_unresolvable() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     with pytest.raises(ArgumentResolutionError, match="Argument dep1 of type <class 'str'> cannot be resolved") as exc:
         app_container.resolve_provider(MyGroup.app_factory_unresolvable)
     assert exc.value.arg_name == "dep1"
@@ -76,6 +79,7 @@ def test_app_factory_unresolvable() -> None:
 
 def test_func_with_union_factory() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     instance1 = app_container.resolve_provider(MyGroup.func_with_union_factory)
     assert instance1 == str(SimpleCreator(dep1="original"))
 
@@ -85,6 +89,7 @@ def test_func_with_broken_annotation() -> None:
         factory = providers.Factory(creator=func_with_broken_annotation, bound_type=None)
 
     app_container = Container()
+    app_container.open()
     app_container.providers_registry.add_providers(factory)
     with pytest.raises(ArgumentResolutionError, match="has no usable type annotation"):
         app_container.resolve_provider(factory)
@@ -92,7 +97,9 @@ def test_func_with_broken_annotation() -> None:
 
 def test_request_factory() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     request_container.resolve_provider(MyGroup.request_factory)
     instance1 = request_container.resolve_provider(MyGroup.request_factory)
     instance2 = request_container.resolve_provider(MyGroup.request_factory)
@@ -100,6 +107,7 @@ def test_request_factory() -> None:
     assert instance1 is not instance2
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance3 = request_container.resolve_provider(MyGroup.request_factory)
     instance4 = request_container.resolve_provider(MyGroup.request_factory)
     assert instance3 is not instance4
@@ -109,7 +117,9 @@ def test_request_factory() -> None:
 
 def test_request_factory_with_di_container() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance1 = request_container.resolve_provider(MyGroup.request_factory_with_di_container)
     instance2 = request_container.resolve_provider(MyGroup.request_factory_with_di_container)
     assert instance1 is not instance2
@@ -118,6 +128,7 @@ def test_request_factory_with_di_container() -> None:
     assert instance1.di_container is instance2.di_container
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance3 = request_container.resolve_provider(MyGroup.request_factory_with_di_container)
     instance4 = request_container.resolve_provider(MyGroup.request_factory_with_di_container)
     assert instance3 is not instance4
@@ -127,6 +138,7 @@ def test_request_factory_with_di_container() -> None:
 
 def test_factory_overridden_app_scope() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     instance1 = app_container.resolve_provider(MyGroup.app_factory)
 
     app_container.override(MyGroup.app_factory, SimpleCreator(dep1="override"))
@@ -148,13 +160,16 @@ def test_factory_overridden_app_scope() -> None:
 
 def test_factory_overridden_request_scope() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     app_container.override(MyGroup.request_factory, DependentCreator(dep1=SimpleCreator(dep1="override")))
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance1 = request_container.resolve(DependentCreator)
     request_container.close_sync()
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance2 = request_container.resolve(DependentCreator)
     assert instance1 is instance2
     assert instance2.dep1.dep1 == instance1.dep1.dep1 == "override"
@@ -171,6 +186,7 @@ def test_override_bypasses_scope_check_from_shallower_container() -> None:
     # deeper-scoped provider can be resolved from a shallower container — see
     # architecture/testing-and-overrides.md "Scope behaviour under overrides".
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     with pytest.raises(ScopeNotInitializedError):
         app_container.resolve_provider(MyGroup.request_factory)
 
@@ -181,6 +197,7 @@ def test_override_bypasses_scope_check_from_shallower_container() -> None:
 
 def test_factory_scope_is_not_initialized() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     with pytest.raises(
         ScopeNotInitializedError,
         match=r"Provider of scope REQUEST cannot be resolved in container of scope APP.",
@@ -198,6 +215,7 @@ def test_factory_self_reference() -> None:
     second_factory = providers.Factory(creator=second_creator, kwargs={"first_factory": first_factory})
 
     app_container = Container()
+    app_container.open()
     app_container.providers_registry.add_providers(first_factory, second_factory)
 
     assert app_container.resolve_provider(second_factory) == "one two"
@@ -213,6 +231,7 @@ def test_factory_self_reference_in_union_falls_through_to_default() -> None:
 
     factory = providers.Factory(creator=make)
     app_container = Container()
+    app_container.open()
     app_container.providers_registry.add_providers(factory)
 
     result = app_container.resolve(SelfRef)
@@ -230,6 +249,7 @@ def test_factory_self_reference_by_type_falls_through_to_default() -> None:
 
     factory = providers.Factory(creator=make)
     app_container = Container()
+    app_container.open()
     app_container.providers_registry.add_providers(factory)
 
     # `nested` is typed as the factory's own bound type: it must not wire to itself,
@@ -289,6 +309,7 @@ def test_factory_allows_extra_kwargs_when_creator_accepts_var_keyword() -> None:
 
     factory = providers.Factory(creator=make, kwargs={"anything": 1, "extra": 2})
     container = Container()
+    container.open()
     container.providers_registry.add_providers(factory)
     result = container.resolve(dict)
     assert result == {"anything": 1, "extra": 2}
@@ -303,6 +324,7 @@ def test_factory_default_value_compared_with_is_not_eq() -> None:
 
     factory = providers.Factory(creator=make)
     container = Container()
+    container.open()
     container.providers_registry.add_providers(factory)
     result = container.resolve(str)
     assert result == repr(unittest.mock.ANY)
@@ -321,6 +343,7 @@ def test_unannotated_param_error_explains_missing_annotation() -> None:
     assert _unannotated_creator(sentinel) is sentinel  # exercise body for coverage
     # validate=False: this exercises the resolve-time argument error, not deferred validation.
     container = Container(scope=Scope.APP, groups=[_UnannotatedGroup], validate=False)
+    container.open()
     with pytest.raises(ArgumentResolutionError, match="has no usable type annotation"):
         container.resolve(object)
 
@@ -343,6 +366,7 @@ def test_union_param_error_names_the_union_members() -> None:
     dep = _UnionDep1()
     assert _union_creator(dep) == str(dep)  # exercise body for coverage
     container = Container(scope=Scope.APP, groups=[_UnionGroup], validate=False)
+    container.open()
     with pytest.raises(ArgumentResolutionError, match=r"_UnionDep1 \| _UnionDep2"):
         container.resolve(str)
 
@@ -370,6 +394,7 @@ class _PrecedenceGroup(Group):
 
 def test_static_kwargs_win_over_type_matched_provider() -> None:
     container = Container(scope=Scope.APP, groups=[_PrecedenceGroup])
+    container.open()
     svc = container.resolve(_PrecedenceSvc)
     assert svc.dep is _static_dep
     assert svc.dep.label == "from-kwargs"
@@ -411,6 +436,7 @@ def test_creator_raising_mid_creation_caches_nothing_and_retry_succeeds() -> Non
     _flaky_state["raised"] = False
     _flaky_events.clear()
     container = Container(scope=Scope.APP, groups=[_FlakyGroup])
+    container.open()
     with pytest.raises(RuntimeError, match="boom"):
         container.resolve(_FlakySvc)
     expected_cached_after_failure = 1  # only the dep cached; failed svc not cached
@@ -440,6 +466,7 @@ def test_wiring_plan_is_memoized_across_child_containers() -> None:
     real_build = wiring_mod.WiringPlan.build
     with unittest.mock.patch.object(wiring_mod.WiringPlan, "build", autospec=True, side_effect=real_build) as build_spy:
         app_container = Container(scope=Scope.APP, groups=[_MemoGroup], validate=True)
+        app_container.open()
         for _ in range(50):
             with app_container.build_child_container(scope=Scope.REQUEST) as request_container:
                 request_container.resolve(DependentCreator)
@@ -469,6 +496,8 @@ def test_shared_factory_wires_independently_per_registry() -> None:
 
     with_leaf = Container(scope=Scope.APP, groups=[WithLeaf], validate=True)
     without_leaf = Container(scope=Scope.APP, groups=[WithoutLeaf], validate=True)
+    with_leaf.open()
+    without_leaf.open()
 
     assert with_leaf.providers_registry.find_provider(OptionalDepSvc) is svc_factory
     assert without_leaf.providers_registry.find_provider(OptionalDepSvc) is svc_factory
@@ -498,6 +527,7 @@ class _NeedsOptionalUnion:
 def test_optional_param_injects_none_when_no_provider() -> None:
     factory: providers.Factory[_NeedsOptionalSingle] = providers.Factory(creator=_NeedsOptionalSingle, scope=Scope.APP)
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(_NeedsOptionalSingle, factory)
     obj = container.resolve(_NeedsOptionalSingle)
     assert obj.dep is None
@@ -507,6 +537,7 @@ def test_optional_param_uses_provider_when_present() -> None:
     dep_factory: providers.Factory[_OptionalDep] = providers.Factory(creator=_OptionalDep, scope=Scope.APP)
     factory: providers.Factory[_NeedsOptionalSingle] = providers.Factory(creator=_NeedsOptionalSingle, scope=Scope.APP)
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(_OptionalDep, dep_factory)
     container.providers_registry.register(_NeedsOptionalSingle, factory)
     obj = container.resolve(_NeedsOptionalSingle)
@@ -516,6 +547,7 @@ def test_optional_param_uses_provider_when_present() -> None:
 def test_optional_multi_member_union_injects_none_when_no_provider() -> None:
     factory: providers.Factory[_NeedsOptionalUnion] = providers.Factory(creator=_NeedsOptionalUnion, scope=Scope.APP)
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(_NeedsOptionalUnion, factory)
     obj = container.resolve(_NeedsOptionalUnion)
     assert obj.dep is None
@@ -545,6 +577,7 @@ def test_optional_param_backed_by_unset_context_provider_injects_none() -> None:
     )
     factory: providers.Factory[_NeedsOptionalCtx] = providers.Factory(creator=_NeedsOptionalCtx, scope=Scope.APP)
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(_OptionalCtx, ctx_provider)
     container.providers_registry.register(_NeedsOptionalCtx, factory)
     obj = container.resolve(_NeedsOptionalCtx)
@@ -563,6 +596,7 @@ def test_skip_creator_parsing_missing_args_raises_di_error() -> None:
         creator=_needs_two_args, bound_type=int, skip_creator_parsing=True, kwargs={"a": 1}
     )
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(int, factory)
     with pytest.raises(exceptions.CreatorCallError) as exc_info:
         container.resolve(int)
@@ -580,6 +614,7 @@ def test_skip_creator_parsing_missing_args_cached_raises_di_error() -> None:
         cache=True,
     )
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(int, factory)
     with pytest.raises(exceptions.CreatorCallError) as exc_info:
         container.resolve(int)
@@ -599,6 +634,7 @@ def test_internal_typeerror_from_creator_body_is_not_wrapped() -> None:
         creator=_InternalTypeErrorService, bound_type=_InternalTypeErrorService, skip_creator_parsing=True
     )
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(_InternalTypeErrorService, factory)
     with pytest.raises(TypeError) as exc_info:
         container.resolve(_InternalTypeErrorService)
@@ -627,6 +663,7 @@ def test_repeated_failing_resolve_breadcrumb_does_not_compound() -> None:
     """
     factory: providers.Factory[_NeedsUnregistered] = providers.Factory(creator=_NeedsUnregistered, scope=Scope.APP)
     container = Container(scope=Scope.APP, validate=False)  # exercise resolve-time breadcrumb, not validation
+    container.open()
     container.providers_registry.register(_NeedsUnregistered, factory)
 
     def _grab() -> str:
@@ -664,6 +701,7 @@ def test_nested_then_direct_resolve_does_not_leak_parent_breadcrumb() -> None:
     leaf2: providers.Factory[_Leaf2] = providers.Factory(creator=_Leaf2, scope=Scope.APP)
     parent2: providers.Factory[_Parent2] = providers.Factory(creator=_Parent2, scope=Scope.APP)
     c2 = Container(scope=Scope.APP, validate=False)  # exercise resolve-time breadcrumb, not validation
+    c2.open()
     c2.providers_registry.register(_Leaf2, leaf2)
     c2.providers_registry.register(_Parent2, parent2)
 
@@ -686,6 +724,7 @@ def test_cache_true_returns_same_instance() -> None:
         f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=True)
 
     container = Container(groups=[G])
+    container.open()
     assert container.resolve_provider(G.f) is container.resolve_provider(G.f)
     assert isinstance(G.f.cache_settings, providers.CacheSettings)
 
@@ -698,6 +737,7 @@ def test_cache_true_unresolvable_raises_argument_resolution_error() -> None:
         f = providers.Factory(creator=SimpleCreator, cache=True, bound_type=None)
 
     container = Container(groups=[G])
+    container.open()
     with pytest.raises(ArgumentResolutionError, match="Argument dep1 of type <class 'str'> cannot be resolved") as exc:
         container.resolve_provider(G.f)
     assert exc.value.arg_name == "dep1"
@@ -709,6 +749,7 @@ def test_cache_absent_returns_fresh_instances() -> None:
         f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"})
 
     container = Container(groups=[G])
+    container.open()
     assert container.resolve_provider(G.f) is not container.resolve_provider(G.f)
     assert G.f.cache_settings is None
 
@@ -719,6 +760,7 @@ def test_cache_falsy_disables_caching(cache_value: bool | None) -> None:
         f = providers.Factory(creator=SimpleCreator, kwargs={"dep1": "x"}, cache=cache_value)
 
     container = Container(groups=[G])
+    container.open()
     assert container.resolve_provider(G.f) is not container.resolve_provider(G.f)
     assert G.f.cache_settings is None
 
@@ -730,6 +772,7 @@ def test_cache_accepts_cache_settings_and_finalizes() -> None:
         f = providers.Factory(creator=dict, cache=providers.CacheSettings(finalizer=cleaned.append))
 
     container = Container(groups=[G])
+    container.open()
     instance = container.resolve_provider(G.f)
     assert container.resolve_provider(G.f) is instance
     container.close_sync()
@@ -751,6 +794,7 @@ def test_factory_accepts_positional_creator() -> None:
         factory = providers.Factory(SimpleCreator, kwargs={"dep1": "positional"})
 
     container = Container(groups=[G], validate=True)
+    container.open()
     instance = container.resolve(SimpleCreator)
     assert instance.dep1 == "positional"
 
@@ -866,6 +910,7 @@ def test_nonetype_param_with_default_uses_the_default() -> None:
 
     factory = providers.Factory(scope=Scope.APP, creator=Svc)
     container = Container()
+    container.open()
     container.providers_registry.add_providers(factory)
 
     result = container.resolve(Svc)
@@ -881,6 +926,7 @@ def test_nonetype_param_without_default_injects_none() -> None:
 
     factory = providers.Factory(scope=Scope.APP, creator=Svc)
     container = Container()
+    container.open()
     container.providers_registry.add_providers(factory)
 
     result = container.resolve(Svc)
@@ -930,13 +976,16 @@ def test_positional_only_with_default_stays_on_kwargs_path() -> None:
         thing = providers.Factory(creator=_cov_pos_only_creator, scope=Scope.APP)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     assert container.resolve_provider(G.thing) == _CovPosOnlyResult(prefix="P", dep=_CovLeaf())
 
 
 def _build_closed_app_and_request(*group: type[Group]) -> tuple[Container, Container]:
     """Return (closed APP container, open REQUEST child) sharing `group`'s providers."""
     app = Container(scope=Scope.APP, groups=list(group), validate=False)
+    app.open()
     request = app.build_child_container(scope=Scope.REQUEST)
+    request.open()
     app.close_sync()
     return app, request
 
@@ -977,6 +1026,7 @@ def test_transient_kwargs_body_typeerror_propagates_unchanged() -> None:
         thing = providers.Factory(creator=_CovKwOnlyBodyTypeError, scope=Scope.APP)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(TypeError) as exc:
         container.resolve_provider(G.thing)
     assert not isinstance(exc.value, exceptions.CreatorCallError)
@@ -995,6 +1045,7 @@ def test_cached_positional_dependency_step_error() -> None:
         thing = providers.Factory(creator=_CovPosNeedsReq, scope=Scope.APP, cache=True)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(ScopeNotInitializedError):
         container.resolve_provider(G.thing)
 
@@ -1023,6 +1074,7 @@ def test_cached_positional_binding_typeerror_wraps() -> None:
         )
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(exceptions.CreatorCallError):
         container.resolve_provider(G.thing)
 
@@ -1045,6 +1097,7 @@ def test_cached_positional_body_typeerror_propagates_unchanged() -> None:
         )
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(TypeError) as exc:
         container.resolve_provider(G.thing)
     assert not isinstance(exc.value, exceptions.CreatorCallError)
@@ -1063,6 +1116,7 @@ def test_cached_kwargs_dependency_step_error() -> None:
         thing = providers.Factory(creator=_CovCachedNeedsReq, scope=Scope.APP, cache=True)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(ScopeNotInitializedError):
         container.resolve_provider(G.thing)
 
@@ -1074,6 +1128,7 @@ def test_unwireable_factory_override_short_circuits() -> None:
         thing = providers.Factory(creator=SimpleCreator, bound_type=None)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     mock = SimpleCreator(dep1="mock")
     container.override(G.thing, mock)
     assert container.resolve_provider(G.thing) is mock
@@ -1099,6 +1154,7 @@ def test_cached_kwargs_body_typeerror_propagates_unchanged() -> None:
         thing = providers.Factory(creator=_CovKwOnlyBodyTypeError, scope=Scope.APP, cache=True)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(TypeError) as exc:
         container.resolve_provider(G.thing)
     assert not isinstance(exc.value, exceptions.CreatorCallError)
@@ -1117,6 +1173,7 @@ def test_transient_positional_binding_typeerror_wraps() -> None:
         )
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(exceptions.CreatorCallError):
         container.resolve_provider(G.thing)
 
@@ -1126,6 +1183,7 @@ def _resolve_creator_call_error(
 ) -> exceptions.CreatorCallError:
     """Resolve `factory` in its own container and return the CreatorCallError it raises."""
     container = Container(scope=Scope.APP, validate=False)
+    container.open()
     container.providers_registry.register(bound_type, factory)
     with pytest.raises(exceptions.CreatorCallError) as exc_info:
         container.resolve(bound_type)

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -46,6 +46,7 @@ async def test_app_singleton() -> None:
         )
 
     app_container = Container(groups=[LocalGroup])
+    app_container.open()
     singleton1 = app_container.resolve_provider(LocalGroup.singleton)
     singleton2 = app_container.resolve_provider(LocalGroup.singleton)
     assert singleton1 is singleton2
@@ -76,6 +77,7 @@ def test_close_does_not_re_finalize_with_clear_cache_false() -> None:
         )
 
     container = Container(groups=[G])
+    container.open()
     container.resolve(str)
     container.close_sync()
     container.close_sync()
@@ -94,6 +96,7 @@ def test_closed_container_raises_then_reopened_rebuilds_with_clear_cache_true() 
         )
 
     container = Container(groups=[G])
+    container.open()
     container.resolve(str)
     container.close_sync()
     assert calls == ["r"]
@@ -116,6 +119,7 @@ async def test_close_async_runs_sync_finalizer() -> None:
         )
 
     container = Container(groups=[G])
+    container.open()
     container.resolve(str)
     await container.close_async()
     assert calls == ["r"]
@@ -123,13 +127,16 @@ async def test_close_async_runs_sync_finalizer() -> None:
 
 async def test_request_singleton() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance1 = request_container.resolve_provider(MyGroup.request_singleton)
     instance2 = request_container.resolve(DependentCreator)
     assert isinstance(instance1.dep1, SimpleCreator)
     assert instance1 is instance2
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     instance3 = request_container.resolve_provider(MyGroup.request_singleton)
     instance4 = request_container.resolve(DependentCreator)
     assert instance3 is instance4
@@ -151,10 +158,13 @@ async def test_request_singleton() -> None:
 
 def test_app_singleton_in_request_scope() -> None:
     app_container = Container(groups=[MyGroup])
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     singleton1 = request_container.resolve_provider(MyGroup.app_singleton)
 
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     singleton2 = request_container.resolve_provider(MyGroup.app_singleton)
 
     assert singleton1 is singleton2
@@ -184,6 +194,7 @@ def test_sync_finalizer_exception_does_not_abort_remaining_cleanup() -> None:
         )
 
     app_container = Container(groups=[BrokenGroup])
+    app_container.open()
     app_container.resolve_provider(BrokenGroup.first)
     app_container.resolve_provider(BrokenGroup.second)
 
@@ -219,6 +230,7 @@ async def test_async_finalizer_exception_does_not_abort_remaining_cleanup() -> N
         )
 
     app_container = Container(groups=[BrokenAsyncGroup])
+    app_container.open()
     app_container.resolve_provider(BrokenAsyncGroup.first)
     app_container.resolve_provider(BrokenAsyncGroup.second)
 
@@ -243,6 +255,7 @@ def test_finalizer_runs_for_falsy_cached_resource_sync() -> None:
         )
 
     app_container = Container(groups=[FalsyGroup])
+    app_container.open()
     instance = app_container.resolve_provider(FalsyGroup.empty_dict)
     assert instance == {}
 
@@ -263,6 +276,7 @@ async def test_finalizer_runs_for_falsy_cached_resource_async() -> None:
         )
 
     app_container = Container(groups=[FalsyGroup])
+    app_container.open()
     instance = app_container.resolve_provider(FalsyGroup.empty_list)
     assert instance == []
 
@@ -289,6 +303,7 @@ def test_cached_none_is_returned_and_finalized() -> None:
         )
 
     app_container = Container(groups=[NoneGroup])
+    app_container.open()
     app_container.resolve_provider(NoneGroup.none_resource)
     app_container.resolve_provider(NoneGroup.none_resource)
 
@@ -317,6 +332,7 @@ def test_singleton_threading_concurrency() -> None:
         return container.resolve_provider(singleton)
 
     app_container = Container()
+    app_container.open()
     with ThreadPoolExecutor(max_workers=4) as pool:
         tasks = [
             pool.submit(resolve_singleton, app_container),
@@ -367,6 +383,7 @@ class _LifoGroup(Group):
 def test_finalizers_run_in_reverse_creation_order_even_with_warmup() -> None:
     _lifo_events.clear()
     container = Container(scope=Scope.APP, groups=[_LifoGroup])
+    container.open()
     container.resolve(_LifoLeaf)  # the docs-recommended warmup pattern
     container.resolve(_LifoTop)
     container.close_sync()
@@ -386,6 +403,7 @@ def test_singleton_resolution_is_reentrant() -> None:
         outer = providers.Factory(creator=Outer, cache=True)
 
     container = Container(groups=[ReentrantGroup])
+    container.open()
     result: list[Outer] = []
 
     # Use a daemon Thread (not ThreadPoolExecutor) so the worker can be abandoned
@@ -425,6 +443,7 @@ class _AwaitableFinGroup(Group):
 async def test_sync_finalizer_returning_awaitable_is_awaited_in_async_close() -> None:
     _awaitable_fin_events.clear()
     container = Container(scope=Scope.APP, groups=[_AwaitableFinGroup])
+    container.open()
     container.resolve(_AwaitableFinSvc)
     await container.close_async()
     assert _awaitable_fin_events == ["cleaned"]
@@ -433,6 +452,7 @@ async def test_sync_finalizer_returning_awaitable_is_awaited_in_async_close() ->
 async def test_sync_finalizer_returning_awaitable_raises_in_sync_close_then_recovers() -> None:
     _awaitable_fin_events.clear()
     container = Container(scope=Scope.APP, groups=[_AwaitableFinGroup])
+    container.open()
     container.resolve(_AwaitableFinSvc)
     with pytest.raises(FinalizerError):
         container.close_sync()

--- a/tests/registries/test_providers_registry.py
+++ b/tests/registries/test_providers_registry.py
@@ -139,6 +139,7 @@ def test_concurrent_first_resolve_of_same_provider_does_not_false_cycle(
         root = providers.Factory(creator=_Root, scope=Scope.APP)
 
     container = Container(groups=[_G], validate=False)
+    container.open()
     real_compile = pr_mod.compile_resolver
     entered = threading.Event()
     release = threading.Event()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -34,6 +34,7 @@ def test_container_prevent_copy() -> None:
 def test_container_scope_skipped() -> None:
     app_factory = providers.Factory(creator=lambda: "test")
     container = Container(scope=Scope.REQUEST)
+    container.open()
     with pytest.raises(ScopeSkippedError, match=r"No APP-scope container exists in this chain") as exc:
         container.resolve_provider(app_factory)
     assert exc.value.provider_scope == Scope.APP
@@ -41,6 +42,7 @@ def test_container_scope_skipped() -> None:
 
 def test_container_build_child() -> None:
     app_container = Container()
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
     assert request_container.scope == Scope.REQUEST
     assert app_container.scope == Scope.APP
@@ -48,6 +50,7 @@ def test_container_build_child() -> None:
 
 def test_container_scope_limit_reached() -> None:
     step_container = Container(scope=Scope.STEP)
+    step_container.open()
     with pytest.raises(MaxScopeReachedError, match=r"Max scope of STEP is reached.") as exc:
         step_container.build_child_container()
     assert exc.value.parent_scope == Scope.STEP
@@ -55,6 +58,7 @@ def test_container_scope_limit_reached() -> None:
 
 def test_container_build_child_wrong_scope() -> None:
     app_container = Container()
+    app_container.open()
     with pytest.raises(InvalidChildScopeError, match="Scope of child container cannot be") as exc:
         app_container.build_child_container(scope=Scope.APP)
     assert exc.value.parent_scope == Scope.APP
@@ -112,6 +116,7 @@ async def test_container_async_context_manager() -> None:
 
 def test_container_repr() -> None:
     container = Container()
+    container.open()
     assert repr(container) == "Container(scope=APP, parent=None, providers=1, cached=0)"
 
     request_container = container.build_child_container(scope=Scope.REQUEST)
@@ -367,6 +372,7 @@ def test_validation_failed_error_str_renders_inner_errors() -> None:
 
 def test_build_child_container_propagates_use_lock_false() -> None:
     root = Container(use_lock=False)
+    root.open()
     child = root.build_child_container(scope=Scope.REQUEST)
     assert root._lock is None  # noqa: SLF001
     assert child._lock is None  # noqa: SLF001
@@ -384,6 +390,7 @@ def test_container_provider_resolves_on_subclasses() -> None:
         svc = providers.Factory(creator=Service)
 
     container = MyContainer(groups=[G])
+    container.open()
     instance = container.resolve(Service)
     assert instance.di_container is container
 
@@ -396,6 +403,7 @@ def test_container_rejects_non_intenum_scope_at_init() -> None:
 
 def test_constructor_rejects_parent_with_non_increasing_scope() -> None:
     app = Container(scope=Scope.APP)
+    app.open()
     with pytest.raises(InvalidChildScopeError):
         Container(scope=Scope.APP, parent_container=app)
     request = app.build_child_container(scope=Scope.REQUEST)
@@ -444,7 +452,9 @@ class _AppBrokerGroup(Group):
 
 def test_resolving_through_closed_parent_via_open_child_raises() -> None:
     app = Container(scope=Scope.APP, groups=[_AppBrokerGroup], validate=False)
+    app.open()
     child = app.build_child_container(scope=Scope.REQUEST)
+    child.open()
     app.close_sync()
     with pytest.raises(ContainerClosedError):
         child.resolve(_PersistentBroker)
@@ -474,19 +484,78 @@ def test_open_reopens_closed_container() -> None:
 def test_container_closed_error_message_and_attr() -> None:
     err = ContainerClosedError(container_scope=Scope.APP)
     assert err.container_scope is Scope.APP
-    assert "closed" in str(err)
-    assert "Create a new container" in str(err)
+    assert "not open" in str(err)
+    assert "open()" in str(err)
 
 
 def test_open_on_open_container_is_noop() -> None:
-    container = Container(scope=Scope.APP)
+    with Container(scope=Scope.APP) as container:
+        container.open()
+        assert container.closed is False
+        assert container.resolve(Container) is container
+
+
+# --- 3.0 mandatory-open lifecycle -----------------------------------------------------------------
+
+
+def test_fresh_container_starts_unopened() -> None:
+    # 3.0: a just-constructed container is not open; it must be entered before use.
+    container = Container(scope=Scope.APP, validate=False)
+    assert container.closed is True
+
+
+def test_unopened_container_resolve_raises() -> None:
+    container = Container(scope=Scope.APP, validate=False)  # never opened
+    with pytest.raises(ContainerClosedError):
+        container.resolve(Container)
+
+
+def test_unopened_container_build_child_raises() -> None:
+    container = Container(scope=Scope.APP, validate=False)  # never opened
+    with pytest.raises(ContainerClosedError):
+        container.build_child_container(scope=Scope.REQUEST)
+
+
+def test_open_enables_use_and_validates_root_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+    real = Container.validate
+
+    def counting(self: Container) -> None:
+        calls["n"] += 1
+        real(self)
+
+    monkeypatch.setattr(Container, "validate", counting)
+    container = Container(scope=Scope.APP, groups=[_DeferValidGroup])  # default validate=True
     container.open()
     assert container.closed is False
-    assert container.resolve(Container) is container
+    assert calls["n"] == 1  # open() validated the root exactly once
+    assert isinstance(container.resolve(_DeferValidService), _DeferValidService)
+    assert calls["n"] == 1  # resolve no longer validates
+
+
+def test_child_from_build_requires_open_and_does_not_validate(monkeypatch: pytest.MonkeyPatch) -> None:
+    with Container(scope=Scope.APP, validate=False) as app:
+        child = app.build_child_container(scope=Scope.REQUEST)
+        assert child.closed is True  # child starts unopened too
+        with pytest.raises(ContainerClosedError):
+            child.resolve(Container)
+
+        calls = {"n": 0}
+        real = Container.validate
+
+        def counting(self: Container) -> None:  # pragma: no cover -- asserted not to run
+            calls["n"] += 1
+            real(self)
+
+        monkeypatch.setattr(Container, "validate", counting)
+        child.open()  # child never validates (root-only)
+        assert calls["n"] == 0
+        assert child.resolve(Container) is child
 
 
 def test_private_lock_and_scope_map_back_the_machinery() -> None:
     root = Container(use_lock=True)
+    root.open()
     child = root.build_child_container(scope=Scope.REQUEST)
 
     # _lock is a reentrant lock (threading.RLock is a factory, not a type, so
@@ -503,6 +572,7 @@ def test_private_lock_and_scope_map_back_the_machinery() -> None:
 
 def test_use_lock_false_yields_no_private_lock() -> None:
     root = Container(use_lock=False)
+    root.open()
     child = root.build_child_container(scope=Scope.REQUEST)
     assert root._lock is None  # noqa: SLF001
     assert child._lock is None  # noqa: SLF001
@@ -530,6 +600,7 @@ def test_resolve_emits_no_deprecation_warning() -> None:
         dep = providers.Factory(scope=Scope.APP, creator=_Dep, cache=True)
 
     container = Container(groups=[_Group])
+    container.open()
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         container.resolve(_Dep)  # touches _lock and _scope_map internally
@@ -579,7 +650,9 @@ def test_valid_graph_validates_clean_at_entry_without_warning() -> None:
             pass
 
 
-def test_deferred_validation_raises_on_first_resolve_not_construction() -> None:
+def test_resolve_on_unopened_container_raises_before_validating() -> None:
+    # 3.0: resolve on a never-opened container raises ContainerClosedError; it does NOT validate
+    # (validation moved to open()), so the broken graph is never even walked here.
     @dataclasses.dataclass(kw_only=True, slots=True)
     class Missing:
         pass
@@ -592,20 +665,22 @@ def test_deferred_validation_raises_on_first_resolve_not_construction() -> None:
         svc = providers.Factory(creator=Service)
 
     container = Container(scope=Scope.APP, groups=[G])  # constructs fine; broken graph not yet checked
-    with pytest.raises(ValidationFailedError):
-        container.resolve(Service)  # first-resolve fallback validates
+    with pytest.raises(ContainerClosedError):
+        container.resolve(Service)  # unopened -> closed error, not ValidationFailedError
 
 
 def test_child_container_never_validates() -> None:
     # Root-only: only a root gets _validate_enabled; a child never validates regardless of the root's setting.
     root = Container(scope=Scope.APP, validate=True)
     assert root._validate_enabled is True  # noqa: SLF001
+    root.open()
     child = root.build_child_container(scope=Scope.REQUEST)
     assert child._validate_enabled is False  # noqa: SLF001
 
 
 def test_add_providers_registers_and_resolves_by_type_and_reference() -> None:
     container = Container(scope=Scope.APP, validate=False)
+    container.open()
     str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
 
     container.add_providers(str_factory)
@@ -637,6 +712,7 @@ def test_add_providers_raises_on_duplicate_intra_batch() -> None:
 
 def test_add_providers_on_child_container_raises() -> None:
     root = Container(scope=Scope.APP, validate=False)
+    root.open()
     child = root.build_child_container(scope=Scope.REQUEST)
     str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
 
@@ -714,6 +790,7 @@ def test_add_providers_rolls_back_whole_batch_when_revalidation_fails() -> None:
         original = providers.Factory(creator=Original)
 
     container = Container(scope=Scope.APP, groups=[G])
+    container.open()
     container.validate()  # deferred: validate explicitly so add_providers re-validates the batch
 
     valid_factory = providers.Factory(creator=lambda: "ok", bound_type=str)
@@ -759,6 +836,7 @@ def test_resolve_dependency_with_provider_returns_same_instance_as_resolve_provi
         cached = providers.Factory(creator=lambda: "value", bound_type=str, cache=True)
 
     container = Container(groups=[G])
+    container.open()
     via_dispatch = container.resolve_dependency(G.cached)
     via_resolve_provider = container.resolve_provider(G.cached)
     assert via_dispatch is via_resolve_provider
@@ -776,6 +854,7 @@ def test_add_providers_rebuilds_stale_wiring_plan_for_optional_dependency() -> N
         inner: Inner | None = None
 
     container = Container(scope=Scope.APP, validate=True)
+    container.open()
     outer_factory = providers.Factory(creator=Outer)  # not cached: second resolve rebuilds
 
     first = container.resolve_provider(outer_factory)
@@ -799,6 +878,7 @@ def test_add_providers_rebuilds_stale_wiring_plan_for_required_dependency() -> N
         inner: Inner
 
     container = Container(scope=Scope.APP, validate=False)
+    container.open()
     outer_factory = providers.Factory(creator=Outer)
 
     with pytest.raises(ArgumentResolutionError):
@@ -832,6 +912,7 @@ def test_add_providers_rolls_back_on_any_exception_from_revalidation() -> None:
 def test_add_providers_on_validated_root_with_valid_batch_succeeds() -> None:
     """Positive branch: a validated root re-validates successfully and the batch resolves afterwards."""
     container = Container(scope=Scope.APP)
+    container.open()
     container.validate()  # deferred: validate first so add_providers exercises the success re-validation branch
     str_factory = providers.Factory(creator=lambda: "added", bound_type=str)
 
@@ -857,6 +938,7 @@ def test_resolve_dependency_with_type_returns_same_instance_as_resolve() -> None
         cached = providers.Factory(creator=lambda: "value", bound_type=str, cache=True)
 
     container = Container(groups=[G])
+    container.open()
     via_dispatch = container.resolve_dependency(str)
     via_resolve = container.resolve(str)
     assert via_dispatch is via_resolve
@@ -871,6 +953,7 @@ def test_resolve_dependency_with_provider_returns_override() -> None:
         app_factory = providers.Factory(creator=Service)
 
     container = Container(groups=[G])
+    container.open()
     override = Service(name="override")
     container.override(G.app_factory, override)
 
@@ -904,7 +987,9 @@ def test_resolve_dependency_works_on_child_container_for_both_arms() -> None:
         request_factory = providers.Factory(scope=Scope.REQUEST, creator=lambda: "value", bound_type=str)
 
     app_container = Container(groups=[G])
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
 
     assert request_container.resolve_dependency(str) == "value"
     assert request_container.resolve_dependency(G.request_factory) == "value"
@@ -919,6 +1004,7 @@ class _OverrideGroup(Group):
 
 def test_override_context_manager_applies_and_resets() -> None:
     container = Container(groups=[_OverrideGroup], validate=False)
+    container.open()
     mock = _OverrideSvc()
     with container.override(_OverrideGroup.svc, mock) as bound:
         assert bound is mock
@@ -928,6 +1014,7 @@ def test_override_context_manager_applies_and_resets() -> None:
 
 def test_override_context_manager_restores_prior_imperative_override() -> None:
     container = Container(groups=[_OverrideGroup], validate=False)
+    container.open()
     first = _OverrideSvc()
     second = _OverrideSvc()
     container.override(_OverrideGroup.svc, first)
@@ -938,6 +1025,7 @@ def test_override_context_manager_restores_prior_imperative_override() -> None:
 
 def test_override_context_manager_nested_unwinds_in_order() -> None:
     container = Container(groups=[_OverrideGroup], validate=False)
+    container.open()
     outer = _OverrideSvc()
     inner = _OverrideSvc()
     with container.override(_OverrideGroup.svc, outer):
@@ -951,6 +1039,7 @@ def test_override_context_manager_nested_unwinds_in_order() -> None:
 
 def test_override_context_manager_restores_on_exception() -> None:
     container = Container(groups=[_OverrideGroup], validate=False)
+    container.open()
     mock = _OverrideSvc()
     msg = "boom"
     with pytest.raises(RuntimeError), container.override(_OverrideGroup.svc, mock):
@@ -960,6 +1049,7 @@ def test_override_context_manager_restores_on_exception() -> None:
 
 def test_override_context_manager_exit_restores_snapshot_after_inner_reset() -> None:
     container = Container(groups=[_OverrideGroup], validate=False)
+    container.open()
     first = _OverrideSvc()
     second = _OverrideSvc()
     container.override(_OverrideGroup.svc, first)
@@ -978,6 +1068,7 @@ def test_resolve_provider_raises_for_unhandled_provider_type() -> None:
 
     provider = _UnknownProvider(scope=Scope.APP, bound_type=None)
     container = Container(validate=False)
+    container.open()
     with pytest.raises(TypeError, match="no compiled resolver for provider type _UnknownProvider"):
         container.resolve_provider(provider)
 
@@ -1027,12 +1118,14 @@ def test_invalid_graph_does_not_raise_at_construction() -> None:
         container.open()  # validation runs at container entry
 
 
-def test_deferred_validation_runs_on_first_resolve() -> None:
-    # Never entered via with/open(): the first-resolve fallback validates before dispatching, so a broken
-    # graph surfaces as ValidationFailedError (not the bare ArgumentResolutionError a raw resolve would give).
+def test_validation_runs_at_open_not_resolve() -> None:
+    # Validation lives only in open(): resolving an unopened container raises ContainerClosedError, while
+    # open() walks the (broken) graph and surfaces ValidationFailedError.
     container = Container(scope=Scope.APP, groups=[_DeferBrokenGroup])
-    with pytest.raises(ValidationFailedError):
+    with pytest.raises(ContainerClosedError):
         container.resolve(_DeferBrokenService)
+    with pytest.raises(ValidationFailedError):
+        container.open()
 
 
 def test_deferred_validation_raises_via_context_manager_entry() -> None:

--- a/tests/test_custom_scope.py
+++ b/tests/test_custom_scope.py
@@ -30,6 +30,7 @@ class TenantService:
 
 def test_build_child_at_custom_scope_from_step() -> None:
     step_container = Container(scope=Scope.STEP)
+    step_container.open()
     tenant_container = step_container.build_child_container(scope=MyScope.TENANT)
     assert tenant_container.scope is MyScope.TENANT
     assert tenant_container.parent_container is step_container
@@ -37,6 +38,7 @@ def test_build_child_at_custom_scope_from_step() -> None:
 
 def test_build_child_at_custom_scope_from_app_skips_intermediate() -> None:
     app_container = Container()
+    app_container.open()
     tenant_container = app_container.build_child_container(scope=MyScope.TENANT)
     assert tenant_container.scope is MyScope.TENANT
 
@@ -46,7 +48,9 @@ def test_factory_resolves_through_custom_scope_container() -> None:
         svc = providers.Factory(scope=MyScope.TENANT, creator=TenantService)
 
     app_container = Container(groups=[TenantGroup])
+    app_container.open()
     tenant_container = app_container.build_child_container(scope=MyScope.TENANT)
+    tenant_container.open()
 
     instance = tenant_container.resolve(TenantService)
     assert isinstance(instance, TenantService)
@@ -57,6 +61,7 @@ def test_resolve_at_custom_scope_from_app_raises_scope_not_initialized() -> None
         svc = providers.Factory(scope=MyScope.TENANT, creator=TenantService)
 
     app_container = Container(groups=[TenantGroup])
+    app_container.open()
     with pytest.raises(ScopeNotInitializedError, match="TENANT") as exc:
         app_container.resolve(TenantService)
     assert exc.value.provider_scope is MyScope.TENANT
@@ -66,6 +71,7 @@ def test_resolve_at_custom_scope_from_app_raises_scope_not_initialized() -> None
 def test_resolve_app_provider_from_custom_scope_with_skipped_chain() -> None:
     # A standalone tenant container that never went through APP -> ... chain
     tenant_container = Container(scope=MyScope.TENANT)
+    tenant_container.open()
     app_factory = providers.Factory(creator=lambda: "x")
     with pytest.raises(ScopeSkippedError, match="APP"):
         tenant_container.resolve_provider(app_factory)
@@ -73,6 +79,7 @@ def test_resolve_app_provider_from_custom_scope_with_skipped_chain() -> None:
 
 def test_invalid_child_scope_uses_parent_enum_for_allowed_list() -> None:
     tenant_container = Container(scope=MyScope.TENANT)
+    tenant_container.open()
     with pytest.raises(InvalidChildScopeError) as exc:
         tenant_container.build_child_container(scope=MyScope.TENANT)
     # allowed_scopes must be drawn from the parent's own enum class (MyScope),
@@ -82,6 +89,7 @@ def test_invalid_child_scope_uses_parent_enum_for_allowed_list() -> None:
 
 def test_invalid_child_scope_with_conflicting_value() -> None:
     app_container = Container()
+    app_container.open()
     with pytest.raises(InvalidChildScopeError) as exc:
         app_container.build_child_container(scope=ConflictingScope.SAME_AS_APP)
     assert exc.value.parent_scope is Scope.APP
@@ -117,8 +125,11 @@ def test_caching_isolated_across_tenant_containers() -> None:
         )
 
     app_container = Container(groups=[TenantGroup])
+    app_container.open()
     tenant_a = app_container.build_child_container(scope=MyScope.TENANT)
+    tenant_a.open()
     tenant_b = app_container.build_child_container(scope=MyScope.TENANT)
+    tenant_b.open()
 
     instance_a = tenant_a.resolve(TenantService)
     instance_b = tenant_b.resolve(TenantService)
@@ -128,6 +139,7 @@ def test_caching_isolated_across_tenant_containers() -> None:
 
 def test_auto_derive_within_custom_enum() -> None:
     tenant_container = Container(scope=MyScope.TENANT)
+    tenant_container.open()
     bg_container = tenant_container.build_child_container()
     assert bg_container.scope is MyScope.BACKGROUND_JOB
 
@@ -141,12 +153,14 @@ def test_auto_derive_with_gapped_custom_enum() -> None:
     # Non-contiguous values: the next scope is the smallest member greater than the
     # current one, not current.value + 1 (which would not be a valid member).
     tenant_container = Container(scope=GappedScope.TENANT)
+    tenant_container.open()
     bg_container = tenant_container.build_child_container()
     assert bg_container.scope is GappedScope.BACKGROUND_JOB
 
 
 def test_auto_derive_at_deepest_gapped_scope_raises_max() -> None:
     bg_container = Container(scope=GappedScope.BACKGROUND_JOB)
+    bg_container.open()
     with pytest.raises(MaxScopeReachedError):
         bg_container.build_child_container()
 
@@ -167,5 +181,6 @@ def test_build_child_container_rejects_zero_valued_custom_scope() -> None:
         TWO = 2
 
     parent = Container(scope=ZeroEnum.ONE)
+    parent.open()
     with pytest.raises(InvalidChildScopeError):
         parent.build_child_container(scope=ZeroEnum.ZERO)

--- a/tests/test_dependency_graph_contract.py
+++ b/tests/test_dependency_graph_contract.py
@@ -82,5 +82,6 @@ def test_runtime_guard_converts_unvalidated_cycle() -> None:
         b = Factory(scope=Scope.APP, creator=_B)
 
     container = Container(scope=Scope.APP, groups=[G], validate=False)
+    container.open()
     with pytest.raises(exceptions.CircularDependencyError):
         container.resolve(_A)

--- a/tests/test_dependency_path.py
+++ b/tests/test_dependency_path.py
@@ -35,6 +35,7 @@ class IncompleteGroup(Group):
 def test_chain_appears_when_arg_unresolvable() -> None:
     # validate=False: this exercises the resolve-time dependency-chain breadcrumb, not deferred validation.
     container = Container(groups=[IncompleteGroup], validate=False)
+    container.open()
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(MyService)
 
@@ -73,8 +74,10 @@ def test_chain_includes_scope_name() -> None:
         repo = providers.Factory(scope=Scope.REQUEST, creator=Repository)
         outer = providers.Factory(scope=Scope.REQUEST, creator=Outer)
 
-    container = Container(groups=[CrossScope])
+    container = Container(groups=[CrossScope], validate=False)
+    container.open()
     request = container.build_child_container(scope=Scope.REQUEST)
+    request.open()
     with pytest.raises(ArgumentResolutionError) as exc_info:
         request.resolve(Outer)
 
@@ -120,8 +123,10 @@ def test_captive_dependency_names_both_ends() -> None:
         resource = providers.Factory(scope=Scope.REQUEST, creator=ScopedResource)
         consumer = providers.Factory(scope=Scope.APP, creator=CaptiveConsumer)
 
-    app_container = Container(groups=[CaptiveGroup])
+    app_container = Container(groups=[CaptiveGroup], validate=False)
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
 
     with pytest.raises(ScopeNotInitializedError) as exc_info:
         request_container.resolve(CaptiveConsumer)
@@ -141,6 +146,7 @@ def test_alias_prepends_step_on_scope_error() -> None:
         alias = providers.Alias(source_type=ScopedResource, bound_type=AbstractResource)
 
     app_container = Container(groups=[AliasCaptiveGroup])
+    app_container.open()
     with pytest.raises(ScopeNotInitializedError) as exc_info:
         app_container.resolve(AbstractResource)
 
@@ -171,6 +177,7 @@ def test_breadcrumb_line_carries_definition_site() -> None:
         anchored = providers.Factory(_Anchored, scope=Scope.REQUEST)
 
     container = Container(groups=[_G], validate=False)
+    container.open()
     with pytest.raises(ScopeNotInitializedError) as exc_info:
         container.resolve(_Anchored)
     lineno = inspect.getsourcelines(_Anchored)[1]

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -40,6 +40,7 @@ class _StressGroup(Group):
 
 def test_concurrent_resolution_shares_app_singletons() -> None:
     container = Container(groups=[_StressGroup], validate=True)
+    container.open()
     n = 32
     barrier = threading.Barrier(n)
     top_results: list[_Top | None] = [None] * n

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -42,6 +42,7 @@ def test_group_inherits_providers_from_parent() -> None:
         b = providers.Factory(creator=_B)
 
     container = Container(groups=[Child])
+    container.open()
     assert isinstance(container.resolve(_A), _A)
     assert isinstance(container.resolve(_B), _B)
 
@@ -54,6 +55,7 @@ def test_group_subclass_overrides_parent_provider() -> None:
         a = providers.Factory(creator=_A, bound_type=_B)  # override; resolve _B yields _A instance
 
     container = Container(groups=[Child])
+    container.open()
     assert isinstance(container.resolve(_B), _A)
 
 
@@ -168,7 +170,9 @@ def test_group_scope_stamps_defaulted_providers() -> None:
     assert RequestGroup.svc.scope is Scope.REQUEST
     assert RequestGroup.ctx.scope is Scope.REQUEST
     app_container = Container(groups=[RequestGroup], validate=True)
+    app_container.open()
     request_container = app_container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     assert isinstance(request_container.resolve(_Svc), _Svc)
 
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -53,6 +53,7 @@ class _Deps(Group):
 
 def test_marker_resolve_delegates_to_container_resolve_dependency() -> None:
     container = Container(groups=[_Deps], validate=True)
+    container.open()
     marker: Marker[_Service] = Marker(_Service)
 
     resolved = marker.resolve(container)
@@ -123,6 +124,7 @@ def test_parse_markers_returns_empty_dict_when_no_markers() -> None:
 
 def test_resolve_markers_resolves_each_marker_by_name() -> None:
     container = Container(groups=[_Deps], validate=True)
+    container.open()
     markers = {"service": Marker(_Service)}
 
     resolved = resolve_markers(container, markers)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -44,6 +44,7 @@ def test_modern_di_imports_without_typing_extensions() -> None:
         "import modern_di\n"
         "from modern_di import Container, Scope\n"
         "container = Container(scope=Scope.APP)\n"
+        "container.open()\n"
         "child = container.build_child_container(scope=Scope.REQUEST)\n"
         "print('OK', child.scope.name)\n"
     )

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -72,6 +72,7 @@ def test_positional_path_binds_args_in_signature_order() -> None:
         ordered = providers.Factory(creator=_make, scope=Scope.APP)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     plan = _plan(container.providers_registry, G.ordered)
     assert _positional_names(G.ordered, plan) is not None  # self-guard: positional path selected
 
@@ -185,6 +186,7 @@ def test_first_resolve_does_not_reintrospect_creator(monkeypatch: pytest.MonkeyP
         ordered = providers.Factory(creator=_make, scope=Scope.APP)
 
     container = Container(groups=[G], validate=False)  # parse_creator already ran at G's class def
+    container.open()
     calls: list[object] = []
     real_signature = inspect.signature
 

--- a/tests/test_runtime_cycle_guard.py
+++ b/tests/test_runtime_cycle_guard.py
@@ -96,6 +96,7 @@ def test_unvalidated_cycle_raises_circular_dependency_error() -> None:
     # `_SHALLOW_RECURSION_LIMIT` above. It mirrors the guard's own `except RecursionError` shape
     # in `resolve_provider`.
     container = Container(groups=[CycleGroup], validate=False)  # exercise the runtime guard, not validation
+    container.open()
     original_limit = sys.getrecursionlimit()
     sys.setrecursionlimit(_SHALLOW_RECURSION_LIMIT)
     try:
@@ -127,6 +128,7 @@ def _assert_deep_chain_cycle_is_self_contained(exc: exceptions.CircularDependenc
 
 def test_deep_chain_cycle_is_self_contained() -> None:
     container = Container(groups=[DeepCycleGroup], validate=False)  # exercise the runtime guard, not validation
+    container.open()
     original_limit = sys.getrecursionlimit()
     sys.setrecursionlimit(_SHALLOW_RECURSION_LIMIT)
     try:
@@ -150,6 +152,7 @@ def test_self_recursing_creator_passes_through_recursion_error() -> None:
     # validate=False keeps the registry unvalidated, so the guard runs find_cycle_from (no static cycle ->
     # re-raise) rather than short-circuiting on the validated flag.
     container = Container(groups=[RecursiveGroup], validate=False)
+    container.open()
     with pytest.raises(RecursionError):
         container.resolve(str)
 
@@ -165,6 +168,7 @@ def test_validated_graph_reraises_recursionerror_without_walk(monkeypatch: pytes
         s = providers.Factory(scope=Scope.APP, creator=SelfRec)
 
     container = Container(scope=Scope.APP, groups=[G], validate=True)
+    container.open()
 
     def _explode(*_: object, **__: object) -> object:  # pragma: no cover
         msg = "walked"
@@ -203,6 +207,7 @@ def test_cycle_error_is_canonical_and_self_contained() -> None:
         b = providers.Factory(creator=_CanonicalB, scope=Scope.APP)
 
     container = Container(scope=Scope.APP, groups=[G], validate=False)
+    container.open()
     limit = sys.getrecursionlimit()
     sys.setrecursionlimit(80)
     try:

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -81,7 +81,9 @@ def test_suggestion_includes_provider_scope() -> None:
         db = providers.Factory(scope=Scope.REQUEST, creator=PostgresDatabase)
 
     container = Container(groups=[G])
+    container.open()
     request_container = container.build_child_container(scope=Scope.REQUEST)
+    request_container.open()
     with pytest.raises(ProviderNotRegisteredError) as exc_info:
         request_container.resolve(Database)
 
@@ -170,6 +172,7 @@ def test_argument_resolution_subclass_suggestion() -> None:
 
     # validate=False: this exercises the resolve-time did-you-mean suggestion, not deferred validation.
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 
@@ -191,6 +194,7 @@ def test_argument_resolution_baseclass_suggestion() -> None:
         service = providers.Factory(creator=Service)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 
@@ -213,6 +217,7 @@ def test_argument_resolution_typo_suggestion() -> None:
         service = providers.Factory(creator=Service)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 
@@ -230,6 +235,7 @@ def test_argument_resolution_no_suggestions_when_nothing_matches() -> None:
         service = providers.Factory(creator=Service)
 
     container = Container(groups=[G], validate=False)
+    container.open()
     with pytest.raises(ArgumentResolutionError) as exc_info:
         container.resolve(Service)
 

--- a/tests/test_types_parser.py
+++ b/tests/test_types_parser.py
@@ -248,6 +248,7 @@ def test_parameterized_generic_param_supplied_via_kwargs_is_allowed() -> None:
     sentinel = [_GenericDep()]
     provider = providers.Factory(creator=_generic_param_creator, kwargs={"x": sentinel})
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(str, provider)
     assert container.resolve(str) == str(sentinel)
 
@@ -260,6 +261,7 @@ def test_parameterized_generic_param_with_default_is_allowed() -> None:
     assert _generic_param_with_default(("a",)) == str(("a",))
     provider = providers.Factory(creator=_generic_param_with_default)
     container = Container(scope=Scope.APP)
+    container.open()
     container.providers_registry.register(str, provider)
     assert container.resolve(str) == str(())
 


### PR DESCRIPTION
A **sixth** 3.0 breaking change (design: `planning/changes/2026-07-19.20-mandatory-open-lifecycle.md`), from maintainer review of the validate-deferral.

A container must be entered via `open()` / `with` / `async with` before it can `resolve` or `build_child_container`; using an unopened container raises `ContainerClosedError` (message broadened to name the not-open state). `open()` validates once (root only). This makes validation impossible to silently skip and the lifecycle explicit — and returns `resolve_provider` to a lean `_raise_if_closed()` + dispatch (the first-resolve validate fallback is removed).

- `validate` becomes a plain `bool = True` (the `None` sentinel is dropped).
- A fresh container starts `closed=True` (unopened). **Children also require open.**
- `modern_di/container.py`, `modern_di/exceptions.py` (broadened `ContainerClosedError` message).
- **Blast radius:** every construct-then-use site opens its container — the full test suite (~196 sites across 18 files) and docs examples. **Integration docs (`docs/integrations/*`) are deferred** — they mirror sibling-repo code whose `with`/`open()` adoption is verified at the `3.0.0rc1` smoke-test. **This change requires integration-repo updates** (unlike the validate-deferral).

## Verification
- `just test-ci` — 435 passed, 100% coverage
- `just lint-ci` — clean (ruff, eof-fixer, ty)
- `mkdocs build --strict` — verified in CI (llmstxt plugin unavailable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)