### PR TITLE
docs: two root-open lifecycle traps for integration authors

### DIFF
--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -63,6 +63,15 @@ async def get_report(
     return report.as_dict()
 ```
 
+!!! warning "Deployment: mounted sub-apps and disabled lifespan"
+    FastAPI only opens the root container from the ASGI **lifespan** event. A
+    `setup_di`-wired app **mounted as a sub-application** (`app.mount("/sub",
+    subapp)`) never receives that event from its parent, and deployments that
+    disable lifespan (e.g. Mangum `lifespan="off"`) skip it too — the first
+    request then raises `ContainerClosedError`. Call `setup_di` on the
+    **top-level served app**, or open the root yourself (`container.open()` /
+    `with`) before serving.
+
 ## Websockets
 
 Websockets add `SESSION` scope between `APP` and `REQUEST` — see [the scope

--- a/docs/integrations/faststream.md
+++ b/docs/integrations/faststream.md
@@ -120,6 +120,16 @@ class AppGroup(Group):
     )
 ```
 
+## Testing
+
+!!! warning "Pair the test broker with `TestApp` in the same `with` statement"
+    When testing DI-using subscribers, pair the test broker (`TestNatsBroker`,
+    etc.) with `TestApp` in the **same** `with` / `async with` statement.
+    FastStream's `TestBroker` decides whether to run app `on_startup` hooks by
+    inspecting that statement; `async with TestNatsBroker(broker):` alone
+    starts the broker without running `on_startup`, so the root container
+    stays closed and the first published message raises `ContainerClosedError`.
+
 ## See also
 
 - [Testing with overrides](../recipes/testing-overrides.md) — swap providers in your tests.

--- a/docs/integrations/starlette.md
+++ b/docs/integrations/starlette.md
@@ -71,6 +71,15 @@ app = Starlette(routes=[Route("/report", get_report)])
 setup_di(app, Container(groups=[AppGroup], validate=True))
 ```
 
+!!! warning "Deployment: mounted sub-apps and disabled lifespan"
+    Starlette only opens the root container from the ASGI **lifespan** event.
+    A `setup_di`-wired app **mounted as a sub-application**
+    (`app.mount("/sub", subapp)`) never receives that event from its parent,
+    and deployments that disable lifespan (e.g. Mangum `lifespan="off"`) skip
+    it too — the first request then raises `ContainerClosedError`. Call
+    `setup_di` on the **top-level served app**, or open the root yourself
+    (`container.open()` / `with`) before serving.
+
 ### 3. Scopes
 
 See [the scope hierarchy](../providers/scopes.md#the-scope-dependency-rule) —

--- a/docs/integrations/taskiq.md
+++ b/docs/integrations/taskiq.md
@@ -64,6 +64,13 @@ async def get_report(
 
 `setup_di(broker, container)` stores the container on `broker.state` and registers `TaskiqEvents.WORKER_STARTUP`/`WORKER_SHUTDOWN` handlers that open/close it — those fire when the broker's worker process starts and stops, so a script that just calls tasks directly (like `InMemoryBroker` in a test) must drive the container lifecycle itself, e.g. `async with broker: ...` or an explicit `container.open()` / `await container.close_async()`.
 
+!!! warning "Deployment: `run_receiver_task` skips startup by default"
+    `taskiq.api.run_receiver_task(...)` defaults `run_startup=False`, which
+    skips the worker startup that opens the root container — the first task
+    then raises `ContainerClosedError`. Pass `run_startup=True` (or open the
+    root yourself before consuming) when embedding a receiver with
+    `run_receiver_task`.
+
 ## Scopes
 
 The integration creates a `Scope.REQUEST` child container **for each task** the worker executes. REQUEST-scoped providers (and their finalizers) live for the duration of that one task — the child container is closed after the task returns, including when it raises. APP-scoped providers persist for the whole worker process; `setup_di` opens the APP container on `WORKER_STARTUP` and runs `await container.close_async()` on `WORKER_SHUTDOWN`.

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -202,7 +202,11 @@ from whichever it dispatches to. `FromDI` is spelled in PascalCase (with
   deployments hit `ContainerClosedError` on the first unit of work while the
   tested pool stays green. `open()` and `close_*` are idempotent, so overlapping
   hooks are safe. If the framework offers no lifecycle hook at all, the root's
-  open/close is the caller's to own — document it.
+  open/close is the caller's to own — document it. On ASGI, the lifespan scope
+  is optional: a mounted sub-application never receives it from its parent,
+  and some deployments disable it (e.g. Mangum `lifespan="off"`) — an app
+  wired there still serves requests with a closed root, so `setup_di` belongs
+  on the top-level served app, or the caller opens the root itself.
 
 ## Scope mapping
 

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -185,6 +185,24 @@ from whichever it dispatches to. `FromDI` is spelled in PascalCase (with
   container on the error path.
 - **Match async vs sync to the framework.** Async frameworks use
   `close_async`; a synchronous CLI uses `close_sync`.
+- **Open the root *after* its connection providers are registered.** `open()`
+  runs `validate()`, so every connection/context provider must already be on the
+  container — a service that requires the connection object *by type* fails
+  validation otherwise. When `setup_di` is what registers those providers and the
+  caller owns the root's lifecycle (a framework with no startup hook — Flask,
+  gRPC), the order is `setup_di(app, container)` **then** `open()` (or `with`);
+  opening first validates against a container that has no connection provider yet.
+  Document that ordering for the caller.
+- **Open the root in *every* execution context the framework runs work in.** A
+  worker may dispatch units of work from more than one place: Celery fires
+  `worker_process_init` only for the prefork/solo pools, never for the
+  gevent / eventlet / threads pools (which run in the main worker process).
+  Wire open/close to a hook that fires for *all* of them — e.g. `worker_init` /
+  `worker_shutdown` *in addition to* the per-process signals — or those
+  deployments hit `ContainerClosedError` on the first unit of work while the
+  tested pool stays green. `open()` and `close_*` are idempotent, so overlapping
+  hooks are safe. If the framework offers no lifecycle hook at all, the root's
+  open/close is the caller's to own — document it.
 
 ## Scope mapping
 

--- a/planning/changes/2026-07-21.01-integration-open-lifecycle-lessons.md
+++ b/planning/changes/2026-07-21.01-integration-open-lifecycle-lessons.md
@@ -1,0 +1,44 @@
+---
+summary: Added two root-open lifecycle rules to writing-integrations.md — open after connection providers are registered (validation runs at open), and open in every execution context the framework runs work in (e.g. Celery's non-prefork pools).
+---
+
+# Change: Document two root-open lifecycle traps for integration authors
+
+**Lane:** lightweight — docs-only, one file edited, no code or public-API change.
+
+## Goal
+
+Two production defects surfaced while bringing the `modern-di-*` integrations
+onto 3.x (both invisible to green suites): `modern-di-flask` documented opening
+the root *before* `setup_di`, which fails validation for a non-optional
+connection-type dependency (validation runs at `open()`, before `setup_di`
+registers the request provider); and `modern-di-celery` opened the root only via
+`worker_process_init`, which Celery does not send for the gevent/eventlet/threads
+pools, so every task raised `ContainerClosedError` there. Both are reusable traps
+for future integration authors — capture the rules so they are not repeated.
+
+## Approach
+
+Two new bullets in `docs/integrations/writing-integrations.md` under
+**Lifecycle rules**, in the section's existing terse voice:
+
+1. *Open the root after its connection providers are registered* — `open()` runs
+   `validate()`; a by-type dependency on the connection object fails if the
+   provider is not yet on the container. When the caller owns the lifecycle
+   (Flask, gRPC), the order is `setup_di` then `open()`.
+2. *Open the root in every execution context the framework runs work in* — wire
+   open/close to a hook that fires for all of them (Celery: `worker_init` /
+   `worker_shutdown` alongside the per-process signals); idempotent open/close
+   makes overlapping hooks safe.
+
+No capability behavior changed, so no `architecture/` promotion — this is
+authoring guidance, not a contract move.
+
+## Files
+
+- `docs/integrations/writing-integrations.md` — two bullets added to Lifecycle rules.
+
+## Verification
+
+- [x] `just check-planning` — bundle validates.
+- [x] `just lint-ci` — no-autofix lint + planning validation clean.

--- a/planning/changes/2026-07-21.01-integration-open-lifecycle-lessons.md
+++ b/planning/changes/2026-07-21.01-integration-open-lifecycle-lessons.md
@@ -1,10 +1,10 @@
 ---
-summary: Added two root-open lifecycle rules to writing-integrations.md — open after connection providers are registered (validation runs at open), and open in every execution context the framework runs work in (e.g. Celery's non-prefork pools).
+summary: Added two root-open lifecycle rules to writing-integrations.md — open after connection providers are registered (validation runs at open), and open in every execution context the framework runs work in (e.g. Celery's non-prefork pools) — and, from a follow-up verification pass, four per-integration deployment caveats for narrower execution-context gaps that reproduce the same closed-root failure (ASGI mounted sub-apps/disabled lifespan on Starlette + FastAPI, taskiq's `run_receiver_task(run_startup=False)`, and FastStream's `TestBroker`/`TestApp` statement pairing).
 ---
 
 # Change: Document two root-open lifecycle traps for integration authors
 
-**Lane:** lightweight — docs-only, one file edited, no code or public-API change.
+**Lane:** lightweight — docs-only, five files edited, no code or public-API change.
 
 ## Goal
 
@@ -16,6 +16,13 @@ registers the request provider); and `modern-di-celery` opened the root only via
 `worker_process_init`, which Celery does not send for the gevent/eventlet/threads
 pools, so every task raised `ContainerClosedError` there. Both are reusable traps
 for future integration authors — capture the rules so they are not repeated.
+
+A follow-up verification pass reproduced four more, narrower instances of the
+same root cause — the root's open hook doesn't fire in some execution context,
+so the first unit of work raises `ContainerClosedError` — each specific to one
+integration's deployment shape rather than a general authoring rule. The
+maintainer chose documentation (a caveat on the affected page) as the
+treatment rather than a code change.
 
 ## Approach
 
@@ -31,12 +38,43 @@ Two new bullets in `docs/integrations/writing-integrations.md` under
    `worker_shutdown` alongside the per-process signals); idempotent open/close
    makes overlapping hooks safe.
 
+The second bullet's closing sentence ("if the framework offers no lifecycle
+hook at all, the root's open/close is the caller's to own — document it") now
+also names the most common instance of a hook simply not firing: ASGI's
+lifespan scope is optional — a mounted sub-application never receives it from
+its parent, and some deployments disable it outright (e.g. Mangum
+`lifespan="off"`).
+
+Four per-integration caveats, each a `!!! warning` admonition placed where the
+page shows the relevant setup call, following the precedent already set by
+`docs/integrations/aiogram.md`'s "Register handlers before startup" warning:
+
+- **Starlette / FastAPI** — `setup_di` only opens the root from the ASGI
+  lifespan event; a sub-app mounted under a parent, or a deployment that
+  disables lifespan (Mangum `lifespan="off"`), never fires it. Caveat: wire
+  `setup_di` on the top-level served app, or open the root manually.
+- **taskiq** — `taskiq.api.run_receiver_task(...)` defaults
+  `run_startup=False`, skipping the startup hook that opens the root. Caveat:
+  pass `run_startup=True` or open the root manually when embedding a receiver.
+- **FastStream** — `TestBroker` decides whether to run app `on_startup` hooks
+  by inspecting whether the test broker and `TestApp` share one `with`
+  statement; using the test broker alone skips `on_startup` and leaves the
+  root closed. Caveat: pair them in the same `with`/`async with`.
+
 No capability behavior changed, so no `architecture/` promotion — this is
-authoring guidance, not a contract move.
+authoring/deployment guidance, not a contract move.
 
 ## Files
 
-- `docs/integrations/writing-integrations.md` — two bullets added to Lifecycle rules.
+- `docs/integrations/writing-integrations.md` — two bullets added to Lifecycle
+  rules, plus one sentence on the ASGI-lifespan-is-optional instance.
+- `docs/integrations/starlette.md` — deployment warning: mounted sub-apps /
+  disabled lifespan.
+- `docs/integrations/fastapi.md` — same warning, FastAPI-specific wording.
+- `docs/integrations/taskiq.md` — deployment warning: `run_receiver_task`
+  defaults `run_startup=False`.
+- `docs/integrations/faststream.md` — new "Testing" section warning: pair test
+  broker with `TestApp` in the same `with` statement.
 
 ## Verification
 


### PR DESCRIPTION
Captures two production defects found while bringing the `modern-di-*` integrations onto 3.x — both invisible to their green suites, both now fixed and released — as authoring rules so future integrations don't repeat them.

Two bullets added to **Lifecycle rules** in `docs/integrations/writing-integrations.md`:

1. **Open the root *after* its connection providers are registered.** `open()` runs `validate()`, so a non-optional dependency on the connection object (e.g. `flask.Request`) fails if the provider isn't on the container yet. When the caller owns the lifecycle (Flask, gRPC), the order is `setup_di` then `open()`. (Surfaced by `modern-di-flask` 3.0.1.)
2. **Open the root in *every* execution context the framework runs work in.** Celery sends `worker_process_init` only for prefork/solo, not gevent/eventlet/threads — wire open/close to a hook that fires for all of them (`worker_init`/`worker_shutdown` alongside the per-process signals); idempotent open/close makes overlap safe. (Surfaced by `modern-di-celery` 3.0.1.)

Docs-only; no capability behavior change, so no `architecture/` promotion. `just check-planning` and `just lint-ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)