### PR TITLE
docs(roadmap): add the warm-singleton (C2) path

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,20 @@ Strawberry, Quart, RQ, APScheduler, Jobify, Flet, ag2.
 - **Public, reproducible benchmark suite** with neutral methodology —
   shipped; see [Performance](https://modern-di.modern-python.org/introduction/performance/).
 - **Optional OpenTelemetry instrumentation** of resolution and finalization.
+- **Trim the warm-singleton path (C2)** — the one published scenario where
+  modern-di is clearly last: ~3.9x dependency-injector and ~2.8x that-depends.
+  A warm hit costs ~170 ns, of which two Python method calls are pure
+  indirection — `ProvidersRegistry.resolver_for` on every top-level resolve
+  (~56 ns) and `CacheRegistry.fetch_cache_item` inside the compiled resolver
+  (~44 ns). Inlining each one's dict-lookup hit path, and calling the method
+  only on a miss, keeps the cycle-safe compilation thunk and the shared-item
+  guarantee intact. Bounded win: it should roughly halve the cell, not close
+  it — dependency-injector's ~47 ns is a C-level slot read on a Cython core,
+  which pure Python does not reach. A third step exists and is **deliberately
+  deferred**: an APP-scoped resolver could close over its `CacheItem` and reach
+  ~16 ns, but the target is only invariant because one registry belongs to one
+  root, so the registry would have to reference its root — the container
+  reference cycle removed in 3.1.1. That needs a weakref and a proof, for ~30 ns.
 
 ### Docs & ecosystem
 - **Canonical on-ramp per integration** — every official integration ships a


### PR DESCRIPTION
C2 warm singleton is the one published comparative scenario where modern-di is clearly last — ~3.9x dependency-injector and ~2.8x that-depends. This records it as a known, bounded gap rather than leaving it unremarked next to a benchmark page that publishes it.

**Profiled rather than estimated.** A warm hit costs ~170 ns on an M4 / CPython 3.14.6:

| | cost |
|---|---|
| `resolve_provider` wrapper | 68.8 ns — of which `resolver_for()` is **56 ns** |
| compiled resolver body | 100.7 ns — of which `fetch_cache_item()` is **43.5 ns** |
| ideal (closed-over `CacheItem`) | 16.1 ns |
| bare attribute read | 10.8 ns |

So ~100 ns of the 170 is two Python method calls that are pure indirection on the warm path. Both wrap a memoized dict lookup; inlining each one's *hit* path and calling the method only on a miss preserves what they exist for — `resolver_for`'s cycle-safe compilation thunk, and `fetch_cache_item`'s guarantee that concurrent first-resolvers share one `CacheItem`.

**Deliberately bounded.** The entry says this should roughly halve the cell, not close it: dependency-injector's ~47 ns is a C-level slot read on a Cython core, which pure Python does not reach. Overpromising here would be easy and wrong.

**One step named as deferred.** An APP-scoped resolver could close over its `CacheItem` and reach the ~16 ns floor, because the target container is invariant per registry. But that invariance holds only because one registry belongs to one root — so the registry would have to hold a reference back to its root, which is the container reference cycle [#381](https://github.com/modern-python/modern-di/pull/381) removed in 3.1.1. It needs a weakref and a proof for ~30 ns, so the roadmap names it rather than implying it is free.

Roadmap-only, no bundle — matching [#377](https://github.com/modern-python/modern-di/pull/377)'s treatment of the same kind of change. `just lint-ci` and `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)