### PR TITLE
docs(performance): re-measure the comparative table for 3.1.0

### DIFF
--- a/docs/introduction/performance.md
+++ b/docs/introduction/performance.md
@@ -30,20 +30,24 @@ rules: [`benchmarks/README.md`](https://github.com/modern-python/modern-di/blob/
 
 ## Results
 
-Measured 2026-07-17 on an Apple M2 (macOS), CPython 3.14.4, median-of-medians
-over 5 runs (run-to-run variation small). Rival versions: dishka 1.10.1,
-dependency-injector 4.49.1, that-depends 4.0.2, wireup 2.12.0. Reproduce with
-`just bench-compare`.
+Measured 2026-07-27 with modern-di 3.1.0 on an Apple M4 (macOS), CPython 3.14.6,
+median-of-medians over 5 runs (run-to-run variation small). Rival versions:
+dishka 1.10.1, dependency-injector 4.49.1, that-depends 4.0.2, wireup 2.12.0.
+Reproduce with `just bench-compare`.
+
+The previous publication of this table ran on an Apple M2 under CPython 3.14.4,
+so its absolute times are lower here for the machine, not only for the library —
+compare the ratio columns across revisions of this page, not the nanoseconds.
 
 Each cell is modern-di ÷ rival: below 1.0 (bold) means modern-di is faster,
 above 1.0 means slower.
 
 | Scenario | modern-di | vs dishka | vs dependency-injector | vs that-depends | vs wireup |
 |----------|-----------|-----------|------------------------|-----------------|-----------|
-| C1 transient | 541 ns | 1.30 | **0.81** | 1.08 | 1.77 |
-| C2 warm singleton | 282 ns | 1.17 | 4.58 | 3.37 | 2.95 |
-| C3 deep chain (6) | 1250 ns | 1.87 | **0.57** | **0.81** | 1.32 |
-| C4 request lifecycle | 31.0 µs | 1.02 | **0.18** | **0.75** | **0.69** |
+| C1 transient | 375 ns | 1.28 | **0.90** | 1.12 | 1.73 |
+| C2 warm singleton | 185 ns | 1.08 | 3.93 | 2.90 | 2.49 |
+| C3 deep chain (6) | 875 ns | 1.75 | **0.57** | **0.78** | 1.34 |
+| C4 request lifecycle | 29.2 µs | 1.00 | **0.20** | **0.78** | **0.69** |
 
 ## What the numbers show
 
@@ -51,14 +55,14 @@ above 1.0 means slower.
   slower on C2. dependency-injector's warm-singleton hit (C2) is a C-level slot
   read; modern-di's is a Python dict lookup behind an override guard.
 - Against `dishka` and `wireup` on the construction-heavy scenarios (C1
-  transient, C3 deep chain), modern-di is roughly 1.3–1.9x slower. Both inline
+  transient, C3 deep chain), modern-di is roughly 1.3–1.8x slower. Both inline
   dependency calls into `exec`-generated source, which removes the per-node
   function-call frame that modern-di keeps. modern-di does not generate code (a
   [documented non-goal](design-decisions.md#non-goals)), so this difference is
   expected rather than a regression.
-- On C4 (request lifecycle) modern-di is within run-to-run noise of `dishka`
-  (1.02) and faster than the other three. See the caveat below before reading
-  the C4 column as a resolve-speed comparison.
+- On C4 (request lifecycle) modern-di is level with `dishka` (1.00) and faster
+  than the other three. See the caveat below before reading the C4 column as a
+  resolve-speed comparison.
 
 **C4 is not a like-for-like resolve.** modern-di resolves the connection
 synchronously while finalizing it asynchronously; the other four force an awaited
@@ -75,6 +79,13 @@ override check, and cache lookup out of the per-call path and calls its
 dependencies' resolvers directly. The remaining gap to the codegen frameworks on
 C1 and C3 is the per-node call frame that `exec`-inlined source removes and
 modern-di keeps.
+
+3.1.0 removed one more frame from the top of every resolve: `resolve_provider`
+now opens with an inline `closed` check instead of an unconditional method call,
+and `build_child_container` carries no such check at all. Measured on the guard
+suite against 3.0.0 on one machine, that is worth roughly 5–11% on C1- and
+C2-shaped resolves and on child construction; the deeper scenarios, which run
+through compiled resolvers where the check was already inline, did not move.
 
 ## Reproduce it yourself
 

--- a/planning/changes/2026-07-27.01-refresh-performance-numbers.md
+++ b/planning/changes/2026-07-27.01-refresh-performance-numbers.md
@@ -1,0 +1,73 @@
+---
+summary: Re-measured the comparative benchmark table on the published methodology (median-of-medians over 5 runs) with modern-di 3.1.0 and refreshed docs/introduction/performance.md; no verdict changes, and the machine differs from the previous publication so absolute times are not comparable across revisions.
+---
+
+# Change: Refresh the published performance numbers for 3.1.0
+
+**Lane:** lightweight — docs-only, one page plus this bundle, no code or
+public-API change.
+
+## Goal
+
+`docs/introduction/performance.md` published numbers measured 2026-07-17,
+i.e. against 3.0.0. 3.1.0 changed the top of the resolve path (`resolve_provider`
+opens with an inline `closed` test rather than an unconditional
+`_raise_if_closed()` call, and `build_child_container` lost its check entirely),
+so the table needed re-measuring rather than carrying pre-release numbers.
+
+## Approach
+
+Re-ran `just bench-compare` five times and took the median-of-medians per
+scenario, which is the methodology the page already states. Rival pins are
+unchanged (dishka 1.10.1, dependency-injector 4.49.1, that-depends 4.0.2,
+wireup 2.12.0), so this is a refresh of modern-di's own column and the ratios
+derived from it, not a rival bump.
+
+**No verdict changed** — nothing crossed 1.0 in either direction. The ratios
+moved modestly in modern-di's favour on C1/C2 (e.g. vs dependency-injector on
+C2: 4.58 → 3.93; vs dishka on C1: 1.30 → 1.28) and were flat on C3/C4. Two prose
+figures were tightened to match: the dishka/wireup construction-heavy range
+(1.3–1.9x → 1.3–1.8x) and the C4-vs-dishka figure (1.02 → 1.00).
+
+Two honesty notes were added to the page rather than left implicit:
+
+- The previous publication ran on an Apple M2 / CPython 3.14.4; this one on an
+  Apple M4 / CPython 3.14.6. Absolute times therefore drop for the machine as
+  well as the library — including on C3, which a same-machine guard-tier
+  comparison of 3.0.0 vs 3.1.0 showed did *not* move. The page now says to
+  compare ratio columns across revisions, not nanoseconds.
+- "Why the results look this way" gained the 3.1.0 frame removal, attributed to
+  the guard-suite measurement that isolates it rather than to this cross-machine
+  table.
+
+The guard-tier figures behind those claims: run against the 3.0.0 tag in a
+scratch worktree, in both orderings to rule out thermal drift. Reproducible
+wins were `g1_transient_resolve` −10.9%/−10.9%, `g2_cached_resolve`
+−6.6%/−5.3%, `g6_build_child_container` −8.0%/−5.4%,
+`g6b_build_child_container_auto_scope` −13.3%/−7.0%, and
+`g14_concurrent_cached_hit` −5.5% to −7.4%. No scenario regressed in both
+orderings; `g3`/`g4`/`g9` moved in one ordering only and are noise, which is
+consistent with their running through compiled resolvers whose guard was
+already inline on both versions.
+
+## Files
+
+- `docs/introduction/performance.md` — results table, methodology line, the
+  cross-machine note, two prose figures, and the 3.1.0 paragraph in "Why the
+  results look this way".
+
+## Non-goals
+
+- Not bumping rival pins: that would move ratios for reasons unrelated to 3.1
+  and belongs in its own change.
+- Not adding the C5 (cold first resolve) and C6 (context) scenarios, which the
+  comparative suite runs but the page has never published. Worth doing —
+  C5 in particular is where the codegen frameworks pay their startup cost — but
+  it is a content expansion, not a numbers refresh.
+
+## Verification
+
+- [x] `just bench-compare` × 5, median-of-medians per scenario.
+- [x] `uv run mkdocs build --strict` — clean.
+- [x] `just lint-ci` — clean.
+- [x] `just check-planning` — clean.


### PR DESCRIPTION
The published table was measured 2026-07-17, i.e. against 3.0.0. 3.1.0 changed the top of the resolve path (`resolve_provider` opens with an inline `closed` test rather than an unconditional `_raise_if_closed()` call; `build_child_container` lost its check entirely), so it needed re-measuring. Bundle: [planning/changes/2026-07-27.01-refresh-performance-numbers.md](planning/changes/2026-07-27.01-refresh-performance-numbers.md).

Five runs of `just bench-compare`, median-of-medians per scenario — the methodology the page already states. Rival pins unchanged (dishka 1.10.1, dependency-injector 4.49.1, that-depends 4.0.2, wireup 2.12.0), so this refreshes modern-di's column and the ratios derived from it, not a rival bump.

**No verdict changed** — nothing crossed 1.0 either way. Ratios moved modestly in modern-di's favour on C1/C2 (vs dependency-injector on C2: 4.58 → 3.93; vs dishka on C1: 1.30 → 1.28) and were flat on C3/C4. Two prose figures were tightened to match: the dishka/wireup construction-heavy range (1.3–1.9x → 1.3–1.8x) and C4-vs-dishka (1.02 → 1.00).

Two things I added rather than left implicit:

- **The machine changed** (Apple M2 / CPython 3.14.4 → M4 / 3.14.6), so absolute times drop for the hardware as well as the library — including on C3, which a same-machine guard-tier comparison of 3.0.0 vs 3.1.0 showed did **not** move. The page now says to compare ratio columns across revisions of the page, not nanoseconds. Without that note the diff reads as a 3.1 speedup on a scenario 3.1 didn't touch.
- **"Why the results look this way"** gained the 3.1.0 frame removal, attributed to the guard-suite measurement that isolates it rather than to this cross-machine table.

Guard-tier evidence for that claim, run against the `3.0.0` tag in a scratch worktree **in both orderings** to rule out thermal drift: `g1_transient_resolve` −10.9%/−10.9%, `g2_cached_resolve` −6.6%/−5.3%, `g6_build_child_container` −8.0%/−5.4%, `g6b` −13.3%/−7.0%, `g14_concurrent_cached_hit` −5.5% to −7.4%. Nothing regressed in both orderings, and `g3`/`g4`/`g9` moved in one ordering only — consistent with their running through compiled resolvers whose guard was already inline on both versions.

Deliberately out of scope, noted in the bundle: bumping rival pins, and publishing the C5/C6 scenarios the comparative suite already runs but this page has never shown.

`mkdocs build --strict`, `just lint-ci` and `just check-planning` all clean. Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)