### PR TITLE
docs(troubleshooting): fix stale validation-timing note

### DIFF
--- a/docs/troubleshooting/circular-dependency.md
+++ b/docs/troubleshooting/circular-dependency.md
@@ -39,7 +39,7 @@ in one pass (not just the one a particular resolve happens to hit) — prefer it
 ```python
 from modern_di import Container
 
-# Option 1: enable validation (runs deferred, at container entry / first resolve)
+# Option 1: enable validation (runs deferred, at container entry via open()/with)
 container = Container(groups=[MyGroup], validate=True)
 
 # Option 2: validate explicitly at construction (validate=False disables the


### PR DESCRIPTION
Final 3.0 whole-branch review caught a cross-change inconsistency: `docs/troubleshooting/circular-dependency.md` still described validation as running "at container entry / first resolve" — the "first resolve" fallback was an intermediate design (change #4) that the mandatory-open change (#6) removed. Final behavior: validation runs only at container entry (`open()`/`with`).

Aligns the page with `docs/migration/to-3.x.md` and `architecture/validation.md`.

## Verification
- `just lint-ci` — clean
🤖 Generated with [Claude Code](https://claude.com/claude-code)