### PR TITLE
docs(roadmap): mark canonical-example on-ramp as shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,10 @@ Strawberry, Quart, RQ, APScheduler, Jobify, Flet, ag2.
 - **Optional OpenTelemetry instrumentation** of resolution and finalization.
 
 ### Docs & ecosystem
-- More recipes and example apps; comparison and migration guides.
+- **Canonical on-ramp per integration** — every official integration ships a
+  runnable `examples/` app plus a normalized README `Usage example:` link, so a
+  newcomer can adopt it in one sitting; **shipped**.
+- More recipes; comparison and migration guides.
 
 ## Explicitly not planned
 


### PR DESCRIPTION
Reflects the completed blessed-ready (A2) work in the roadmap: every official integration now ships a runnable `examples/` app + a normalized README `Usage example:` link. Marked **shipped** under Docs & ecosystem, using the same idiom as the benchmark-suite line.

Docs-only; `lint-ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)