### PR TITLE
perf(resolve): inline the two warm-hit lookups

### DIFF
--- a/docs/introduction/performance.md
+++ b/docs/introduction/performance.md
@@ -56,7 +56,7 @@ for why that matters and which cells it moved.
 
 ## Results
 
-Measured 2026-07-27 with modern-di 3.1.1 on an Apple M4 (macOS 26.5), CPython 3.14.6,
+Measured 2026-07-28 with modern-di 3.1.2 on an Apple M4 (macOS 26.5), CPython 3.14.6,
 median over 5 runs (ratios paired within each run); the footnote under each table bounds the
 across-run dispersion of each side's own median.
 Rival versions: dishka 1.10.1, dependency-injector 4.49.1, that-depends 4.0.2, wireup 2.12.0.
@@ -73,75 +73,79 @@ as a verdict.
 
 | Scenario | modern-di | vs dependency-injector | vs that-depends |
 |---|---|---|---|
-| C1 transient | 301 ns ±1.5% | **0.83** ±0.8% | **0.97** ±1.7% |
-| C2 warm singleton | 186 ns ±1.1% | 3.88 ±0.6% | 2.80 ±1.9% |
-| C3 deep chain (6) | 804 ns ±3.0% | **0.59** ±2.4% | **0.76** ±4.5% |
+| C1 transient | 279 ns ±0.6% | **0.76** ±1.2% | **0.89** ±1.6% |
+| C2 warm singleton | 142 ns ±1.2% | 2.94 ±1.7% | 2.13 ±1.9% |
+| C3 deep chain (6) | 768 ns ±0.9% | **0.54** ±3.0% | **0.72** ±1.1% |
 
-_Across-run IQR of each side's own median (5 runs): modern-di ≤3.0%, rivals ≤1.8%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+_Across-run IQR of each side's own median (5 runs): modern-di ≤1.2%, rivals ≤2.0%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
 
 ### By-type resolution
 
 | Scenario | modern-di | vs dishka | vs wireup |
 |---|---|---|---|
-| C1 transient | 347 ns ±0.8% | 1.45 ±1.3% | 1.62 ±1.2% |
-| C2 warm singleton | 229 ns ±1.1% | 1.32 ±2.0% | 3.02 ±1.6% |
-| C3 deep chain (6) | 852 ns ±2.7% | 1.92 ±1.9% | 1.32 ±3.4% |
+| C1 transient | 323 ns ±1.4% | 1.34 ±1.7% | 1.50 ±1.0% |
+| C2 warm singleton | 182 ns ±0.2% | 1.06 ±0.9% | 2.40 ±2.0% |
+| C3 deep chain (6) | 814 ns ±0.9% | 1.82 ±1.8% | 1.26 ±0.2% |
 
-_Across-run IQR of each side's own median (5 runs): modern-di ≤2.7%, rivals ≤2.5%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+_Across-run IQR of each side's own median (5 runs): modern-di ≤1.4%, rivals ≤1.0%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
 
 ### Request lifecycle (batched, published per request)
 
 | Scenario | modern-di | vs dependency-injector | vs that-depends | vs dishka | vs wireup |
 |---|---|---|---|---|---|
-| C4 request lifecycle | 1.93 µs ±3.0% | **0.02** ±3.8% | **0.20** ±1.3% | 1.26 ±2.2% | **0.13** ±2.1% |
+| C4 request lifecycle | 1.92 µs ±2.9% | **0.02** ±2.3% | **0.20** ±1.2% | 1.28 ±3.4% | **0.13** ±2.0% |
 
-_Across-run IQR of each side's own median (5 runs): modern-di ≤3.0%, rivals ≤0.8%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+_Across-run IQR of each side's own median (5 runs): modern-di ≤2.9%, rivals ≤2.5%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
 
 ### Per-request context
 
 | Scenario | modern-di | vs dependency-injector | vs that-depends | vs dishka | vs wireup |
 |---|---|---|---|---|---|
-| C6 context | 1.45 µs ±2.4% | **0.59** ±2.5% | **0.65** ±2.0% | 1.69 ±3.8% | 1.42 ±3.6% |
+| C6 context | 1.41 µs ±0.9% | **0.58** ±1.6% | **0.63** ±3.9% | 1.65 ±1.1% | 1.38 ±1.4% |
 
-_Across-run IQR of each side's own median (5 runs): modern-di ≤2.4%, rivals ≤3.2%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
+_Across-run IQR of each side's own median (5 runs): modern-di ≤0.9%, rivals ≤4.6%. The ± on each ratio cell is a different quantity: the spread of the paired per-run ratios._
 
 ## What the numbers show
 
-- Against `dependency-injector`, modern-di is faster by reference on C1 (**0.83**) and
-  C3 (**0.59**), and far faster on the batched C4 request lifecycle (**0.02**).
+- Against `dependency-injector`, modern-di is faster by reference on C1 (**0.76**) and
+  C3 (**0.54**), and far faster on the batched C4 request lifecycle (**0.02**).
   dependency-injector's C4 body calls `init_resources()`/`shutdown_resources()` every cycle
   in addition to resolving; the suite doesn't decompose how much of its per-request cost is
   that lifecycle work versus the resolve itself, so C4 should be read as a whole-lifecycle
-  comparison, not an isolated resolve (see the caveat below). dependency-injector is faster
-  on C2 warm-singleton (3.88, an implied ~48 ns cache hit against modern-di's 186 ns): its
-  hit is a C-level slot read on a Cython-compiled core, where modern-di's is a Python dict
-  lookup behind an override guard.
-- Against `that-depends`, modern-di leads by reference on C1 by about 3% (**0.97**, interquartile
-  width 1.7%). Read that as near-parity rather than a decisive win: the margin is smaller than the
-  46 ns by-type lookup this page charges elsewhere, and this cell has sat on both sides of 1.00
-  across publications (1.08, 1.12, 0.98, 0.98, now 0.97) rather than settling. modern-di is faster on C3 (**0.76**) and far faster on C4 (**0.20**).
-  that-depends is faster on C2 warm-singleton (2.80, an implied ~66 ns cache hit); the suite
-  doesn't decompose that-depends' `resolve_sync` cache-hit path, so no mechanism is asserted
-  here.
+  comparison, not an isolated resolve (see the caveat below). dependency-injector is still
+  faster on C2 warm-singleton (2.94, an implied ~48 ns cache hit against modern-di's 142 ns):
+  its hit is a C-level slot read on a Cython-compiled core, where modern-di's is a Python
+  dict lookup behind an override guard. Pure Python does not reach ~48 ns, so this cell is
+  expected to stay above 1.0 however much of modern-di's own overhead is removed.
+- Against `that-depends`, modern-di now leads by reference on C1 by 11% (**0.89**,
+  interquartile width 1.6%) — the first publication where that cell's spread does not cover
+  1.00. Treat it as a real but modest lead: it has sat on both sides of parity across
+  publications (1.08, 1.12, 0.98, 0.98, 0.97, now 0.89), and this move is explained by
+  modern-di getting ~28 ns faster rather than by that-depends changing — its implied C2
+  absolute is unchanged at ~67 ns. modern-di is also faster on C3 (**0.72**) and far faster
+  on C4 (**0.20**). that-depends remains faster on C2 warm-singleton (2.13); the suite does
+  not decompose its `resolve_sync` cache-hit path, so no mechanism is asserted here.
 - Against `dishka` and `wireup` on the by-type table, modern-di is slower on all three
-  synchronous scenarios (1.32–1.92x dishka, 1.32–3.02x wireup). Both inline dependency calls
+  synchronous scenarios (1.06–1.82x dishka, 1.26–2.40x wireup). Both inline dependency calls
   into `exec`-generated source, which removes a per-node function-call frame that modern-di
   keeps; modern-di does not generate code (a
   [documented non-goal](design-decisions.md#non-goals)). That mechanism is asserted **for
-  dishka only**, where the ratio grows with node count as a per-node cost should: 1.45 on C1
-  (2 nodes) against 1.92 on C3 (6 nodes). wireup's ratio moves the other way (1.62 on C1 down
-  to 1.32 on C3), which a per-node cost does not explain, and the suite does not decompose
+  dishka only**, where the ratio grows with node count as a per-node cost should: 1.34 on C1
+  (2 nodes) against 1.82 on C3 (6 nodes). wireup's ratio moves the other way (1.50 on C1 down
+  to 1.26 on C3), which a per-node cost does not explain, and the suite does not decompose
   wireup's resolve further — so no mechanism is claimed for it.
-- The two rivals also diverge on C2. dishka's largest gap is C3 (1.92), not C2 (1.32), and much
-  of that 1.32 is the fixed by-type lookup: dividing modern-di's **by-reference** C2 (186 ns)
-  by dishka's implied C2 absolute (229 ÷ 1.32 = 173.5 ns) gives 1.07. wireup's largest gap is C2
-  (3.02), and the same division still gives 2.45 (186 ÷ 75.8 ns) — most of wireup's C2 gap
-  already exists at the by-reference baseline, and the suite does not decompose the rest. Both
-  are **cross-basis figures**, comparing modern-di by reference against a rival that can only
-  be measured by type, which is exactly the mixed basis the split tables above avoid; they are
-  offered as decomposition, not as published ratios.
-- On C6 (per-request context) modern-di is faster than `dependency-injector` (**0.59**) and
-  `that-depends` (**0.65**), and slower than `dishka` (1.69) and `wireup` (1.42). The direction
+- The two rivals also diverge on C2, and modern-di is now **level with dishka** there (1.06,
+  interquartile width 0.9%). Most of what remains is the fixed by-type lookup: dividing
+  modern-di's **by-reference** C2 (142 ns) by dishka's implied C2 absolute (182 ÷ 1.06 =
+  171.7 ns) gives **0.83** — on the same by-reference basis modern-di's warm hit is now the
+  faster of the two. wireup's largest gap is C2 (2.40), and the same division still gives 1.87
+  (142 ÷ 75.8 ns), so most of wireup's C2 gap exists at the by-reference baseline and the
+  suite does not decompose the rest. Both are **cross-basis figures**, comparing modern-di by
+  reference against a rival that can only be measured by type, which is exactly the mixed
+  basis the split tables above avoid; they are offered as decomposition, not as published
+  ratios.
+- On C6 (per-request context) modern-di is faster than `dependency-injector` (**0.58**) and
+  `that-depends` (**0.63**), and slower than `dishka` (1.65) and `wireup` (1.38). The direction
   matches the by-type table — the two codegen frameworks lead, the two others trail — but the
   cells are **not** on one basis: each framework supplies the request value through its own
   idiom, and two of those are structural analogs rather than equivalents (see the caveat below).
@@ -154,19 +158,32 @@ _Across-run IQR of each side's own median (5 runs): modern-di ≤2.4%, rivals �
   identically by all five frameworks. Before batching, that floor was ~93% of every cell and
   compressed the real differences toward 1.0; the page used to read modern-di as "level with
   dishka (1.00)" on that basis. With the floor amortized, dishka is measurably **faster** than
-  modern-di here (1.26 — modern-di is the slower side of that cell), not tied. modern-di
+  modern-di here (1.28 — modern-di is the slower side of that cell), not tied. modern-di
   remains far faster than that-depends, dependency-injector, and wireup on this scenario.
 
-**What moved in this publication.** Two benchmark-body corrections, no library change. C4 no
-longer calls `open()` on the request child it just built — a container is open from construction
-as of 3.1, so that timed a redundant lock acquire. At 81 ns per request that accounts for more
-than the whole of C4's 40 ns move from 1.97 µs to **1.93 µs**, with run-to-run drift pushing back
-against it; the dishka ratio moves from 1.30 to **1.26**. C6, newly published here, now closes the
-child inside the timed body, because all four rivals exit a scope inside theirs; that made
-modern-di's C6 cells worse, not better. Every other cell moved within run-to-run noise, and
-several by more than their own published `±` — that annotation bounds dispersion within one
-publication's five runs, not drift between publications, so do not read a cell's `±` as a bound
-on how much it may move next time.
+**What moved in this publication.** A library change, not a benchmark one: the warm-hit path
+lost two Python method frames. `ProvidersRegistry.resolver_for` and
+`CacheRegistry.fetch_cache_item` both open with a dict lookup that hits and returns; both are
+now inlined at their call sites, with the method called only on a miss, where it still owns the
+cycle guard, the memo write and the `setdefault` that makes concurrent first-resolvers share one
+`CacheItem`. Measured in isolation, that removes ~42 ns from a warm hit.
+
+Because the first of the two sits in `resolve_provider`, every top-level resolve benefits, not
+just cached ones. C2 by reference falls from 186 ns to **142 ns** and C1 from 301 ns to
+**279 ns**; the C2 ratios move 3.88 → **2.94** against dependency-injector, 2.80 → **2.13**
+against that-depends, 1.32 → **1.06** against dishka, and 3.02 → **2.40** against wireup. Both
+rivals whose implied C2 absolutes this page prints are unchanged (~48 ns and ~67 ns), which is
+the check that the movement is modern-di's and not drift.
+
+The bound stated when this was planned still holds: it trims the cell, it does not close it.
+dependency-injector's ~48 ns hit is a C-level slot read on a Cython core. A third step —
+closing an APP-scoped resolver over its `CacheItem` to reach ~16 ns — is deliberately not taken,
+because it would require the providers registry to reference its root container, reintroducing
+the reference cycle removed in 3.1.1.
+
+Every other cell moved within run-to-run noise, and several by more than their own published
+`±` — that annotation bounds dispersion within one publication's five runs, not drift between
+publications, so do not read a cell's `±` as a bound on how much it may move next time.
 
 **The C4 gain recorded at 3.1.1 was a library fix**, and it stands: every `Container` used to
 store itself in its own `_scope_map`, making it a reference cycle that reference counting could
@@ -228,6 +245,14 @@ garbage collector. Seeding the map from the parent removed it. Resolution is unt
 C1–C3 cells did not move — but the request lifecycle did: C4's median fell from 232.7 µs to
 194.8 µs per 100-request batch and its standard deviation from 123.0 µs to 7.9 µs, because the
 collector no longer has to reclaim containers that refcounting now frees.
+
+3.1.2 removed two more frames, this time from the warm-hit path. A cached resolve reached its
+compiled resolver through `ProvidersRegistry.resolver_for` and its `CacheItem` through
+`CacheRegistry.fetch_cache_item`; both methods open with a dict lookup that hits and returns.
+Both lookups are now inlined at the call site, with the method called only on a miss — where it
+still owns the cycle guard, the memo write, and the `setdefault` that makes concurrent
+first-resolvers share one `CacheItem`. Worth ~42 ns on a warm hit, and because the first sits in
+`resolve_provider` it applies to every top-level resolve rather than only cached ones.
 
 ## Reproduce it yourself
 

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -217,7 +217,15 @@ class Container:
         if self.closed:
             self._prepare()
         try:
-            return self.providers_registry.resolver_for(provider)(self)
+            # Inlined memo hit: `resolver_for` opens with exactly this lookup and returns, and the
+            # method frame costs ~34ns of a ~170ns warm hit. Call it only on a miss, where it owns
+            # the cycle guard and the memo write. Stays inside the try so a RecursionError while
+            # compiling still becomes CircularDependencyError.
+            registry = self.providers_registry
+            resolver = registry._resolvers.get(provider.provider_id)  # noqa: SLF001
+            if resolver is None:
+                resolver = registry.resolver_for(provider)
+            return resolver(self)
         except RecursionError as exc:
             _handle_recursion_error(provider, self, exc)
 

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -220,7 +220,13 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
             target._prepare()  # noqa: SLF001
-        cache_item = target.cache_registry.fetch_cache_item(f)
+        # Inlined memo hit: `fetch_cache_item` opens with exactly this lookup and returns, and the
+        # method frame costs ~23ns of a ~170ns warm hit. Call it only on a miss, where its
+        # `setdefault` is what makes concurrent first-resolvers share one CacheItem.
+        cache_registry = target.cache_registry
+        cache_item = cache_registry._items.get(pid)  # noqa: SLF001
+        if cache_item is None:
+            cache_item = cache_registry.fetch_cache_item(f)
         cached = cache_item.cache
         if cached is not types.UNSET:
             return cached  # warm hit: skip the get_or_create frame (same sentinel check it makes)

--- a/planning/changes/2026-07-28.01-warm-singleton-inlining.md
+++ b/planning/changes/2026-07-28.01-warm-singleton-inlining.md
@@ -1,0 +1,117 @@
+---
+summary: Inlined the two dict-lookup hit paths a warm singleton resolve paid through method calls — `resolver_for` and `fetch_cache_item` — calling the method only on a miss. A warm hit drops 170 → 128 ns (~25%) and every top-level resolve benefits, since one of the two sits in `resolve_provider`; C2 vs dishka moves 1.32 → 1.06. Shipped in 3.1.2.
+---
+
+# Design: Inline the warm-singleton lookups
+
+## Summary
+
+A warm singleton hit spends two Python method calls purely on indirection, each
+wrapping a dict lookup that hits. Inline both hit paths at their call sites and
+call the method only on a miss. No behaviour changes: the miss paths, the
+cycle-safe compilation thunk, and the shared-`CacheItem` guarantee all keep
+their current code.
+
+## Motivation
+
+C2 (warm singleton) is the one published scenario where modern-di is clearly
+last — 3.92x dependency-injector and 2.80x that-depends on the current
+[performance page](../../docs/introduction/performance.md). Measured on an Apple
+M4 / CPython 3.14.6, 300 000 iterations x 9 rounds:
+
+| | ns |
+|---|---|
+| `resolve_provider` warm hit, end to end | **168.5** |
+| the compiled resolver alone, lookup skipped | 98.9 |
+| `ProvidersRegistry.resolver_for` alone | 55.3 |
+| `CacheRegistry.fetch_cache_item` alone | 42.4 |
+
+So ~98 ns of a 168 ns hit is spent in two methods whose fast path is a single
+`dict.get` that returns. This confirms the estimate recorded in
+[ROADMAP.md](../../ROADMAP.md); the numbers there (~170 / ~56 / ~44 ns) were
+independently reproduced before starting.
+
+## Design
+
+Two call sites, same shape: read the memo dict directly, fall back to the method
+when the lookup misses.
+
+`Container.resolve_provider`:
+
+```python
+registry = self.providers_registry
+resolver = registry._resolvers.get(provider.provider_id)
+if resolver is None:
+    resolver = registry.resolver_for(provider)
+return resolver(self)
+```
+
+The compiled resolver in `_compile_cached_factory`:
+
+```python
+cache_registry = target.cache_registry
+cache_item = cache_registry._items.get(pid)
+if cache_item is None:
+    cache_item = cache_registry.fetch_cache_item(f)
+```
+
+`pid` is already bound to `f.provider_id` in the enclosing compile, so the
+inlined lookup is the same key the method computes.
+
+**Why this is safe.**
+
+- Both methods already open with exactly this lookup and return on a hit
+  (`providers_registry.py:87-89`, `cache_registry.py:95-97`). The inline is that
+  branch, unchanged.
+- **Miss behaviour is untouched.** `resolver_for` keeps its cycle guard and its
+  memo write; `fetch_cache_item` keeps its `setdefault`, so concurrent
+  first-resolvers still share one `CacheItem` through one atomic op — the
+  property the singleton cache and its double-checked lock depend on.
+- **Registry mutation still invalidates.** `add_providers` clears `_resolvers`
+  (`providers_registry.py:132`); a cleared dict misses and recompiles.
+- **Free-threading.** A bare `dict.get` is what the method already performed
+  outside the container lock; inlining moves no work into or out of a lock and
+  adds no new shared state.
+- The `resolve_provider` inline stays **inside** the existing `try`, so a
+  `RecursionError` raised while compiling on the miss path is still converted to
+  `CircularDependencyError`.
+
+Both sites reach into a registry's private dict, as `container.py` already does
+for `_lock` and `_scope_map`. Registries are internal (`architecture/`), and the
+alternative — a public accessor — reintroduces the method call being removed.
+
+## Non-goals
+
+- **Closing the gap to dependency-injector.** Its ~47 ns hit is a C-level slot
+  read on a Cython core; pure Python does not reach it. This is a bounded trim,
+  not a fix for the ranking.
+- **The APP-scoped closure step** deferred in ROADMAP.md: caching the
+  `CacheItem` on the resolver would reach ~16 ns but requires the registry to
+  reference its root container, reintroducing the reference cycle removed in
+  3.1.1. Out of scope, and it needs a weakref and a proof.
+- Touching the cold path, the override front-guard, or `_navigate`.
+
+## Testing
+
+No behaviour changes, so the gate is the existing suite plus a measurement:
+
+- `just test-ci` — 450 tests, 100% line coverage. The paths this touches are
+  already covered: cold first-resolve, `add_providers` invalidation, cycle
+  detection, and the concurrent first-resolve guards (G15 / the free-threaded
+  tests).
+- Before/after on the same machine, same harness as the Motivation table, for
+  the warm hit and for `g2_cached_resolve`.
+- `just bench` — no other guard scenario regresses beyond the tier's ~41 ns
+  timer grid (see `benchmarks/README.md`).
+
+Ship whatever the measurement reports. If the saving is materially below the
+~57 ns the component measurements predict, that is the result.
+
+## Risk
+
+- **A future reader "tidies" the inline back into the method call**, silently
+  restoring ~57 ns. Mitigated by a comment at each site naming the cost.
+- **The two dicts are private**, so a rename inside a registry now breaks two
+  extra call sites. Both are in-package and covered by the type checker.
+- **Small absolute win.** ~57 ns will not change C2's ranking; the change is
+  worth it only because the hot path is the framework's core claim.

--- a/planning/releases/3.1.2.md
+++ b/planning/releases/3.1.2.md
@@ -1,0 +1,64 @@
+# modern-di 3.1.2 — a warm singleton hit loses two method frames
+
+A cached resolve reached its compiled resolver through one method call and its
+`CacheItem` through another. Both methods open with a dict lookup that hits and
+returns, so on the warm path both frames were pure indirection. They are now
+inlined at the call site, with the method called only on a miss.
+
+**No API changes. No behaviour changes.** Purely a hot-path trim.
+
+## Performance
+
+- **A warm singleton hit is ~25% faster.** `ProvidersRegistry.resolver_for` and
+  `CacheRegistry.fetch_cache_item` are inlined on their hit paths. Measured on
+  an Apple M4 / CPython 3.14.6, 300 000 iterations × 11 rounds:
+
+  | | 3.1.1 | 3.1.2 |
+  |---|---|---|
+  | warm singleton, by reference | 170 ns | **128 ns** |
+  | warm singleton, by type | 208 ns | **163 ns** |
+  | transient resolve, by reference | 304 ns | **276 ns** |
+
+  The first of the two inlines sits in `resolve_provider`, so **every top-level
+  resolve** benefits, not only cached ones — which is why the transient case
+  moves too.
+
+  On the published comparative table the warm-singleton (C2) ratios move
+  3.88 → **2.94** against dependency-injector, 2.80 → **2.13** against
+  that-depends, 1.32 → **1.06** against dishka, and 3.02 → **2.40** against
+  wireup. Both rivals whose implied absolutes that page prints are unchanged
+  (~48 ns and ~67 ns), which is the check that the movement is modern-di's and
+  not measurement drift. On the by-reference basis modern-di's warm hit is now
+  the faster of modern-di and dishka.
+
+  The bound stated when this was planned holds: it trims the cell, it does not
+  close it. dependency-injector's ~48 ns hit is a C-level slot read on a Cython
+  core, which pure Python does not reach.
+
+## What did not change
+
+The miss paths are untouched. `resolver_for` still owns the cycle-safe
+compilation thunk and the memo write; `fetch_cache_item` still uses `setdefault`,
+so concurrent first-resolvers share one `CacheItem` through a single atomic op —
+the property the singleton cache and its double-checked lock depend on.
+Registry mutation still clears the memo and forces a recompile, and a
+`RecursionError` raised while compiling is still converted to
+`CircularDependencyError`.
+
+A further step is **deliberately not taken**: an APP-scoped resolver could close
+over its `CacheItem` and reach ~16 ns, but that requires the providers registry
+to reference its root container — reintroducing the reference cycle removed in
+3.1.1. It needs a weakref and a proof, for ~30 ns.
+
+## Downstream
+
+No action needed. No API changed; integrations pick the improvement up on
+upgrade.
+
+## Internals
+
+- 452 tests, 100% line coverage, Python 3.10–3.14 including free-threaded 3.14t;
+  `ruff`, `ty` clean.
+- Guard tier: `g2_cached_resolve` −22%, `g17_resolve_by_type_large_registry`
+  −20%, `g14_concurrent_cached_hit` −24% (8 000 warm reads per batch). No
+  scenario regressed.


### PR DESCRIPTION
Implements the warm-singleton (C2) item from [ROADMAP.md](ROADMAP.md), specced in
[`planning/changes/2026-07-28.01-warm-singleton-inlining.md`](planning/changes/2026-07-28.01-warm-singleton-inlining.md).

## The defect

A cached resolve reached its compiled resolver through `ProvidersRegistry.resolver_for` and
its `CacheItem` through `CacheRegistry.fetch_cache_item`. Both methods open with a dict
lookup that hits and returns, so on the warm path both frames were pure indirection.

Measured before starting (Apple M4 / CPython 3.14.6, 300k iterations × 9 rounds), which
reproduced the roadmap's estimates almost exactly:

| | ns | roadmap said |
|---|---|---|
| warm hit, end to end | 168.5 | ~170 |
| `resolver_for` alone | 55.3 | ~56 |
| `fetch_cache_item` alone | 42.4 | ~44 |

## The change

Inline both lookups at the call site; call the method only on a miss.

## Result

| | 3.1.1 | this PR |
|---|---|---|
| warm singleton, by reference | 170 ns | **128 ns** (−25%) |
| warm singleton, by type | 208 ns | **163 ns** (−21%) |
| transient resolve, by reference | 304 ns | **276 ns** (−9%) |

The transient case moves because the first inline sits in `resolve_provider`, so **every
top-level resolve** benefits, not only cached ones. Guard tier: `g2` −22%, `g17` −20%,
`g14_concurrent_cached_hit` −24% (8 000 warm reads per batch). Nothing regressed.

Published C2 ratios: 3.88 → **2.94** vs dependency-injector, 2.80 → **2.13** vs
that-depends, 1.32 → **1.06** vs dishka, 3.02 → **2.40** vs wireup. Both rivals whose
implied absolutes the page prints are unchanged (~48 ns and ~67 ns) — the check that the
movement is ours and not measurement drift.

**Bounded, as planned.** It trims the cell, it does not close it: dependency-injector's
~48 ns hit is a C-level slot read on a Cython core, which pure Python does not reach. The
roadmap's "roughly halve" was optimistic; the real figure is ~25%.

## What did not change

Miss paths are untouched — `resolver_for` keeps its cycle-safe compilation thunk and memo
write, `fetch_cache_item` keeps the `setdefault` that makes concurrent first-resolvers share
one `CacheItem`. Registry mutation still clears the memo and forces a recompile. The
`resolve_provider` inline stays inside the existing `try`, so a `RecursionError` while
compiling is still converted to `CircularDependencyError`.

A further step is **deliberately not taken**: an APP-scoped resolver could close over its
`CacheItem` and reach ~16 ns, but that requires the providers registry to reference its root
container — reintroducing the reference cycle removed in 3.1.1.

## Verification

`just test-ci` 452 passed at 100% coverage · `just lint-ci` clean · `just docs-build` clean ·
guard tier no regressions.

Includes the regenerated performance page and `planning/releases/3.1.2.md`, so this can be
tagged straight after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)