### PR TITLE
docs(release): 3.0.0 notes — explicit container lifecycle

### DIFF
--- a/planning/releases/3.0.0.md
+++ b/planning/releases/3.0.0.md
@@ -1,0 +1,98 @@
+# modern-di 3.0.0 — an explicit container lifecycle
+
+3.0 is a **breaking release**. It makes the container lifecycle explicit and
+turns six long-standing "warn-then-continue" behaviors into hard rules: a
+container must be opened before use, and validation runs by default. Five of the
+six changes have been warned about since 2.x — if your 2.x suite is green under
+the [warnings-as-errors readiness recipe](https://modern-di.modern-python.org/migration/to-3.x/#readiness-recipe-escalating-warnings-to-errors-with-filterwarnings),
+those five are a no-op. The sixth — the mandatory-open lifecycle — is a hard
+break with no 2.x signal; see [Migrating](#migrating).
+
+Full guide: **[Migration to 3.x](https://modern-di.modern-python.org/migration/to-3.x/)**.
+
+## Breaking changes
+
+### A container must be opened before use (#365)
+
+The headline change. A freshly constructed container starts **unopened**;
+`resolve` and `build_child_container` raise `ContainerClosedError` until you
+enter it via `with` / `async with` / `open()`. Child containers require opening
+too.
+
+```python
+# Before (2.x)
+container = Container(scope=Scope.APP, groups=[MyGroup])
+service = container.resolve(MyService)          # worked
+
+# After (3.0)
+with Container(scope=Scope.APP, groups=[MyGroup]) as container:
+    service = container.resolve(MyService)      # open, then resolve
+# or: container = Container(...); container.open(); container.resolve(...)
+```
+
+This makes the lifecycle explicit and guarantees validation cannot be silently
+skipped (opening is what validates). It has **no 2.x deprecation warning** — 2.x
+containers were usable on construction, so there was no "unopened" state to warn
+on.
+
+### Validation runs by default, at container entry (#364)
+
+`validate` now defaults to on and is a plain `bool` (`validate: bool = True`; the
+old `None` was dropped). Validation runs **once, when you open the container** —
+not at construction, and not on first resolve. `validate=False` disables it. For
+a construction-time check, call `container.validate()` explicitly.
+
+```python
+with Container(groups=[MyGroup]) as container:   # validates here (cycles + scope order)
+    ...
+```
+
+Because integrations register their connection providers *after* you build the
+container, deferring validation to entry is what lets a `Factory` depend on a
+framework's request/message type without a spurious startup error.
+
+### Reusing a closed container raises (#362)
+
+Resolving from — or building a child of — a **closed** container now raises
+`ContainerClosedError` instead of silently reopening (self-healing). Re-enter
+with `with` / `open()` before reuse. (This and the mandatory-open rule above are
+the same error: a container must be open to use.)
+
+### Direct resolve of an unset `ContextProvider` raises (#363)
+
+`container.resolve(SomeContextType)` with no value set now raises
+`ContextValueNotSetError` instead of returning `None`. A `Factory` parameter
+backed by the same provider is unchanged — it still follows its
+default/nullable/required disposition.
+
+### `Alias(scope=)` removed (#359)
+
+The `scope` argument never affected an alias's resolution (its scope is derived
+from its source). It's gone; passing it raises `TypeError`.
+
+### `Factory(cache_settings=)` removed (#360)
+
+The pre-`cache=` spelling is gone; use `cache=` (`cache=True` for defaults, or
+`cache=CacheSettings(...)` to tune).
+
+## Migrating
+
+1. **The five signalled switches** (closed-raises, `Alias(scope=)`,
+   `Factory(cache_settings=)`, validate-by-default, unset-context-raises) each
+   warned in 2.x. Run your 2.x suite under the
+   [readiness recipe](https://modern-di.modern-python.org/migration/to-3.x/#readiness-recipe-escalating-warnings-to-errors-with-filterwarnings)
+   (warnings as errors); if it stays green, these are a no-op for you.
+
+2. **The mandatory-open lifecycle** (and validation now running at entry) cannot
+   be caught by the recipe — it has no 2.x signal. Wrap your containers in
+   `with` / `async with`, or call `open()` before use. This is the one change
+   that may need code edits even if your suite was warning-clean.
+
+3. **Framework integrations.** The `modern-di-*` integration packages that build
+   or hand you a container are updated to open it for you; upgrade them alongside
+   `modern-di` 3.0. If you build request-scoped child containers yourself, open
+   them (or use `with`).
+
+The retained warning classes (`ContainerClosedWarning`,
+`UnvalidatedContainerWarning`, `ContextValueNoneWarning`) still import for
+back-compat but are no longer emitted.


### PR DESCRIPTION
Draft GitHub Release body for **3.0.0** (`planning/releases/3.0.0.md`) — used verbatim by `release.yml` when the tag is cut. **This PR does not tag anything.**

Covers the six breaking changes, foregrounds the mandatory-open lifecycle and validate-at-entry, links the migration guide, and clearly separates:
- the **five 2.x-signalled switches** (no-op under the warnings-as-errors readiness recipe), from
- the **mandatory-open hard break** (no 2.x signal — may need code edits regardless), plus the integration-package upgrade note.

Please review the wording before cutting `3.0.0rc1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)