### PR TITLE
docs(migration): warn that suites asserting on closed break in 3.1

### DIFF
--- a/docs/migration/to-3.x.md
+++ b/docs/migration/to-3.x.md
@@ -264,6 +264,22 @@ part was wrong and has been corrected here: **validation is explicit-only as of 
 `open()` (and `with`/`async with`, which call it) no longer runs `validate()` — it only
 clears `closed`, unconditionally. Nothing validates automatically: not construction,
 not `open()`, not `add_providers`, not `resolve()`.
+
+!!! warning "A test suite that asserts on `closed` will fail"
+    3.1 is a relaxation for *callers*, but not for *tests that assert the lifecycle flag*.
+    Two 3.0-era assertions break, and both were found in the wild across the official
+    integrations:
+
+    - `assert container.closed is True` on a freshly built container — it is `False` in
+      3.1, because construction leaves it open.
+    - `with pytest.raises(ValidationFailedError): container.open()` — `open()` validates
+      nothing in 3.1, so it does not raise.
+
+    Both are mechanical to fix, but the second needs care: if a test's *subject* is the
+    lifecycle transition ("this signal opens the root"), flipping the assertion makes it
+    pass without proving anything. Close the container first, so the transition stays
+    observable. If the subject is the validation-ordering rule, point it at
+    `container.validate()` — the rule still holds, it just binds a different call.
 `container.validate()` is the only thing that walks the graph, and `Container(validate=...)`
 is deprecated — passing `True` or `False` is ignored and emits `ValidateArgumentWarning`
 (a `DeprecationWarning`), removed in 4.0. So in the "After (3.0)" example above, the comment


### PR DESCRIPTION
The 3.1 note in this guide says the mandatory-open requirement is "relaxed, not reversed", and the release notes say integrations need no code change. That is true of *runtime* code and of every `open()`/`with` call site — I verified those. It is **not** true of test suites that assert on the lifecycle flag, and that gap was found the hard way.

Three official integrations were red against 3.1.1 on their own `main` branches, for exactly two shapes:

- `assert container.closed is True` on a freshly built container — `False` in 3.1, since construction leaves it open. (arq ×2, celery ×1)
- `with pytest.raises(ValidationFailedError): container.open()` — `open()` validates nothing in 3.1, so it does not raise. (flask ×1)

This adds the caveat where someone hitting the failure will look, rather than amending the published release notes after the fact.

It also records the non-obvious part, which cost real thought while fixing those three: **flipping the assertion can silently gut the test.** celery's failing test existed to prove `worker_init` *opens* the root — with containers now born open, `assert closed is False` passes whether or not the signal does anything. That one needed the container closed first to keep the transition observable. Where the subject is the validation-ordering rule instead, the fix is to point it at `container.validate()`, since the rule still holds and only the call it binds to changed.

Fixes for all three integrations are open alongside this: [arq#8](https://github.com/modern-python/modern-di-arq/pull/8), [celery#9](https://github.com/modern-python/modern-di-celery/pull/9), [flask#8](https://github.com/modern-python/modern-di-flask/pull/8).

`just lint-ci` and `mkdocs build --strict` clean. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)