### PR TITLE
refactor(exceptions): single home for the creator-call TypeError rule

### DIFF
--- a/architecture/resolution.md
+++ b/architecture/resolution.md
@@ -213,11 +213,11 @@ hierarchy are. See [2026-07-14-error-text-is-not-a-contract](../planning/decisio
 
 ## Step 6 — Creator call and caching
 
-The resolver calls the creator with the built arguments. A `TypeError` from the call is handled by a `tb_next`
-guard reused across every resolver (and by `Factory._call_creator`, which the cached kwargs path still reuses):
-an argument-binding failure (no inner traceback frame) is wrapped in a `CreatorCallError` with this provider's
-step prepended, while a `TypeError` raised *inside* the creator body (inner frame present) propagates unchanged,
-like any other error.
+The resolver calls the creator with the built arguments. A `TypeError` from the call is routed through
+`CreatorCallError.from_type_error` — one classmethod every resolver and `Factory._call_creator` call from
+their `except TypeError` block: an argument-binding failure (no inner traceback frame) becomes a
+`CreatorCallError` with this provider's step prepended, while a `TypeError` raised *inside* the creator body
+(inner frame present) returns `None` and is re-raised unchanged, like any other error.
 
 - **Transient** (no `cache_settings`) — the built instance is returned immediately; the creator re-runs on every
   resolve.

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -375,6 +375,26 @@ class CreatorCallError(ResolutionError):
             f"Failed to call creator {creator_name}: {original_error}. Check kwargs and skip_creator_parsing usage."
         )
 
+    @classmethod
+    def from_type_error(
+        cls,
+        *,
+        creator: typing.Any,  # noqa: ANN401
+        exc: TypeError,
+        resolution_step: "typing.Callable[[], ResolutionStep]",
+    ) -> "CreatorCallError | None":
+        """Wrap an argument-binding ``TypeError`` as a ``CreatorCallError`` with the resolution step prepended.
+
+        A ``TypeError`` raised *inside* the creator body (it carries an inner traceback frame) is not a
+        binding failure: return ``None`` so the caller re-raises it unchanged. The resolution step is built
+        only when wrapping, never on the propagate path.
+        """
+        if exc.__traceback__ is not None and exc.__traceback__.tb_next is not None:
+            return None
+        error = cls(creator=creator, original_error=exc)
+        error.prepend_step(resolution_step())
+        return error
+
 
 class CircularDependencyError(ResolutionError):
     """A dependency cycle was detected by ``validate()`` or the runtime resolve guard.

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -211,10 +211,9 @@ class Factory(AbstractProvider[types.T_co]):
         try:
             return self._creator(**resolved_kwargs)
         except TypeError as exc:
-            # Argument-binding failures raise here with no inner traceback frame; a TypeError
-            # raised inside the creator body must propagate unchanged, like ValueError/RuntimeError.
-            if exc.__traceback__ is not None and exc.__traceback__.tb_next is not None:
+            error = exceptions.CreatorCallError.from_type_error(
+                creator=self._creator, exc=exc, resolution_step=self._resolution_step
+            )
+            if error is None:
                 raise
-            error = exceptions.CreatorCallError(creator=self._creator, original_error=exc)
-            error.prepend_step(self._resolution_step())
             raise error from exc

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -107,10 +107,11 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
             try:  # inlined Factory._call_creator, positional
                 return creator(*args)
             except TypeError as exc:
-                if exc.__traceback__ is not None and exc.__traceback__.tb_next is not None:
+                error = exceptions.CreatorCallError.from_type_error(
+                    creator=creator, exc=exc, resolution_step=resolution_step
+                )
+                if error is None:
                     raise  # a TypeError from inside the creator body propagates unchanged
-                error = exceptions.CreatorCallError(creator=creator, original_error=exc)
-                error.prepend_step(resolution_step())
                 raise error from exc
 
         return resolve_positional
@@ -139,10 +140,11 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
         try:  # inlined Factory._call_creator
             return creator(**kwargs)
         except TypeError as exc:
-            if exc.__traceback__ is not None and exc.__traceback__.tb_next is not None:
+            error = exceptions.CreatorCallError.from_type_error(
+                creator=creator, exc=exc, resolution_step=resolution_step
+            )
+            if error is None:
                 raise  # a TypeError from inside the creator body propagates unchanged
-            error = exceptions.CreatorCallError(creator=creator, original_error=exc)
-            error.prepend_step(resolution_step())
             raise error from exc
 
     return resolve
@@ -181,10 +183,11 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
             try:
                 return creator(*args)
             except TypeError as exc:
-                if exc.__traceback__ is not None and exc.__traceback__.tb_next is not None:
+                error = exceptions.CreatorCallError.from_type_error(
+                    creator=creator, exc=exc, resolution_step=resolution_step
+                )
+                if error is None:
                     raise  # a TypeError from inside the creator body propagates unchanged
-                error = exceptions.CreatorCallError(creator=creator, original_error=exc)
-                error.prepend_step(resolution_step())
                 raise error from exc
 
         build_cold = build_args

--- a/planning/changes/2026-07-20.01-centralize-creator-call-error.md
+++ b/planning/changes/2026-07-20.01-centralize-creator-call-error.md
@@ -1,0 +1,93 @@
+---
+summary: Collapse the four inlined copies of the creator-call TypeError rule into one `CreatorCallError.from_type_error` classmethod, called only from the raise path; retire the drift-lock equivalence test.
+---
+
+# Design: A single home for the creator-call error rule
+
+## Summary
+
+The rule "a binding `TypeError` becomes `CreatorCallError` (with the resolution
+step prepended); a `TypeError` raised inside the creator body propagates
+unchanged" is inlined in four byte-identical copies. Move the
+discriminate-and-construct step into one `CreatorCallError.from_type_error`
+classmethod that the four sites call from inside their `except TypeError` block.
+The success (hot) path is untouched. The cross-path drift-lock equivalence
+test — which existed only to police the copies — is deleted and replaced by a
+direct unit test of the classmethod.
+
+## Motivation
+
+`2026-07-16.02` inlined the creator call to avoid a per-node frame on the
+resolve hot path, which forced the `tb_next` discriminator into four copies:
+`factory._call_creator` (canonical, `factory.py:210`) plus three closures in
+`resolver_compiler.py` (`:107`, `:139`, `:180`). The copies have no locality:
+the subtle part (the `tb_next` check that tells an argument-binding failure from
+a `TypeError` thrown inside the creator body) must stay byte-identical across
+four sites, and a drift is invisible per-copy. The team already pays for this
+with a dedicated equivalence test (`test_factory.py:1193`) whose only job is to
+assert the four agree — a standing tax that proves the friction is real.
+
+## Design
+
+One classmethod on `CreatorCallError` (in `exceptions.py`, the home of error
+construction):
+
+```python
+@classmethod
+def from_type_error(cls, *, creator, exc, resolution_step):
+    """Binding TypeError -> a CreatorCallError with the step prepended; a creator-body TypeError -> None."""
+    if exc.__traceback__ is not None and exc.__traceback__.tb_next is not None:
+        return None
+    error = cls(creator=creator, original_error=exc)
+    error.prepend_step(resolution_step())
+    return error
+```
+
+Each of the four sites becomes:
+
+```python
+try:
+    return creator(*args)                # hot path unchanged
+except TypeError as exc:
+    error = exceptions.CreatorCallError.from_type_error(creator=creator, exc=exc, resolution_step=resolution_step)
+    if error is None:
+        raise                            # propagate: bare raise, traceback byte-identical
+    raise error from exc                  # wrap: identical to today
+```
+
+`resolution_step` is passed as the callable and invoked only on the wrap branch,
+so the step is built exactly when it is today (never on the propagate path). The
+return-or-None contract keeps the `raise` at the call site, so both branches'
+tracebacks are unchanged. This reverses the drift-lock bundle's "no shared
+helper" non-goal on a narrower ground — see
+[decision](../decisions/2026-07-20-except-body-creator-error-helper.md).
+
+## Non-goals
+
+- No change to the success/hot path — only the `except TypeError` body moves.
+- No change to `CreatorCallError`'s message, attributes, or docs slug.
+- No broader dedup of the compiler's other inlined patterns (override
+  front-guard, `_navigate`) — those stay inlined per the
+  [per-provider-compile-seam decision](../decisions/2026-07-17-per-provider-compile-seam-declined.md).
+
+## Testing
+
+- `just test-ci` green at 100% line coverage.
+- Delete `test_creator_call_error_str_is_identical_across_transient_and_cached`;
+  add a direct unit test of `from_type_error` (binding `TypeError` → wraps,
+  prepends the step, carries the docs slug; body `TypeError` → `None`). Keep all
+  per-path behavioral tests, including `test_transient_positional_binding_typeerror_wraps`.
+- Perf gate: `pytest benchmarks/test_guard_resolve.py --benchmark-only
+  --benchmark-save=baseline` on the base commit, then `--benchmark-compare=baseline
+  --benchmark-compare-fail=mean:5%` on the change; comparison pasted in the PR.
+
+## Risk
+
+Low. The moved code runs only on the raise path; the success path is
+byte-identical, so a hot-path regression is not mechanically possible — the
+bench gate confirms it empirically. The one behavioral invariant
+(body-`TypeError` traceback fidelity) is preserved by the bare `raise` at each
+site and covered by the existing per-path propagate tests.
+
+Promotion: `architecture/resolution.md` (the `:217` narration of the reused
+guard) is updated in the implementing PR to describe the single classmethod home.

--- a/planning/decisions/2026-07-20-except-body-creator-error-helper.md
+++ b/planning/decisions/2026-07-20-except-body-creator-error-helper.md
@@ -1,0 +1,61 @@
+---
+status: accepted
+summary: Accept an except-body-only helper for the creator-call TypeError rule — it dodges the frame cost that made the drift-lock bundle reject a shared helper, because the moved code runs only on the raise path.
+supersedes: null
+superseded_by: null
+---
+
+# Extract the creator-call error rule via an except-body-only helper
+
+**Decision:** Centralize the creator-call `TypeError` rule in one
+`CreatorCallError.from_type_error` classmethod, called from inside each site's
+`except TypeError` block. This supersedes the "no shared helper" non-goal
+recorded in
+[2026-07-17.02-creator-call-error-drift-lock](../changes/2026-07-17.02-creator-call-error-drift-lock.md).
+
+## Context
+
+The drift-lock bundle (`changes/2026-07-17.02`) faced the same four-copy
+duplication of the rule "a binding `TypeError` becomes `CreatorCallError` with a
+prepended step; a `TypeError` from inside the creator body propagates unchanged."
+It explicitly rejected deduping: *"Do not extract a shared helper — that
+reintroduces the frame the inlining removed,"* and locked the copies with a
+cross-path equivalence test instead.
+
+That rejection weighed one helper shape: a helper wrapping the whole
+`creator(...)` call, which adds a Python frame on **every** resolve — the success
+path the [single-path compiled resolver](../changes/2026-07-16.02-single-path-compiled-resolver.md)
+inlining exists to keep frame-free.
+
+The option it did not weigh: extract only the `except`-body — the `tb_next`
+discriminate, the `CreatorCallError` construction, and the `prepend_step` — while
+leaving `try: return creator(...)` at each site. That code runs only when the
+creator call raises `TypeError`, i.e. on the already-failing raise path, never on
+success.
+
+## Decision & rationale
+
+Chose the except-body helper. The drift-lock bundle's objection is real but
+scoped to whole-call wrapping; it does not bind the except-body form. Under this
+form:
+
+- The success (hot) path stays `return creator(*args)` byte-for-byte — no frame
+  is restored. A `--benchmark-compare-fail=mean:5%` resolve-bench gate confirms
+  it empirically before ship.
+- The rule gets one home (locality); changing it is one edit, not four.
+- The equivalence test that existed only to police the copies is retired — one
+  source cannot drift from itself.
+- Traceback fidelity is preserved: the return-or-`None` contract keeps the bare
+  `raise` at each site, so a creator-body `TypeError` propagates with its
+  traceback unchanged.
+
+The narrower frame concern the drift-lock bundle protected is honored, not
+overridden — the reversal applies precisely because the except-body form
+sidesteps it.
+
+## Revisit trigger
+
+The resolve hot path regresses after this lands (meaning the success path was not
+as frame-free as argued), **or** a future change needs the creator-call rule to
+differ per site again (making a single shared rule wrong) — either reopens the
+single-home decision.

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -1178,53 +1178,33 @@ def test_transient_positional_binding_typeerror_wraps() -> None:
         container.resolve_provider(G.thing)
 
 
-def _resolve_creator_call_error(
-    factory: "providers.Factory[typing.Any]", bound_type: type
-) -> exceptions.CreatorCallError:
-    """Resolve `factory` in its own container and return the CreatorCallError it raises."""
-    container = Container(scope=Scope.APP, validate=False)
-    container.open()
-    container.providers_registry.register(bound_type, factory)
-    with pytest.raises(exceptions.CreatorCallError) as exc_info:
-        container.resolve(bound_type)
-    return exc_info.value
+def test_from_type_error_wraps_binding_and_prepends_step() -> None:
+    def _one_arg(x: int) -> int:
+        return x
+
+    arg = 5
+    assert _one_arg(arg) == arg  # exercise body
+
+    step = exceptions.ResolutionStep(scope=Scope.APP, name="one_arg", location=None)
+    try:
+        _one_arg()  # ty: ignore[missing-argument]  # missing arg: binding TypeError, no inner frame (tb_next is None)
+    except TypeError as exc:
+        error = exceptions.CreatorCallError.from_type_error(creator=_one_arg, exc=exc, resolution_step=lambda: step)
+    assert isinstance(error, exceptions.CreatorCallError)
+    assert error.dependency_path == [step]  # the step was prepended
+    assert "creator-call-error" in str(error)  # docs slug intact
+    assert error.creator is _one_arg
 
 
-def test_creator_call_error_str_is_identical_across_transient_and_cached() -> None:
-    # The tb_next binding-error rule is inlined in four places (factory._call_creator plus three
-    # resolver_compiler closures). Nothing else asserts the copies AGREE. For a fixed creator+scope,
-    # a re-inlined copy must render byte-identically to its reused/canonical sibling:
-    #   - positional pair: resolve_positional (transient) vs create_positional (cached)
-    #   - kwargs pair:      resolve/build_kwargs (transient) vs Factory._call_creator (cached)
-    # A single copy drifting its message, dropping prepend_step, or changing the docs slug breaks one
-    # of these equalities.
-    transient_pos = _resolve_creator_call_error(
-        providers.Factory(creator=_cov_needs_one_arg, bound_type=_CovOneArgResult, skip_creator_parsing=True),
-        _CovOneArgResult,
-    )
-    cached_pos = _resolve_creator_call_error(
-        providers.Factory(
-            creator=_cov_needs_one_arg, bound_type=_CovOneArgResult, skip_creator_parsing=True, cache=True
-        ),
-        _CovOneArgResult,
-    )
-    transient_kw = _resolve_creator_call_error(
-        providers.Factory(creator=_needs_two_args, bound_type=int, skip_creator_parsing=True, kwargs={"a": 1}),
-        int,
-    )
-    cached_kw = _resolve_creator_call_error(
-        providers.Factory(
-            creator=_needs_two_args, bound_type=int, skip_creator_parsing=True, kwargs={"a": 1}, cache=True
-        ),
-        int,
-    )
+def test_from_type_error_returns_none_for_creator_body_typeerror() -> None:
+    def _body_raises() -> None:
+        len(5)  # ty: ignore[invalid-argument-type]  # TypeError inside the body (inner frame present)
 
-    assert str(transient_pos) == str(cached_pos)  # positional copies agree
-    assert str(transient_kw) == str(cached_kw)  # kwargs copies agree
-
-    # Cross-convention structural floor: all four wrapped, prepended a step, and carry the docs slug.
-    for error in (transient_pos, cached_pos, transient_kw, cached_kw):
-        rendered = str(error)
-        assert "Failed to call creator" in rendered  # the wrap happened
-        assert "Cannot resolve dependency chain:" in rendered  # a resolution step was prepended
-        assert "creator-call-error" in rendered  # docs slug intact
+    step = exceptions.ResolutionStep(scope=Scope.APP, name="body", location=None)
+    try:
+        _body_raises()  # TypeError from inside the body: inner frame present (tb_next set)
+    except TypeError as exc:
+        result = exceptions.CreatorCallError.from_type_error(
+            creator=_body_raises, exc=exc, resolution_step=lambda: step
+        )
+    assert result is None


### PR DESCRIPTION
## What

Collapse the four byte-identical copies of the creator-call `TypeError` rule (three closures in `resolver_compiler.py` plus `Factory._call_creator`) into one `CreatorCallError.from_type_error` classmethod, called only from each site's `except TypeError` block. Retire the drift-lock equivalence test that existed solely to police the copies; replace it with a direct unit test of the classmethod.

Design + rationale live in the change bundle: `planning/changes/2026-07-20.01-centralize-creator-call-error.md`. This reverses the "no shared helper" non-goal of the drift-lock bundle (`planning/changes/2026-07-17.02-creator-call-error-drift-lock.md`) on a narrower ground, recorded in `planning/decisions/2026-07-20-except-body-creator-error-helper.md`: an *except-body-only* helper leaves the success hot path frame-free, so the frame the earlier inlining removed is never restored.

## Why it's safe on the hot path

Only the `except TypeError` body moves. Every site keeps `try: return creator(...)` byte-identical, and `from_type_error` is referenced only on the raise path. Both branches' tracebacks are preserved: a bare `raise` on propagate (creator-body `TypeError`), `raise error from exc` on wrap (binding `TypeError`).

## Verification

- `just test-ci`: **436 passed, 100% line coverage.**
- Resolve-tier benchmark vs baseline: **7/7 within the `mean:5%` gate**; success path byte-identical, observed deltas within run-to-run noise.
- Reviewed via a two-stage task review (spec ✅ / quality Approved) and an adversarial whole-branch review (verdict: Ready to merge), including a doc-faithfulness check confirming the decision record represents the reversed non-goal accurately rather than strawmanning it.

## Not in scope

No change to `CreatorCallError`'s message, attributes, or `docs_slug`; no dedup of the compiler's other inlined patterns (override front-guard, `_navigate`), which stay inlined per the per-provider-compile-seam decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
