### PR TITLE
fix(container): stop every container being a reference cycle

### DIFF
--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -102,8 +102,11 @@ Rules:
   (see [validation.md](validation.md)). Building a child off a closed parent therefore skips nothing
   that would otherwise have run.
 
-The child gets its own, independent `_scope_map` dict that includes all ancestors plus itself,
-enabling `find_container(scope)` to walk up to any ancestor scope in O(1).
+The child gets its own, independent `_scope_map` dict holding all of its ancestors, enabling
+`find_container(scope)` to reach any ancestor scope in O(1). The map never contains the container
+itself: a `scope: self` entry would make every container a reference cycle, so no container could
+be freed by reference counting and each would wait for a generational GC pass. `find_container`
+short-circuits on its own scope before consulting the map, so the self-entry was never read.
 
 ## Registry sharing
 

--- a/architecture/scopes.md
+++ b/architecture/scopes.md
@@ -35,15 +35,19 @@ the base one-liner with no breadcrumb prepended.
 
 ## How the container locates the right-scope container
 
-Each `Container` maintains a `scope_map: dict[IntEnum, Container]`. When a root container is created, the map is
-`{scope: self}`. Each child container extends the map: `{**parent.scope_map, child_scope: child}`.
+Each `Container` maintains a `scope_map: dict[IntEnum, Container]` of its **ancestors**. A root container's
+map is empty; each child extends its parent's: `{**parent.scope_map, parent_scope: parent}`. A container is
+never in its own map — that self-reference would make every container a reference cycle, leaving each one to
+be reclaimed by the garbage collector rather than by reference counting.
 
 `Container.find_container(scope)` performs the lookup:
 
-1. If `scope` is in `scope_map`, return the corresponding container immediately — no tree walk needed.
-2. If `scope` is not in `scope_map` and `scope > self.scope`, raise `ScopeNotInitializedError` (the required
+1. If `scope` is this container's own scope, return `self` — checked first, before the map, which is why the
+   map does not need a self-entry.
+2. If `scope` is in `scope_map`, return the corresponding container immediately — no tree walk needed.
+3. If `scope` is not in `scope_map` and `scope > self.scope`, raise `ScopeNotInitializedError` (the required
    child container has not been built yet).
-3. If `scope` is not in `scope_map` and `scope <= self.scope`, raise `ScopeSkippedError` (the scope was
+4. If `scope` is not in `scope_map` and `scope <= self.scope`, raise `ScopeSkippedError` (the scope was
    never present in this chain).
 
 The `scope_map` is built incrementally at construction time, so lookups are O(1). There is no runtime

--- a/docs/providers/advanced-api.md
+++ b/docs/providers/advanced-api.md
@@ -28,8 +28,9 @@ inspect or iterate all providers declared on a group hierarchy.
 
 ### `find_container(scope)`
 
-`find_container(scope)` walks `_scope_map` and returns the container registered at
-`scope`; raises `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
+`find_container(scope)` returns `self` immediately when `scope` is the resolving container's own
+scope; otherwise it looks `scope` up in `_scope_map` and returns the ancestor registered there,
+raising `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
 It is the primitive the compiled resolvers use to locate the container at a provider's
 scope when it differs from the resolving container's.
 
@@ -42,8 +43,11 @@ scope when it differs from the resolving container's.
 
 - **`parent_container`** — constructor kwarg and slot; the direct parent of a child container,
   or `None` for a root. Passing a `scope ≤ parent.scope` raises `InvalidChildScopeError`.
-- **`_scope_map`** — `dict[IntEnum, Container]` mapping every scope in the chain to its
-  container; built at construction time and inherited (plus the new scope) by each child.
+- **`_scope_map`** — `dict[IntEnum, Container]` mapping each **ancestor's** scope to its container;
+  built at construction time, a child inheriting its parent's map plus the parent itself. A root's
+  map is empty. The container is never in its own map — that self-reference would make every
+  container a reference cycle — and `find_container` never needs it, since it short-circuits on
+  its own scope first.
 - **`_lock`** — a `threading.RLock` instance, or `None` when the container was created with
   `use_lock=False`. A cached `Factory`'s compiled resolver hands it to `CacheItem.get_or_create`,
   which gates the cold-miss build so one instance is created per cache key.

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -118,8 +118,13 @@ class Container:
         self.closed = False
         self.scope = scope
         self.parent_container = parent_container
+        # Ancestors only, never self: a `scope: self` entry would make every container a reference
+        # cycle, so none could be freed by refcounting. `find_container` short-circuits on its own
+        # scope before consulting this map, so the self-entry was never read anyway.
         self._scope_map: dict[enum.IntEnum, typing_extensions.Self] = (
-            {**parent_container._scope_map, scope: self} if parent_container else {scope: self}  # noqa: SLF001
+            {**parent_container._scope_map, parent_container.scope: parent_container}  # noqa: SLF001
+            if parent_container
+            else {}
         )
         self.cache_registry = CacheRegistry()
         self.context_registry = ContextRegistry(context=context or {})

--- a/planning/changes/2026-07-27.03-container-reference-cycles.md
+++ b/planning/changes/2026-07-27.03-container-reference-cycles.md
@@ -1,5 +1,5 @@
 ---
-summary: Build `_scope_map` from the parent rather than from self, so a container no longer references itself — removing the reference cycle that makes every container wait for the GC instead of the refcounter.
+summary: Built `_scope_map` from the parent rather than from self, so no container references itself — roots, children and full 5-deep chains all go from cyclic garbage to zero work for the collector. Isolated construction is unchanged within noise; the win is the realistic build-and-drop path, ~36% faster with GC enabled. `find_container` was unaffected, as predicted: it short-circuits on its own scope before consulting the map.
 ---
 
 # Design: Stop every container being a reference cycle

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,9 +1,11 @@
 import copy
 import dataclasses
+import gc
 import inspect
 import os
 import typing
 import warnings
+import weakref
 
 import pytest
 
@@ -614,9 +616,51 @@ def test_private_lock_and_scope_map_back_the_machinery() -> None:
     assert root._lock.acquire()  # reentrant  # noqa: SLF001
     root._lock.release()  # noqa: SLF001
     root._lock.release()  # noqa: SLF001
-    # child inherits the parent's scope map plus its own scope
-    assert set(child._scope_map) == {Scope.APP, Scope.REQUEST}  # noqa: SLF001
+    # The map holds ancestors only — never the container itself, which would be a reference cycle.
+    # `find_container` short-circuits on its own scope, so a self-entry would be dead weight.
+    assert set(child._scope_map) == {Scope.APP}  # noqa: SLF001
     assert child._scope_map[Scope.APP] is root  # noqa: SLF001
+    assert root._scope_map == {}  # noqa: SLF001
+    assert child.find_container(Scope.REQUEST) is child  # own scope still resolves
+    assert child.find_container(Scope.APP) is root
+
+
+def test_closed_children_are_freed_without_the_cycle_collector() -> None:
+    # A container must not reference itself: a self-reference makes every container cyclic garbage,
+    # so a request-scoped app produces work for the collector at its request rate. Asserts the
+    # property that matters (reclaimable by refcount alone), not the shape of the map behind it.
+    class Sentinel:  # rides in each child's context so liveness is observable
+        pass
+
+    freed = 0
+
+    def _count(_: object) -> None:
+        nonlocal freed
+        freed += 1
+
+    n_children = 100
+    root = Container(scope=Scope.APP)
+    root.open()
+    gc.collect()
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        children = []
+        for _ in range(n_children):
+            sentinel = Sentinel()
+            child = root.build_child_container(scope=Scope.REQUEST, context={Sentinel: sentinel})
+            weakref.finalize(sentinel, _count, None)
+            child.open()
+            child.close_sync()
+            children.append(child)
+        del children, child, sentinel
+        # Both halves matter: the children really did become garbage (freed == n_children), AND
+        # refcounting alone reclaimed them, leaving the cycle collector nothing to do.
+        assert freed == n_children
+        assert gc.collect() == 0
+    finally:
+        if was_enabled:
+            gc.enable()
 
 
 def test_use_lock_false_yields_no_private_lock() -> None:


### PR DESCRIPTION
Implements [`planning/changes/2026-07-27.03-container-reference-cycles.md`](planning/changes/2026-07-27.03-container-reference-cycles.md),
from the audit in [`planning/audits/2026-07-27-container-reference-cycles-report.md`](planning/audits/2026-07-27-container-reference-cycles-report.md).

## The defect

`Container.__init__` seeded `_scope_map` with `scope: self`. A container referenced
its own dict and the dict referenced the container, so **no container could ever be freed
by reference counting** — every one waited for a generational GC pass. A request-scoped
application produced cyclic garbage at exactly its request rate.

`find_container` short-circuits on its own scope *before* consulting the map, so the
self-entry was never actually read. Seeding the map from the parent instead removes the
cycle and changes nothing about lookup.

```python
# before
{**parent._scope_map, scope: self} if parent else {scope: self}
# after
{**parent._scope_map, parent.scope: parent} if parent else {}
```

## Effect

| | before | after |
|---|---|---|
| 100 closed REQUEST children | 792 objects reclaimable only by GC | **0** |
| 100 closed roots | 2300 | **0** |
| 100 full APP→SESSION→REQUEST→ACTION→STEP chains | 5500 | **0** |
| build-and-drop a child, GC enabled | ~849 ns | **~542 ns** (−36%) |

Isolated construction is unchanged within noise (~500 vs ~506 ns, GC off, children
retained) — an earlier draft of this commit claimed ~2% from the smaller dict; review
refuted it as noise and it has been corrected. The win is the collector no longer having
to reclaim what refcounting now frees.

`find_container` is unchanged on both its own-scope and ancestor paths.

## Verification

Failing test first (`assert 792 == 0`), and it still goes red against `main` after being
hardened to also assert the children genuinely became garbage — so it cannot pass by them
never being collectable.

Review independently proved behavioural equivalence exhaustively: all 31 strictly-increasing
scope chains plus 15 chains over a non-contiguous custom `IntEnum`, probing every scope at
every level — identical results, including both error paths and skipped-scope chains.

`just test-ci` 450 passed at 100% coverage · `just lint-ci` clean · `just docs-build` clean.

`architecture/containers.md`, `architecture/scopes.md` and `docs/providers/advanced-api.md`
updated in the same PR, per the repo's promotion rule.

## Compatibility

`scope_map` is a deprecated public property whose contents change (it no longer contains the
container itself). Review confirmed **zero** references to it across all 12 sibling
`modern-di-*` integration repos. Worth a line in the next release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)