### PR TITLE
docs(3.0): migration guide + exception docstrings match shipped behavior

### DIFF
--- a/docs/migration/to-3.x.md
+++ b/docs/migration/to-3.x.md
@@ -4,20 +4,31 @@ This document describes the changes required to migrate from modern-di 2.x to mo
 
 ## Overview
 
-modern-di 3.0 flips five switches from warn-then-continue to raise/validate-by-default. Every one
-of them already has a 2.x signal — a warning that fires today wherever the 3.0 behavior would
-differ. If your 2.x test suite is green with the [readiness recipe](#readiness-recipe-escalating-warnings-to-errors-with-filterwarnings) below
-escalating those warnings to errors, the upgrade to 3.0 is a no-op for you.
+modern-di 3.0 flips five switches from warn-then-continue to raise/validate-by-default, and adds
+one more that has no 2.x precedent to warn from. Each of the five already has a 2.x signal — a
+warning that fires today wherever the 3.0 behavior would differ. If your 2.x test suite is green
+with the [readiness recipe](#readiness-recipe-escalating-warnings-to-errors-with-filterwarnings)
+below escalating those five warnings to errors, **those five switches** are a no-op for you.
 
-## The five switches
+3.0 **additionally** requires a container to be opened (`with`/`async with`/`open()`) before it can
+`resolve` or `build_child_container` — switch 6 below — and changes `validate`'s constructor
+signature from `bool | None` to a plain `bool`. Neither has a 2.x warning to escalate: 2.x has no
+"unopened" state to signal on, and an explicit `validate=True` in 2.x validates eagerly at
+construction, a timing 3.0 changes without ever warning about it. These are genuine hard breaks —
+a green suite under the recipe does not, by itself, get you past them. See
+[switch 4](#4-validate-runs-at-container-entry-on-by-default) and
+[switch 6](#6-a-container-must-be-opened-before-use) below.
+
+## The six switches
 
 | 3.0 change | 2.x signal |
 |---|---|
 | Reusing a closed container raises `ContainerClosedError` | `ContainerClosedWarning` |
 | `Alias(scope=)` parameter removed | `DeprecationWarning` |
 | `Factory(cache_settings=)` removed | `DeprecationWarning` |
-| `validate()` runs by default at root construction | `UnvalidatedContainerWarning` |
+| `validate` defaults to `True` and runs at container entry (`open()`/`with`) | `UnvalidatedContainerWarning` — covers the *unset* case only; see below |
 | Direct resolve of an unset `ContextProvider` raises `ContextValueNotSetError` | `ContextValueNoneWarning` |
+| A container must be opened before `resolve`/`build_child_container` | **none** — inherent hard break, no 2.x state to warn from |
 
 ## Key Changes
 
@@ -42,12 +53,20 @@ service = container.resolve(MyService)  # succeeds — container self-reopens
 **After (3.0):**
 ```python
 container = Container(scope=Scope.APP, groups=[MyGroup], validate=True)
-container.close_sync()
+with container:
+    service = container.resolve(MyService)  # works — container is open inside the block
 
-service = container.resolve(MyService)  # raises ContainerClosedError
+# the `with` block closed the container on exit
+service = container.resolve(MyService)  # raises ContainerClosedError — reused after close
 ```
 
 Re-enter the container with `with`/`async with`, or call `container.open()`, before reusing it.
+
+This is one half of a single rule: **a container must be open to be used.** This switch is the
+*closed-after-use* half (a container that was open, then closed); [switch 6](#6-a-container-must-be-opened-before-use)
+below is the *never-opened* half (a fresh container that was never entered at all). Both raise the
+same `ContainerClosedError`, and both are fixed the same way — enter the container with
+`with`/`async with`, or call `open()`, before resolving or building children.
 
 ### 2. `Alias(scope=)` parameter removed
 
@@ -98,34 +117,63 @@ factory = providers.Factory(
 )
 ```
 
-### 4. `validate()` runs by default at root construction
+### 4. `validate` runs at container entry, on by default
 
-In 2.x, leaving the `Container` constructor's `validate` argument unset skips validation (as
-before) but emits `UnvalidatedContainerWarning`. In 3.0, leaving it unset runs `validate()`
-automatically, so an invalid graph raises `ValidationFailedError` at construction time instead of
-failing lazily on first resolve.
+The final 3.0 form differs from what 2.x signals in two ways, so read this one carefully.
+
+**The signature.** In 2.x, `Container`'s `validate` argument is `bool | None = None`: unset (`None`)
+skips validation but emits `UnvalidatedContainerWarning`; `False` skips it silently; `True` enables
+it. In 3.0, the parameter is a plain `validate: bool = True` — the `None` sentinel is gone.
+Passing `validate=False` still means "off"; there is no other spelling to adopt for the unset case,
+because unset now *is* the default-on case.
+
+**The timing.** In 2.x, `validate=True` validates **eagerly at construction** — `Container(...)`
+itself raises `ValidationFailedError` if the graph is broken. In 3.0, validation never runs in
+`__init__`. It runs once, at container **entry** — `open()`, or `with`/`async with` (which call
+`open()`) — so an invalid graph raises there instead. This lets a framework integration register
+its own providers (e.g. via `add_providers`) after construction and still have the complete graph
+validated before first use. `validate=True` is **not eager**: if you need a construction-time
+check, call `container.validate()` explicitly right after building it.
+
+This timing change has no 2.x warning: an explicit `validate=True` caller in 2.x sees no
+deprecation notice, because from 2.x's perspective that call already validates and already
+succeeds — 2.x has nothing to warn about a timing it doesn't yet have. `UnvalidatedContainerWarning`
+only ever covered the *unset* case (2.x's "no explicit `validate=` argument" state); it says nothing
+about when validation happens once enabled. Escalating it to an error still gets you a 2.x-clean
+signal for switching the *default* to on — it does not, and cannot, warn you about the *timing*
+move for callers who already pass `validate=True`.
 
 **Before (2.x):**
 ```python
 # UnvalidatedContainerWarning: This root container was created without an
-# explicit `validate` argument. modern-di 3.0 runs validate() at root
-# construction by default. Pass validate=True to adopt the 3.0 behavior now,
-# or validate=False to keep validation off.
+# explicit `validate` argument. modern-di 3.0 runs validate() at container
+# entry by default. Pass validate=True to adopt the 3.0 behavior now, or
+# validate=False to keep validation off.
 container = Container(scope=Scope.APP, groups=[MyGroup])
+container.resolve(MyService)
+
+# Explicit opt-in — validates immediately, no warning, at construction:
+container = Container(scope=Scope.APP, groups=[MyGroup], validate=True)  # raises here if broken
 ```
 
 **After (3.0):**
 ```python
-# validate() runs automatically; raises ValidationFailedError if the graph
-# has cycles or scope-ordering problems.
-container = Container(scope=Scope.APP, groups=[MyGroup])
+# validate is on by default; it runs once at open(), not at construction.
+with Container(scope=Scope.APP, groups=[MyGroup]) as container:
+    # validate() already ran here — raises ValidationFailedError before this
+    # block is entered if the graph has cycles or scope-ordering problems.
+    service = container.resolve(MyService)
 
-# Opt out of validation — this spelling works identically before and after 3.0.
+# Opt out entirely — this spelling works identically before and after 3.0.
 container = Container(scope=Scope.APP, groups=[MyGroup], validate=False)
+
+# Want the check at construction time instead of at open()? Call it yourself.
+container = Container(scope=Scope.APP, groups=[MyGroup])
+container.validate()  # raises ValidationFailedError here if the graph is broken
 ```
 
-Child containers (built via `build_child_container`) never validate and never warn, in either
-version — this switch only affects root construction.
+Child containers (built via `build_child_container`) never validate, in either version — this
+switch only affects root containers.
 
 ### 5. Direct resolve of an unset `ContextProvider` raises
 
@@ -152,10 +200,66 @@ Pass `context={SomeContextType: value}` to the container (or its ancestor at the
 `ContextProvider`'s scope), or call `container.set_context(SomeContextType, value)`, before
 resolving.
 
+### 6. A container must be opened before use
+
+New in 3.0, added mid-development, with **no 2.x deprecation signal at all** — 2.x has no
+"unopened" state, so there was never anything for it to warn about. A freshly constructed
+container now starts unopened; using it before entering it — `resolve`, `resolve_provider`,
+`build_child_container` — raises `ContainerClosedError`. Enter it with `with`/`async with`, or call
+`open()` directly (for a callback-style lifecycle that cannot use a `with` block), before the first
+use. Child containers (from `build_child_container`) also start unopened and must be entered
+themselves before they can be used.
+
+This is the *never-opened* half of the same rule as [switch 1](#1-closed-containers-raise-instead-of-self-healing)
+above (the *closed-after-use* half): **a container must be open to be used**, whether it was never
+opened or was opened and then closed. Both cases raise the identical `ContainerClosedError`, with a
+message that names which state applies, and both are fixed the same way.
+
+**Before (2.x):**
+```python
+container = Container(scope=Scope.APP, groups=[MyGroup])
+service = container.resolve(MyService)  # works — no open() call needed
+
+child = container.build_child_container(scope=Scope.REQUEST)
+value = child.resolve(SomeContextType)  # works — no open() call needed either
+```
+
+**After (3.0):**
+```python
+container = Container(scope=Scope.APP, groups=[MyGroup])
+service = container.resolve(MyService)  # raises ContainerClosedError: not open
+
+# Fix: enter the container first.
+with Container(scope=Scope.APP, groups=[MyGroup]) as container:
+    service = container.resolve(MyService)  # works
+
+    # A child also starts unopened and must be entered before use.
+    with container.build_child_container(scope=Scope.REQUEST) as child:
+        value = child.resolve(SomeContextType)  # works
+
+# Or, without a `with` block:
+container = Container(scope=Scope.APP, groups=[MyGroup])
+container.open()
+service = container.resolve(MyService)  # works
+```
+
+Because there is no 2.x signal for this one, the [readiness recipe](#readiness-recipe-escalating-warnings-to-errors-with-filterwarnings)
+below cannot surface it in advance — a green 2.x suite under that recipe still needs every
+construct-then-use call site audited for a matching `with`/`open()` before it can run against 3.0.
+
 ## Readiness recipe: escalating warnings to errors with `filterwarnings`
 
 This is the one place in the docs that lists the full `filterwarnings` escalation recipe; every
 other page that mentions escalating a specific warning links back here.
+
+This recipe covers switches 1, 2, 3, and 5 fully, and switch 4 only for the *unset-`validate`*
+case — the case `UnvalidatedContainerWarning` actually warns about. It has **nothing** to say about
+switch 6 (mandatory-open) or about switch 4's timing move for callers who already pass
+`validate=True` explicitly: both are hard breaks with no 2.x warning to escalate. A green suite
+under this recipe rules out five-and-a-half of the six switches; you still need to audit
+construct-then-use call sites for `with`/`open()` (switch 6) and, if you pass `validate=True`
+explicitly today, re-check any code that depends on validation happening at construction rather
+than at `open()` (switch 4).
 
 `ContainerClosedWarning` and `ContextValueNoneWarning` subclass `DeprecationWarning`;
 `UnvalidatedContainerWarning` subclasses `FutureWarning`; the `Alias(scope=)` and
@@ -207,6 +311,15 @@ warnings.filterwarnings("error", category=exceptions.ContextValueNoneWarning)
 
 ## Deprecation policy
 
-Every breaking change in modern-di is warned for at least one minor release cycle before it flips
-or is removed at the next major. If you're on a 2.x release and see none of the five warnings
-above under the readiness recipe, upgrading to 3.0 requires no code changes on your part.
+Every breaking change that *can* be signalled in modern-di is warned for at least one minor release
+cycle before it flips or is removed at the next major. If you're on a 2.x release and see none of
+the five warnings above under the readiness recipe, those five switches require no code changes on
+your part.
+
+That policy has a boundary: it only covers changes 2.x has a state to warn from. Mandatory-open
+(switch 6) is a new requirement with no 2.x precedent — a 2.x container has no "unopened" state, so
+there was never a warning to add. Likewise, switch 4's timing move (construction to `open()`) only
+affects callers who already pass `validate=True`, a code path 2.x treats as already-correct and so
+never warns about. Neither omission is an oversight in this guide; there is no signal to point to.
+Upgrading to 3.0 requires opening every container you construct-then-use, in addition to a clean
+run under the readiness recipe above.

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -247,25 +247,29 @@ class ContainerClosedError(ContainerError):
 
 
 class ContainerClosedWarning(DeprecationWarning):
-    """Reuse of a closed container (resolve / build a child) — transitional.
+    """Retained for back-compat of existing ``filterwarnings`` configs; no longer emitted.
 
-    The reuse works today because the container self-reopens, but it will raise
-    :class:`ContainerClosedError` in modern-di 3.0. Opt into strict behavior now
-    by escalating this warning::
+    In modern-di 2.x this warned on reuse of a closed container, which then self-reopened. As of
+    3.0 that reuse raises :class:`ContainerClosedError` instead, so this warning is never raised —
+    the class stays importable so an existing::
 
         warnings.filterwarnings("error", category=exceptions.ContainerClosedWarning)
+
+    does not break at import time.
     """
 
 
 class UnvalidatedContainerWarning(FutureWarning):
-    """A root container was built without an explicit ``validate`` argument — transitional.
+    """Retained for back-compat of existing ``filterwarnings`` configs; no longer emitted.
 
-    modern-di 3.0 runs :meth:`Container.validate` at root construction by
-    default. Pass ``validate=True`` to adopt the 3.0 behavior now, or
-    ``validate=False`` to keep validation off (also after 3.0). Opt into strict
-    behavior early by escalating this warning::
+    In modern-di 2.x this warned when a root container was built without an explicit ``validate``
+    argument. As of 3.0, ``validate`` defaults to ``True`` and runs at container entry
+    (:meth:`Container.open`/``with``), so there is nothing left to warn about — the class stays
+    importable so an existing::
 
         warnings.filterwarnings("error", category=exceptions.UnvalidatedContainerWarning)
+
+    does not break at import time.
     """
 
 
@@ -410,12 +414,7 @@ class CircularDependencyError(ResolutionError):
 
 
 class ContextValueNotSetError(ResolutionError):
-    """An unset ``ContextProvider`` was resolved directly.
-
-    Raised in modern-di 3.0; until then direct resolve emits
-    :class:`ContextValueNoneWarning` and returns ``None``. Inspect
-    ``.context_type``.
-    """
+    """An unset ``ContextProvider`` was resolved directly. Inspect ``.context_type``."""
 
     docs_slug = "context-not-set"
 
@@ -430,13 +429,15 @@ class ContextValueNotSetError(ResolutionError):
 
 
 class ContextValueNoneWarning(DeprecationWarning):
-    """Direct resolve of an unset ``ContextProvider`` returned ``None`` — transitional.
+    """Retained for back-compat of existing ``filterwarnings`` configs; no longer emitted.
 
-    The ``None`` return works today but modern-di 3.0 raises
-    :class:`ContextValueNotSetError` here. Opt into strict behavior now by
-    escalating this warning::
+    In modern-di 2.x this warned when a direct resolve of an unset ``ContextProvider`` returned
+    ``None``. As of 3.0 that resolve raises :class:`ContextValueNotSetError` instead, so this
+    warning is never raised — the class stays importable so an existing::
 
         warnings.filterwarnings("error", category=exceptions.ContextValueNoneWarning)
+
+    does not break at import time.
     """
 
 

--- a/planning/changes/2026-07-19.21-migration-guide-and-docstrings.md
+++ b/planning/changes/2026-07-19.21-migration-guide-and-docstrings.md
@@ -1,0 +1,95 @@
+---
+summary: Migration guide and transitional-exception docstrings revised to match what shipped — six switches (not five), validate's final bool/open()-timing form, and mandatory-open framed as a hard break the readiness recipe cannot catch. Landed; `just test-ci` 435 passed, 100% coverage.
+---
+
+# Design: Migration guide and docstring revision for shipped 3.0
+
+## Summary
+
+Docs-and-docstrings-only reconciliation: `docs/migration/to-3.x.md` and the transitional exception
+docstrings in `modern_di/exceptions.py` still described the five-switches plan
+([2026-07-19.14](2026-07-19.14-3.0-release-scope.md)) and the deferred-validation interim
+([2026-07-19.19](2026-07-19.19-validate-by-default-deferred.md)), not the final shipped shape —
+`validate: bool = True` with the first-resolve fallback removed
+([2026-07-19.19](2026-07-19.19-validate-by-default-deferred.md) →
+[2026-07-19.20](2026-07-19.20-mandatory-open-lifecycle.md)) plus the sixth switch,
+mandatory-open, added mid-development. No behavior changed.
+
+## Motivation
+
+The guide promised that a green 2.x suite under the warnings-as-errors readiness recipe makes the
+3.0 upgrade a no-op. That promise is only true for the five *signalled* switches. Mandatory-open has
+no 2.x precedent to warn from, and switch 4's final form (plain `bool`, validated at `open()` rather
+than construction) changes behavior for callers who already pass `validate=True` explicitly — 2.x
+never warned about *that* caller, only the unset-`validate` one. Shipping the guide as-is would
+overclaim a no-op it can no longer deliver. The exception docstrings had the mirror problem: three
+of them ("Raised in modern-di 3.0; until then …") were written from 2.x's vantage point and read as
+stale now that 3.0 is what's on `main`.
+
+## Design
+
+**`docs/migration/to-3.x.md`** ([diff](../../docs/migration/to-3.x.md)):
+
+- Overview and the switches table now cover six, not five. The table's `validate` row notes its 2.x
+  signal covers only the *unset* case. The mandatory-open row states plainly it has no 2.x signal.
+- Switch 4 rewritten to the final shape: signature `bool = True` (no `None` sentinel); validation
+  runs once at container entry (`open()`/`with`), never in `__init__`, never on first resolve (that
+  fallback is gone); `validate=False` disables; `validate=True` is not eager — call
+  `container.validate()` explicitly for a construction-time check. Explains, in prose, why this has
+  no 2.x warning: `UnvalidatedContainerWarning` only ever fired for the unset case, never for a
+  caller who already passed `validate=True` and relied on eager construction-time validation.
+- New switch 6 section: mandatory-open, with 2.x/3.0 before/after (root and child), and an explicit
+  note that the readiness recipe cannot catch it.
+- Switch 1 and switch 6 cross-reference each other as the two halves of one rule
+  ("a container must be open to be used" — closed-after-use vs. never-opened), both raising the
+  same `ContainerClosedError`.
+- Readiness-recipe section gains a scoping paragraph: covers switches 1/2/3/5 fully, switch 4 only
+  for the unset case, nothing for switch 6 or switch 4's timing move.
+- Deprecation-policy paragraph reworded: the "warn for a cycle, then flip" policy only applies to
+  changes 2.x has a state to warn from; mandatory-open and the `validate=True`-caller timing move
+  don't have one, so they're disclosed as unconditional hard breaks rather than folded into the
+  no-op claim.
+
+**`modern_di/exceptions.py`** — five docstrings, present-tense for 3.0:
+
+- `ContainerClosedError` was already present-tense on `main` (no "Raised in 3.0; until then" text
+  found) — left unchanged.
+- `ContainerClosedWarning`, `UnvalidatedContainerWarning`, `ContextValueNoneWarning`: reworded from
+  "transitional, will raise/change in 3.0" to "retained for back-compat of existing
+  `filterwarnings` configs; no longer emitted" — each states what 2.x behavior it used to flag and
+  what 3.0 does instead, in the past/present tense a 3.0-line reader expects.
+- `ContextValueNotSetError`: dropped the "Raised in modern-di 3.0; until then …" paragraph entirely
+  (nothing left to say once 3.0 is the current release); kept to a single contract line.
+- No `docs_slug`, class name, or signature touched.
+
+## Non-goals
+
+- No behavior, signature, or code-logic change anywhere in `modern_di/`.
+- `docs/integrations/*` deliberately untouched (separate task).
+- No change to what `validate()` checks, or to the mandatory-open mechanism itself — both already
+  shipped; this is documentation catching up.
+
+## Testing
+
+- `just test-ci`: **435 passed, 100.00% line coverage** (unchanged from before this change — docs
+  and docstrings carry no executable branches the suite didn't already cover).
+- `just lint-ci`: eof-fixer, `ruff format --check`, `ruff check --no-fix`, `ty check`,
+  `planning/index.py --check` all clean.
+- `just check-planning`: OK.
+- `mkdocs build --strict` not run locally (the `llmstxt` plugin isn't installed in this
+  environment); CI's docs job covers it. Anchor slugs used by the new switch-1/switch-6 and
+  switch-4 cross-references follow the same slugify pattern already exercised by the file's
+  existing `#readiness-recipe-…` self-link.
+
+## Risk
+
+- **Anchor drift**: the new cross-reference links (`#4-validate-runs-at-container-entry-on-by-
+  default`, `#6-a-container-must-be-opened-before-use`, `#1-closed-containers-raise-instead-of-
+  self-healing`) are hand-derived from the header text since `mkdocs --strict` couldn't run
+  locally; mitigated by matching the existing, already-working slug pattern in the same file and by
+  CI's strict docs build catching a broken anchor before merge.
+- **Overclaiming vs. underclaiming the no-op promise**: leaned toward being explicit that switches
+  1/2/3/5 (and the unset-`validate` half of 4) remain a genuine no-op under the recipe, while
+  switch 6 and 4's timing move are named as unconditional hard breaks — avoids both re-promising a
+  blanket no-op and burying the one real behavior change (4's timing) that only affects a subset of
+  callers.


### PR DESCRIPTION
Final docs pass for 3.0 (see `planning/changes/2026-07-19.21-migration-guide-and-docstrings.md`).

- **`docs/migration/to-3.x.md`**:
  - Switch #4 (validate) rewritten to the final form: `validate: bool = True` (no `None` sentinel); validation runs at **container entry** (`open()`/`with`), not construction; `validate=False` disables; `validate=True` is not eager — call `container.validate()` for construction-time.
  - **Added switch #6** — the mandatory-open lifecycle (a container must be opened before use; unopened raises `ContainerClosedError`; children too).
  - **Honest framing**: the "green 2.x suite → no-op upgrade" promise is now scoped to the **five signalled** switches; #6 (and #4's timing/bool change) are called out as **hard breaks with no 2.x signal** the readiness recipe can't catch. Switch #1 (closed-after-use) and #6 (never-opened) reconciled as the same `ContainerClosedError`.
- **`modern_di/exceptions.py`**: the transitional docstrings flipped to present-tense 3.0; the retained-but-unemitted warning classes (`ContainerClosedWarning`, `UnvalidatedContainerWarning`, `ContextValueNoneWarning`) note they're kept for `filterwarnings` back-compat but no longer emitted. No `docs_slug` changed.

## Verification
- `just test-ci` — 435 passed, 100% coverage
- `just lint-ci` — clean; docs build verified in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)