### PR TITLE
bench: publish C6, the per-request context scenario

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -104,25 +104,27 @@ timed as a batch of K=100 cycles per loop entry.
 | dependency-injector 4.49.1 | `Factory` | `Singleton` | async-gen `Resource`, `init/shutdown_resources` | await |
 | wireup 2.12.0 | `injectable(transient)` + scope | `injectable` (singleton default) | async-gen `injectable(scoped)`, async container | await |
 
-**Fixed timing shape for the published scenarios (C1-C4).** pytest-benchmark auto-calibrates
+**Fixed timing shape for the published scenarios (C1-C4, C6).** pytest-benchmark auto-calibrates
 `iterations` per benchmark per run, which in practice left some cells at `iterations=1` -- each
 median carrying a whole per-round timer pair and snapped to the platform timer's ~42 ns grid --
 while others ran at 20-100 and amortized both away. A published ratio must not divide a
-grid-snapped number by an unsnapped one, so C1-C4 use `benchmark.pedantic` at a shape pinned
-**identically in all five files**: C1-C3 at `rounds=200, iterations=1000`, C4 at
+grid-snapped number by an unsnapped one, so C1-C4 and C6 use `benchmark.pedantic` at a shape
+pinned **identically in all five files**: C1-C3 and C6 at `rounds=200, iterations=1000`, C4 at
 `rounds=100, iterations=3` (C4's callable is already a batch of `K = 100` cycles, so a few
 iterations put the timer pair below 0.01% of the cell). `warmup_rounds=1` replaces the warm-up
-calibration used to provide; every other setup stays outside the timed call exactly as before.
+calibration used to provide; every other setup stays outside the timed call exactly as before. (C6's
+later promotion did change what its timed call contains — see its caveat below.)
 `tests/test_bench_report.py` parses the five files and fails if a published scenario drops off
-the pinned shape or the numbers drift apart. C5/C6 are not published on the page and stay on
+the pinned shape or the numbers drift apart. C5 is not published on the page and stays on
 auto-calibration.
 
 Levelling this axis moved published cells **in both directions**, and the shift is not uniform:
 cells that had been at `iterations=1` shed anywhere from ~10 ns (dependency-injector C1) to
 ~50 ns (dishka C1, C3), and one -- modern-di's by-reference C3 -- rose by ~12 ns. Because dishka
 shed proportionally more than modern-di did, modern-di's C1 and C3 ratios against dishka got
-*worse*, not better. Netted over the sixteen published ratio cells, eight moved against
-modern-di, seven for it and one was unchanged.
+*worse*, not better. Netted over the sixteen ratio cells published at the time, eight moved against
+modern-di, seven for it and one was unchanged. (C6 was promoted later, so the table now
+carries twenty.)
 C4's estimator also shifted: a round is now the mean of `iterations` batches, so a right-skewed
 distribution reports nearer its mean -- modern-di's C4 mean was 24% above its median at
 `iterations=1`, and its published per-request figure rose accordingly. The mean itself did not
@@ -172,7 +174,19 @@ a wide margin. C5 aligns validation off (modern-di never validates unless
 isolates build+compile.
 
 **Caveat — C6 is sync for all five** (a clean sync-vs-sync comparison, unlike
-C4), timing the per-request "supply value + resolve" cycle. Two structural
+C4), timing the per-request "supply value + resolve" cycle. It is **published**, against all
+four rivals in one table, for C4's reason alone: modern-di resolves by reference throughout the
+body and has no by-type C6 variant, so a split would leave that half mixed-basis. The rivals do
+line up with the C1-C3 grouping here — that-depends resolves its C6 handler by reference, as it
+does on C1-C3; only the *supply* of the request value is type-keyed, which is not the axis the
+tables split on.
+
+modern-di's C6 body was corrected in two ways when it was published, and they pull against each
+other. It calls no `open()` — a freshly built child is already open as of 3.1, so timing one
+charged a redundant lock acquire (81 ns, ~6% of the cell) with no counterpart in any rival body.
+It now *does* close the child, because all four rivals exit a scope inside their timed bodies and
+this one did not: that teardown is ~110 ns, **larger** than the `open()` removed, so on net the
+correction moved modern-di's C6 cells against it, not for it. Two structural
 notes: dependency-injector injects **by reference** (`providers.Dependency` +
 `.override()`), not by type — a structural analog, not an equivalent; wireup
 requires the runtime type **registered** as a scoped injectable with a raising

--- a/benchmarks/comparative/test_dependency_injector.py
+++ b/benchmarks/comparative/test_dependency_injector.py
@@ -12,7 +12,7 @@ from dependency_injector import containers, providers
 
 _BATCH = 100
 
-# Pinned timing shape for C1-C4; must match every other comparative file (see test_modern_di.py).
+# Pinned timing shape for C1-C4 and C6; must match every other comparative file (see test_modern_di.py).
 _ROUNDS = 200
 _ITERATIONS = 1000
 _C4_ROUNDS = 100
@@ -183,6 +183,6 @@ def test_c6_context_dependency_injector(benchmark):
         with container.request.override(RequestObj()):
             return container.handler()
 
-    result = benchmark(_one_request)
+    result = benchmark.pedantic(_one_request, rounds=_ROUNDS, iterations=_ITERATIONS, warmup_rounds=1)
     assert isinstance(result, Handler)
     assert isinstance(result.request, RequestObj)

--- a/benchmarks/comparative/test_dishka.py
+++ b/benchmarks/comparative/test_dishka.py
@@ -13,7 +13,7 @@ from dishka import Provider, Scope, from_context, make_async_container, make_con
 
 _BATCH = 100
 
-# Pinned timing shape for C1-C4; must match every other comparative file (see test_modern_di.py).
+# Pinned timing shape for C1-C4 and C6; must match every other comparative file (see test_modern_di.py).
 _ROUNDS = 200
 _ITERATIONS = 1000
 _C4_ROUNDS = 100
@@ -170,7 +170,7 @@ def test_c6_context_dishka(benchmark):
             return req.get(Handler)
 
     try:
-        result = benchmark(_one_request)
+        result = benchmark.pedantic(_one_request, rounds=_ROUNDS, iterations=_ITERATIONS, warmup_rounds=1)
     finally:
         container.close()
     assert isinstance(result, Handler)

--- a/benchmarks/comparative/test_modern_di.py
+++ b/benchmarks/comparative/test_modern_di.py
@@ -7,9 +7,12 @@ Three fairness rules this file must keep:
 - C1-C3 exist in BOTH by-reference (`resolve_provider`) and by-type (`resolve`) form. dishka and
   wireup have no by-reference API; that-depends and dependency-injector are by-reference. No single
   variant is fair to both halves of the rival set, so the table compares each against its match.
-- The 3.x lifecycle is explicit: `open()` on the root and per request, as the guard tier and the
-  docs both do.
-- Every published scenario (C1-C4) is timed with `benchmark.pedantic` at a pinned
+- A container is open from construction (3.1), so no *timed* body of a published scenario calls
+  `open()`: it would time a redundant lock acquire against rivals that need a real scope entry.
+  (Unpublished C5 times a cold build and keeps its `open()`, which is part of what it measures.) Per-request work is
+  build child -> resolve -> close, and every timed body closes what it opened, because all four
+  rivals exit a scope inside theirs.
+- Every published scenario (C1-C4, C6) is timed with `benchmark.pedantic` at a pinned
   `rounds x iterations`, identical in all five files. See the note on the constants below.
 """
 
@@ -20,7 +23,7 @@ from modern_di import Container, Group, Scope, providers
 
 _BATCH = 100
 
-# Pinned timing shape for the published scenarios (C1-C4). pytest-benchmark's auto-calibration
+# Pinned timing shape for the published scenarios (C1-C4, C6). pytest-benchmark's auto-calibration
 # picks `iterations` per benchmark, so one cell can land at iterations=1 while the cell it is
 # divided by lands at 25: the first carries the whole per-round timer pair and sits on the
 # platform timer's ~42 ns grid, the second amortizes both away. A published ratio must not divide
@@ -169,7 +172,6 @@ def test_c4_request_lifecycle_modern_di(benchmark):
 
     async def _one_request() -> Connection:
         req = app.build_child_container(scope=Scope.REQUEST)
-        req.open()
         conn = req.resolve_provider(LifecycleGroup.conn)
         await req.close_async()
         return conn
@@ -226,10 +228,11 @@ def test_c6_context_modern_di(benchmark):
 
     def _one_request():
         req = app.build_child_container(scope=Scope.REQUEST, context={RequestObj: RequestObj()})
-        req.open()
-        return req.resolve_provider(ContextGroup.handler)
+        handler = req.resolve_provider(ContextGroup.handler)
+        req.close_sync()
+        return handler
 
-    result = benchmark(_one_request)
+    result = benchmark.pedantic(_one_request, rounds=_ROUNDS, iterations=_ITERATIONS, warmup_rounds=1)
     assert isinstance(result, Handler)
     assert isinstance(result.req, RequestObj)
     assert isinstance(result.dep, AppDep)

--- a/benchmarks/comparative/test_that_depends.py
+++ b/benchmarks/comparative/test_that_depends.py
@@ -14,7 +14,7 @@ from that_depends.providers.context_resources import fetch_context_item_by_type
 
 _BATCH = 100
 
-# Pinned timing shape for C1-C4; must match every other comparative file (see test_modern_di.py).
+# Pinned timing shape for C1-C4 and C6; must match every other comparative file (see test_modern_di.py).
 _ROUNDS = 200
 _ITERATIONS = 1000
 _C4_ROUNDS = 100
@@ -185,6 +185,6 @@ def test_c6_context_that_depends(benchmark):
         with container_context(global_context={"request": ro}):
             return ContextContainer.handler.resolve_sync()
 
-    result = benchmark(_one_request)
+    result = benchmark.pedantic(_one_request, rounds=_ROUNDS, iterations=_ITERATIONS, warmup_rounds=1)
     assert isinstance(result, Handler)
     assert isinstance(result.request_obj, RequestObj)

--- a/benchmarks/comparative/test_wireup.py
+++ b/benchmarks/comparative/test_wireup.py
@@ -14,7 +14,7 @@ import wireup
 
 _BATCH = 100
 
-# Pinned timing shape for C1-C4; must match every other comparative file (see test_modern_di.py).
+# Pinned timing shape for C1-C4 and C6; must match every other comparative file (see test_modern_di.py).
 _ROUNDS = 200
 _ITERATIONS = 1000
 _C4_ROUNDS = 100
@@ -183,6 +183,6 @@ def test_c6_context_wireup(benchmark):
         with container.enter_scope({RequestObj: RequestObj()}) as scope:
             return scope.get(CtxHandler)
 
-    result = benchmark(_one_request)
+    result = benchmark.pedantic(_one_request, rounds=_ROUNDS, iterations=_ITERATIONS, warmup_rounds=1)
     assert isinstance(result, CtxHandler)
     assert isinstance(result.req, RequestObj)

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -4,11 +4,14 @@ The tables are generated, never hand-assembled: `main()` runs the comparative su
 its isolated environment and `build_table()` reduces the runs to markdown. Split so the reduction
 is unit-testable without running a benchmark (see tests/test_bench_report.py).
 
-Three tables, because no single rival set fits every scenario: dishka and wireup expose only
+Four tables, because no single rival set fits every scenario: dishka and wireup expose only
 by-type lookup, that-depends and dependency-injector only by-reference. Each C1-C3 table compares
 one modern-di variant against the rivals whose API matches it, so no published cell is ever n/a.
-C4 does not split this way: modern-di resolves by reference throughout its C4 body, so that table
-compares it against all four rivals regardless of which lookup API they natively expose.
+C4 and C6 do not split this way: modern-di resolves by reference throughout both bodies, so those
+tables compare it against all four rivals regardless of which lookup API they natively expose.
+C6 is one table for C4's reason alone: modern-di has no by-type C6 variant, so a split would leave
+that half mixed-basis. The rivals do line up with the C1-C3 grouping here — that-depends resolves
+its C6 handler by reference, as it does on C1-C3.
 
 Ratios are **paired per run**: one run measures both sides under the same machine state, so the
 published statistic is the median of the per-run ratios, not a ratio of two independently-reduced
@@ -84,6 +87,11 @@ TABLES = (
         "Request lifecycle (batched, published per request)",
         BY_REFERENCE + BY_TYPE,
         (Row("C4 request lifecycle", "c4_request_lifecycle", "c4_request_lifecycle", divisor=BATCH),),
+    ),
+    Table(
+        "Per-request context",
+        BY_REFERENCE + BY_TYPE,
+        (Row("C6 context", "c6_context", "c6_context"),),
     ),
 )
 

--- a/docs/introduction/performance.md
+++ b/docs/introduction/performance.md
@@ -13,7 +13,7 @@ Cython-compiled core (dependency-injector), and one pure-Python framework
 
 ## What is measured
 
-Four scenarios, each the smallest graph that isolates one cost, run with
+Five scenarios, each the smallest graph that isolates one cost, run with
 [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/) in an isolated
 environment with pinned rival versions:
 
@@ -23,6 +23,7 @@ environment with pinned rival versions:
 | C2 | Singleton resolve, warm cache | cache-hit lookup |
 | C3 | Deep chain, depth 6 | per-edge wiring |
 | C4 | Request lifecycle: enter scope → resolve → async-finalize on exit | whole per-request cost |
+| C6 | Per-request context: supply a runtime value by type, resolve a handler that needs it plus an app-scoped dep | the request-injection path every integration uses |
 
 Each framework uses its own idiomatic request-scope and resource-teardown
 spelling, not modern-di's names forced onto it. Full per-framework mapping and
@@ -33,17 +34,23 @@ C1-C3 are published twice for modern-di: once resolved by provider reference
 lookup; that-depends and dependency-injector only by-reference. Each C1-C3 table compares one
 modern-di variant against the rivals whose API matches it, because a single column would
 flatter modern-di against half the set. By-type resolution adds a fixed dict-lookup cost on top
-of `resolve_provider` — 47 ns on C1, 43 ns on C2 and 45 ns on C3 in the cells below, the same
-absolute cost each time but 16%, 23% and 6% of the respective baselines.
+of `resolve_provider` — 46 ns on C1, 43 ns on C2 and 48 ns on C3 in the cells below, close to the
+same absolute cost each time but 15%, 23% and 6% of the respective baselines.
 
 C4 does not split this way: modern-di's C4 body resolves **by reference** throughout, while
 dishka and wireup can only be measured by type. That asymmetry cuts **against** modern-di's
-C4 ratios, not for them — levelling it would add the ~44 ns by-type lookup to modern-di's cell
-and move the dishka ratio below from 1.30 to about 1.33. The C1-C3 leveling does not apply to C4.
+C4 ratios, not for them — levelling it would add the ~46 ns by-type lookup to modern-di's cell
+and move the dishka ratio below from 1.26 to about 1.29. The C1-C3 leveling does not apply to C4.
+
+C6 does not split either, for the same reason: modern-di's C6 body resolves by reference and there
+is no by-type C6 variant to pair against dishka and wireup, so a split would leave that half of the
+table mixed-basis. The rivals themselves do line up with the C1-C3 grouping here — that-depends
+resolves its C6 handler by reference exactly as it does on C1-C3 — so it is modern-di's missing
+variant, not the rivals' idioms, that keeps C6 in one table against all four.
 
 Every published cell is timed at the same `rounds × iterations` for every framework
-(C1-C3 at 200 × 1000, C4 at 100 × 3), so no cell carries per-round timer overhead or sits on the
-platform timer's ~42 ns grid while the cell it is divided by does not. See
+(C1-C3 and C6 at 200 × 1000, C4 at 100 × 3), so no cell carries per-round timer overhead or sits
+on the platform timer's ~42 ns grid while the cell it is divided by does not. See
 [`benchmarks/README.md`](https://github.com/modern-python/modern-di/blob/main/benchmarks/README.md)
 for why that matters and which cells it moved.
 
@@ -66,64 +73,80 @@ as a verdict.
 
 | Scenario | modern-di | vs dependency-injector | vs that-depends |
 |---|---|---|---|
-| C1 transient | 303 ns ±2.3% | **0.83** ±2.9% | **0.98** ±2.7% |
-| C2 warm singleton | 187 ns ±0.8% | 3.92 ±1.4% | 2.80 ±1.9% |
-| C3 deep chain (6) | 801 ns ±2.1% | **0.57** ±0.7% | **0.75** ±0.7% |
+| C1 transient | 301 ns ±1.5% | **0.83** ±0.8% | **0.97** ±1.7% |
+| C2 warm singleton | 186 ns ±1.1% | 3.88 ±0.6% | 2.80 ±1.9% |
+| C3 deep chain (6) | 804 ns ±3.0% | **0.59** ±2.4% | **0.76** ±4.5% |
 
-_Across-run IQR of each side's own median (5 runs): modern-di ≤2.3%, rivals ≤2.5%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+_Across-run IQR of each side's own median (5 runs): modern-di ≤3.0%, rivals ≤1.8%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
 
 ### By-type resolution
 
 | Scenario | modern-di | vs dishka | vs wireup |
 |---|---|---|---|
-| C1 transient | 347 ns ±1.5% | 1.46 ±0.8% | 1.62 ±2.0% |
-| C2 warm singleton | 228 ns ±2.0% | 1.31 ±1.0% | 3.03 ±1.3% |
-| C3 deep chain (6) | 845 ns ±1.5% | 1.88 ±0.9% | 1.33 ±1.1% |
+| C1 transient | 347 ns ±0.8% | 1.45 ±1.3% | 1.62 ±1.2% |
+| C2 warm singleton | 229 ns ±1.1% | 1.32 ±2.0% | 3.02 ±1.6% |
+| C3 deep chain (6) | 852 ns ±2.7% | 1.92 ±1.9% | 1.32 ±3.4% |
 
-_Across-run IQR of each side's own median (5 runs): modern-di ≤2.0%, rivals ≤1.9%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+_Across-run IQR of each side's own median (5 runs): modern-di ≤2.7%, rivals ≤2.5%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
 
 ### Request lifecycle (batched, published per request)
 
 | Scenario | modern-di | vs dependency-injector | vs that-depends | vs dishka | vs wireup |
 |---|---|---|---|---|---|
-| C4 request lifecycle | 1.97 µs ±1.7% | **0.02** ±1.2% | **0.21** ±1.1% | 1.30 ±1.2% | **0.13** ±1.0% |
+| C4 request lifecycle | 1.93 µs ±3.0% | **0.02** ±3.8% | **0.20** ±1.3% | 1.26 ±2.2% | **0.13** ±2.1% |
 
-_Across-run IQR of each side's own median (5 runs): modern-di ≤1.7%, rivals ≤1.8%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+_Across-run IQR of each side's own median (5 runs): modern-di ≤3.0%, rivals ≤0.8%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+
+### Per-request context
+
+| Scenario | modern-di | vs dependency-injector | vs that-depends | vs dishka | vs wireup |
+|---|---|---|---|---|---|
+| C6 context | 1.45 µs ±2.4% | **0.59** ±2.5% | **0.65** ±2.0% | 1.69 ±3.8% | 1.42 ±3.6% |
+
+_Across-run IQR of each side's own median (5 runs): modern-di ≤2.4%, rivals ≤3.2%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
 
 ## What the numbers show
 
 - Against `dependency-injector`, modern-di is faster by reference on C1 (**0.83**) and
-  C3 (**0.57**), and far faster on the batched C4 request lifecycle (**0.02**).
+  C3 (**0.59**), and far faster on the batched C4 request lifecycle (**0.02**).
   dependency-injector's C4 body calls `init_resources()`/`shutdown_resources()` every cycle
   in addition to resolving; the suite doesn't decompose how much of its per-request cost is
   that lifecycle work versus the resolve itself, so C4 should be read as a whole-lifecycle
   comparison, not an isolated resolve (see the caveat below). dependency-injector is faster
-  on C2 warm-singleton (3.92, an implied ~48 ns cache hit against modern-di's 187 ns): its
+  on C2 warm-singleton (3.88, an implied ~48 ns cache hit against modern-di's 186 ns): its
   hit is a C-level slot read on a Cython-compiled core, where modern-di's is a Python dict
   lookup behind an override guard.
-- Against `that-depends`, modern-di and that-depends are **tied** by reference on C1: the cell
-  reads **0.98**, but its across-run spread is ±2.7%, which covers 1.00 — do not read that
-  bold as a win. modern-di is faster on C3 (**0.75**) and far faster on C4 (**0.21**).
-  that-depends is faster on C2 warm-singleton (2.80, an implied ~67 ns cache hit); the suite
+- Against `that-depends`, modern-di leads by reference on C1 by about 3% (**0.97**, interquartile
+  width 1.7%). Read that as near-parity rather than a decisive win: the margin is smaller than the
+  46 ns by-type lookup this page charges elsewhere, and this cell has sat on both sides of 1.00
+  across publications (1.08, 1.12, 0.98, 0.98, now 0.97) rather than settling. modern-di is faster on C3 (**0.76**) and far faster on C4 (**0.20**).
+  that-depends is faster on C2 warm-singleton (2.80, an implied ~66 ns cache hit); the suite
   doesn't decompose that-depends' `resolve_sync` cache-hit path, so no mechanism is asserted
   here.
 - Against `dishka` and `wireup` on the by-type table, modern-di is slower on all three
-  synchronous scenarios (1.31–1.88x dishka, 1.33–3.03x wireup). Both inline dependency calls
+  synchronous scenarios (1.32–1.92x dishka, 1.32–3.02x wireup). Both inline dependency calls
   into `exec`-generated source, which removes a per-node function-call frame that modern-di
   keeps; modern-di does not generate code (a
   [documented non-goal](design-decisions.md#non-goals)). That mechanism is asserted **for
-  dishka only**, where the ratio grows with node count as a per-node cost should: 1.46 on C1
-  (2 nodes) against 1.88 on C3 (6 nodes). wireup's ratio moves the other way (1.62 on C1 down
-  to 1.33 on C3), which a per-node cost does not explain, and the suite does not decompose
+  dishka only**, where the ratio grows with node count as a per-node cost should: 1.45 on C1
+  (2 nodes) against 1.92 on C3 (6 nodes). wireup's ratio moves the other way (1.62 on C1 down
+  to 1.32 on C3), which a per-node cost does not explain, and the suite does not decompose
   wireup's resolve further — so no mechanism is claimed for it.
-- The two rivals also diverge on C2. dishka's largest gap is C3 (1.88), not C2 (1.31), and much
-  of that 1.31 is the fixed by-type lookup: dividing modern-di's **by-reference** C2 (187 ns)
-  by dishka's implied C2 absolute (228 ÷ 1.31 = 174 ns) gives 1.07. wireup's largest gap is C2
-  (3.03), and the same division still gives 2.49 (187 ÷ 75 ns) — most of wireup's C2 gap
+- The two rivals also diverge on C2. dishka's largest gap is C3 (1.92), not C2 (1.32), and much
+  of that 1.32 is the fixed by-type lookup: dividing modern-di's **by-reference** C2 (186 ns)
+  by dishka's implied C2 absolute (229 ÷ 1.32 = 173.5 ns) gives 1.07. wireup's largest gap is C2
+  (3.02), and the same division still gives 2.45 (186 ÷ 75.8 ns) — most of wireup's C2 gap
   already exists at the by-reference baseline, and the suite does not decompose the rest. Both
   are **cross-basis figures**, comparing modern-di by reference against a rival that can only
   be measured by type, which is exactly the mixed basis the split tables above avoid; they are
   offered as decomposition, not as published ratios.
+- On C6 (per-request context) modern-di is faster than `dependency-injector` (**0.59**) and
+  `that-depends` (**0.65**), and slower than `dishka` (1.69) and `wireup` (1.42). The direction
+  matches the by-type table — the two codegen frameworks lead, the two others trail — but the
+  cells are **not** on one basis: each framework supplies the request value through its own
+  idiom, and two of those are structural analogs rather than equivalents (see the caveat below).
+  No mechanism is asserted for the gaps; the suite does not decompose any framework's context
+  lookup.
 - On C4 (request lifecycle), the corrected batching does not *remove* the ~27 µs asyncio floor
   — it amortizes it. The guard tier's `test_g7c_event_loop_floor_control` times the same batch
   shape with an empty body and puts the residual at **~0.31 µs per request** still inside every
@@ -131,18 +154,27 @@ _Across-run IQR of each side's own median (5 runs): modern-di ≤1.7%, rivals �
   identically by all five frameworks. Before batching, that floor was ~93% of every cell and
   compressed the real differences toward 1.0; the page used to read modern-di as "level with
   dishka (1.00)" on that basis. With the floor amortized, dishka is measurably **faster** than
-  modern-di here (1.30 — modern-di is the slower side of that cell), not tied. modern-di
+  modern-di here (1.26 — modern-di is the slower side of that cell), not tied. modern-di
   remains far faster than that-depends, dependency-injector, and wireup on this scenario.
 
-**What moved since the previous publication.** modern-di's C4 improved from 2.39 µs to
-**1.97 µs** per request, and its ratio against dishka from 1.58 to **1.30**. That is one
-library fix, not a measurement change: every `Container` used to store itself in its own
-`_scope_map`, making it a reference cycle that reference counting could never free, so a
-request-scoped application handed the garbage collector work at its request rate. Seeding the
-map from the parent instead removed the cycle. Measured on the C4 benchmark, that cut the
-median from 232.7 µs to 194.8 µs per 100-request batch and the standard deviation from
-123.0 µs to 7.9 µs — the tail this scenario used to carry was the collector reclaiming
-containers, and it is gone. The remaining cells moved by less than their published spread.
+**What moved in this publication.** Two benchmark-body corrections, no library change. C4 no
+longer calls `open()` on the request child it just built — a container is open from construction
+as of 3.1, so that timed a redundant lock acquire. At 81 ns per request that accounts for more
+than the whole of C4's 40 ns move from 1.97 µs to **1.93 µs**, with run-to-run drift pushing back
+against it; the dishka ratio moves from 1.30 to **1.26**. C6, newly published here, now closes the
+child inside the timed body, because all four rivals exit a scope inside theirs; that made
+modern-di's C6 cells worse, not better. Every other cell moved within run-to-run noise, and
+several by more than their own published `±` — that annotation bounds dispersion within one
+publication's five runs, not drift between publications, so do not read a cell's `±` as a bound
+on how much it may move next time.
+
+**The C4 gain recorded at 3.1.1 was a library fix**, and it stands: every `Container` used to
+store itself in its own `_scope_map`, making it a reference cycle that reference counting could
+never free, so a request-scoped application handed the garbage collector work at its request rate.
+Seeding the map from the parent instead removed the cycle. Measured on the C4 benchmark at the
+time, that cut the median from 232.7 µs to 194.8 µs per 100-request batch and the standard
+deviation from 123.0 µs to 7.9 µs — the tail this scenario used to carry was the collector
+reclaiming containers, and it is gone.
 
 **C4 is a batched request lifecycle.** modern-di resolves the connection synchronously while
 finalizing it asynchronously; the other four force an awaited resolve once the finalizer is
@@ -151,6 +183,18 @@ async-finalize), not an isolated resolve. It is timed as a **batch of 100 cycles
 entry**, because a single `run_until_complete` entry costs ~27 µs on any body — timing one
 request per entry made every framework's cell ~93% asyncio floor. The published figure is the
 batch divided by 100. C1–C3 are synchronous resolves for every framework.
+
+**C6 is sync for all five, but not one idiom.** Each framework supplies the per-request value its
+own way: modern-di seeds a child container's context and resolves by reference; dishka uses
+`from_context`; wireup requires the runtime type registered as a scoped injectable behind a raising
+placeholder factory; that-depends supplies it through `container_context(global_context=)`; and
+dependency-injector injects **by reference** via `providers.Dependency` + `.override()`, a
+structural analog rather than an equivalent. modern-di's timed body builds the child, resolves, and closes
+it. It calls no `open()` — a freshly built child is already open as of 3.1, so timing one would
+charge modern-di a redundant lock acquire (81 ns, ~6% of the cell) with no counterpart in any
+rival's body. It does close, because all four rivals exit their scope inside the timed body; that
+teardown is ~110 ns, and omitting it would have flattered modern-di by more than the `open()`
+would have cost it.
 
 **Thread-safety configuration differs, at each framework's default.** dishka's `make_container`
 defaults to `lock_factory=<class '_thread.lock'>`, so every `get()` behind its C1–C3 cells
@@ -192,6 +236,12 @@ git clone https://github.com/modern-python/modern-di
 cd modern-di
 just bench-report   # isolated env; first run resolves the pinned rival deps; runs 5x by default
 ```
+
+`just bench-report` also prints a C5 (cold build + first resolve) scenario that this page does
+not publish: its cells are not one axis — dependency-injector's is ~98% provider-graph deepcopy
+and that-depends wires at import with no per-container build at all — so a ratio column would
+assert a comparison those numbers cannot support. See
+[`benchmarks/README.md`](https://github.com/modern-python/modern-di/blob/main/benchmarks/README.md).
 
 The comparative environment is isolated and its result files are not committed,
 so absolute numbers will differ from those above. The ratios are more comparable

--- a/planning/changes/2026-07-27.04-publish-c6-context.md
+++ b/planning/changes/2026-07-27.04-publish-c6-context.md
@@ -1,0 +1,140 @@
+---
+summary: Promote C6 (per-request context) to a published comparative scenario — pinned to the C1-C3 timing shape in all five framework files, given its own all-rivals table like C4, and covered by a test_bench_report contract now derived from the generator's own tables; both published modern-di bodies were corrected for fairness (C4 and C6 drop a redundant post-3.1 open(); C6 gains the per-request teardown all four rivals already paid), which moved C6's cells against modern-di and C4's for it.
+---
+
+# Design: Publish C6, the per-request context scenario
+
+## Summary
+
+C6 has been measured by the comparative suite since it was written but never
+published, sitting on auto-calibration outside the pinned-shape contract that
+[2026-07-27.02](2026-07-27.02-benchmark-measurement-fidelity.md) established for
+C1-C4. This promotes it: same `rounds × iterations` as C1-C3 in all five
+framework files, a fourth table in `benchmarks/report.py` comparing modern-di
+against all four rivals, and `_PUBLISHED` in `tests/test_bench_report.py`
+derived from the generator so the contract now enforces C6's shape too. Review
+then found both published modern-di bodies unfair in opposite directions, and
+both were corrected here: C4 and C6 drop a redundant post-3.1 `open()`, and C6
+gains the per-request teardown all four rivals already paid inside their timed
+bodies.
+
+## Motivation
+
+C6 times the per-request context path: supply a runtime value by type, resolve a
+handler that needs it plus an app-scoped dependency. That is the shape every
+framework integration actually runs on every request, and the page published
+nothing about it. C1 (synthetic transient) is less representative of real usage
+than C6 is.
+
+The page also instructs readers to reproduce with `just bench-report`, which
+prints every scenario the suite runs. A reader following that instruction got a
+scenario the page did not explain — an inconsistency with no defensible reading.
+
+C5 stays unpublished, deliberately and for a reason the suite already documents:
+its cells are not one axis. dependency-injector's C5 number is ~98% provider-graph
+deepcopy, that-depends wires at import and has no per-container build at all, and
+dishka's cell includes per-call provider registration that modern-di hoists to
+import time. A ratio column asserts a like-for-like comparison those cells cannot
+support, so C5 remains guidance in `benchmarks/README.md` rather than a published
+row.
+
+## Design
+
+**Timing shape.** C6 moves from `benchmark(_one_request)` to
+`benchmark.pedantic(_one_request, rounds=_ROUNDS, iterations=_ITERATIONS,
+warmup_rounds=1)` in all five files, reusing the constants C1-C3 already share
+(200 × 1000). This is what makes its ratio publishable at all: an
+auto-calibrated cell can land at `iterations=1` and carry a whole per-round timer
+pair snapped to the platform's ~42 ns grid, which must never be divided by an
+unsnapped one.
+
+**One table, all four rivals.** C6 gets its own `Table` rather than rows in the
+by-reference and by-type tables, for exactly C4's reason: modern-di resolves by
+reference throughout the C6 body and there is no by-type C6 variant, so a split
+would leave the by-type half mixed-basis or empty. An earlier draft of this
+bundle also claimed the rivals' context idioms fail to line up with the C1-C3
+grouping; review disproved it — that-depends resolves its C6 handler by
+reference exactly as it does on C1-C3. It is modern-di's missing variant, not
+the rivals, that keeps C6 in one table.
+
+**Contract.** `_PUBLISHED` is no longer hand-listed: it is derived from
+`report.TABLES`, so a scenario is published exactly when a table publishes it and
+the contract cannot stay scoped to an old set when a table is added. The existing
+shape assertion already expects `_ROUNDS`/`_ITERATIONS` for anything that is not
+C4, so C6 needs no special case. Two tests were added: one pinning the derivation
+itself, one asserting the new table publishes C6 undivided (a stray
+`divisor=BATCH` would otherwise publish a number wrong by 100x with everything
+green).
+
+**Two fairness corrections to the timed bodies.** Both were found by review, and
+they move the numbers in opposite directions.
+
+*Removed `open()`, in C4 **and** C6.* Both bodies called `req.open()` on a child
+they had just built. A freshly built child is open from construction as of 3.1,
+so that timed a lock acquire no user would write and no rival has a counterpart
+for. Measured in isolation at **81 ns**: ~6% of C6's cell and ~4% of C4's. C4 is
+an already-published table, so this change corrects a figure the page was
+already leaning on — its dishka ratio moves 1.30 to **1.26**.
+
+*Added the per-request teardown, in C6.* All four rivals enter **and exit** a
+scope inside their timed bodies; modern-di's C6 body built a child, resolved, and
+dropped it. That omission was worth ~110 ns, **larger than the `open()` this
+change removed for fairness** — the page could not argue the 81 ns mattered while
+leaving it undisclosed. C6's body now closes the child. Net of the
+`open()` removal the body got ~29 ns slower (~2% of the cell), and its published
+cells moved against modern-di — 0.56 to **0.59** against dependency-injector,
+1.57 to **1.69** against dishka — by more than that, since the rival cells and
+run-to-run drift move too. The direction is attributable to the correction; the
+magnitude is not.
+
+## Non-goals
+
+- Not publishing C5, per the Motivation.
+- Not adding by-reference/by-type C6 variants for modern-di: the rivals have no
+  matching split to compare them against.
+
+## Testing
+
+`just test-ci` at 100% line coverage, `just lint-ci`, `just check-planning` and
+`mkdocs build --strict` clean. The contract change was made test-first: extending
+`_PUBLISHED` to cover C6 fails
+`test_every_published_scenario_pins_the_same_rounds_and_iterations` with C6
+absent from every file's pinned set, and passes once all five are converted.
+
+All four tables were regenerated from one `just bench-report 5` invocation after
+the body corrections, since tables drawn from different batches would undercut the
+pairing the page relies on. Every derived figure in the prose was re-computed
+against that run: the by-type lookup deltas (46/43/48 ns), the C4 levelling
+estimate, both implied cache-hit figures, the C2 cross-basis decomposition, the
+asyncio-floor share, and the per-node argument's endpoints.
+
+Three paragraphs were structurally wrong and were rewritten, not renumbered.
+"What moved since the previous publication" had been measuring against two
+publications ago, folding run-to-run drift into a narrative that asserted "one
+library fix, not a measurement change"; it now reports this publication's two
+body corrections and keeps the 3.1.1 reference-cycle result as the dated,
+still-true finding it is. Its closing claim that "the remaining cells moved by
+less than their published spread" was false — seven of eighteen cells moved by
+more — and is replaced by a statement of what the `±` actually bounds: dispersion
+within one publication's five runs, not drift between publications.
+
+One verdict changed with the new data and is restated rather than carried
+forward: modern-di's C1 by-reference cell against that-depends reads **0.97**
+with an interquartile width of 1.7%, so the previous "tied, its spread covers
+1.00" reading is not derivable — and never was, since that annotation is a full
+IQR width, not a half-width. The page now calls it near-parity, a ~3% lead
+smaller than the by-type lookup it charges elsewhere.
+
+## Risk
+
+- **C6's published number is not comparable to any pre-existing C6 figure.** The
+  estimator changed (auto-calibration to pinned pedantic) and the body changed
+  twice (`open()` removed, teardown added) in the same commit, so the delta is not
+  attributable to any one of them. Nothing published depended on the old value.
+- **C4's published figure moved without a library change.** Its 1.30 dishka ratio
+  became 1.26 because the benchmark stopped timing a redundant call, not because
+  anything in `modern_di/` changed. The page says so where the number appears, so
+  the 3.1.1 reference-cycle result is not credited with it.
+- **A fourth table lengthens an already long page.** Mitigated by C6 being the
+  most representative scenario in the suite; if the page needs shortening later,
+  that is an editorial pass, not a measurement change.

--- a/tests/test_bench_report.py
+++ b/tests/test_bench_report.py
@@ -10,7 +10,12 @@ from benchmarks.report import build_table, parse_run
 
 _COMPARATIVE = pathlib.Path(__file__).resolve().parent.parent / "benchmarks" / "comparative"
 _BATCH_LITERAL = re.compile(r"^_BATCH\s*=\s*(\d+)$", re.MULTILINE)
-_PUBLISHED = re.compile(r"^test_c[1-4]_")
+# Derived from the generator, never hand-listed: a scenario is "published" exactly when a table
+# publishes it, so adding a table cannot leave this contract silently scoped to the old set.
+_PUBLISHED_SCENARIOS = frozenset(
+    key.split("_")[0] for table in report.TABLES for row in table.rows for key in (row.modern_di_key, row.rival_key)
+)
+_PUBLISHED = re.compile(rf"^test_(?:{'|'.join(sorted(_PUBLISHED_SCENARIOS))})_")
 
 
 def _comparative_sources() -> list[pathlib.Path]:
@@ -194,7 +199,7 @@ def test_comparative_batch_literals_match_the_report_divisor() -> None:
 def test_every_published_scenario_pins_the_same_rounds_and_iterations() -> None:
     # pytest-benchmark auto-calibrates `iterations` per benchmark, so one cell can land at 1 (full
     # per-round timer overhead, snapped to the platform timer's grid) while the cell it is divided
-    # by lands at 25. A published ratio must not mix the two, so C1-C4 pin the shape explicitly and
+    # by lands at 25. A published ratio must not mix the two, so C1-C4 and C6 pin the shape explicitly and
     # every framework pins the same numbers. Parsed with `ast` — the comparative venv is separate.
     trees = {path.name: ast.parse(path.read_text(encoding="utf-8")) for path in _comparative_sources()}
 
@@ -278,3 +283,25 @@ def test_build_table_single_run_has_no_iqr_annotation_or_footnote() -> None:
     # IQR is undefined for a single run: no ± on the cell, and no footnote -- never crash, never fake 0.0%.
     assert _section(table, "By-reference resolution") == [["C1 transient", "310 ns", "**0.50**", "n/a"]]
     assert _footnote(table, "By-reference resolution") is None
+
+
+def test_published_scenarios_are_exactly_the_ones_the_tables_publish() -> None:
+    # Pins the derivation itself: if a table is added or dropped, this is the line that says so.
+    assert {"c1", "c2", "c3", "c4", "c6"} == _PUBLISHED_SCENARIOS
+    assert _PUBLISHED.match("test_c6_context_modern_di")
+    assert not _PUBLISHED.match("test_c5_cold_first_resolve_modern_di")
+
+
+def test_build_table_publishes_c6_per_request_undivided() -> None:
+    # C6 is not batched: unlike C4 its row carries no divisor, so the published cell is the
+    # measured median itself. A stray divisor would publish a number wrong by 100x, silently.
+    run = _run(
+        test_c6_context_modern_di=1.45e-6,
+        test_c6_context_dependency_injector=2.9e-6,
+        test_c6_context_that_depends=2.9e-6,
+        test_c6_context_dishka=1e-6,
+        test_c6_context_wireup=1e-6,
+    )
+    assert _section(build_table([run]), "Per-request context") == [
+        ["C6 context", "1.45 µs", "**0.50**", "**0.50**", "1.45", "1.45"]
+    ]


### PR DESCRIPTION
C6 (per-request context: supply a runtime value by type, resolve a handler needing it plus an app-scoped dep) has been measured by the comparative suite since it was written, but never published — it sat on auto-calibration, outside the pinned-shape contract [#380](https://github.com/modern-python/modern-di/pull/380) established for C1-C4. That left `just bench-report`, which this page tells readers to run, printing a scenario the page never explained. Rationale: [planning/changes/2026-07-27.04-publish-c6-context.md](planning/changes/2026-07-27.04-publish-c6-context.md).

**Promotion.** C6 pins to C1-C3's `benchmark.pedantic` shape (200 × 1000) in all five framework files, and gets its own table against all four rivals rather than rows in the by-reference/by-type split — for C4's reason: modern-di resolves by reference throughout the body and has no by-type C6 variant, so a split would leave that half mixed-basis.

**Two fairness corrections to the timed bodies, found in review, pulling in opposite directions.** Neither is a library change:

- **C4 and C6 both called `open()`** on a child they had just built. A container is open from construction as of 3.1, so that timed a redundant lock acquire with no counterpart in any rival body — 81 ns, ~4% of C4's cell and ~6% of C6's. C4 is already published, so this corrects a figure the page was leaning on: its dishka ratio moves 1.30 → **1.26**.
- **C6 skipped the per-request teardown** all four rivals pay *inside* their timed bodies. That omission was worth ~110 ns — **larger than the `open()` removed for fairness** — so the page could not argue the 81 ns mattered while leaving it undisclosed. C6 now closes the child, moving its cells **against** modern-di (0.56 → 0.59 vs dependency-injector, 1.57 → 1.69 vs dishka).

**Contract.** `_PUBLISHED` is no longer hand-listed; it is derived from `report.TABLES`, so a scenario is published exactly when a table publishes it. Two tests added: one pinning the derivation, one asserting the C6 table publishes undivided — a stray `divisor=BATCH` would otherwise publish a number wrong by 100x with everything green. Both were verified to bite by mutation.

**Republished.** All four tables regenerated from one run after the body corrections, with every derived figure in the prose recomputed against it. Three paragraphs were structurally wrong and were rewritten: "what moved" had been measuring against two publications ago and folding drift into a fix narrative; its claim that remaining cells moved less than their published spread was false (7 of 18 moved more); and the C1-vs-that-depends verdict is restated as near-parity, since `±` is a full interquartile width, not a half-width, so the prior "spread covers 1.00" reading was never derivable.

C5 stays unpublished and the page now says why where a reader reproducing will see it: its cells are not one axis (dependency-injector's is ~98% provider-graph deepcopy; that-depends wires at import with no per-container build).

`just test-ci` 452 passed / 100.00% coverage; `just lint-ci`, `just check-planning` and `mkdocs build --strict` clean. Two rounds of independent review; no code defects were found in either, and both new tests were broken deliberately to confirm they bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)