### PR TITLE
docs(planning): spec the 2.31.1 backport of the container GC fix

### DIFF
--- a/planning/changes/2026-07-28.02-backport-gc-fix-to-2x.md
+++ b/planning/changes/2026-07-28.02-backport-gc-fix-to-2x.md
@@ -1,0 +1,132 @@
+---
+summary: Backport the container reference-cycle fix to the 2.x line as 2.31.1 — a dormant `2.x` branch cut from tag 2.31.0, carrying the cherry-picked fix plus two branch-only guards (`make_latest: false`, a `ruff<0.16` pin) so the release neither steals 3.x's Latest badge nor trips lint drift the branch predates.
+---
+
+# Design: Backport the container reference-cycle fix as 2.31.1
+
+## Summary
+
+`64b7cec` (shipped in 3.1.1) stopped every `Container` being a reference cycle. The 2.x
+line still carries the bug and gets no upgrade path short of a major bump. Cut a `2.x`
+branch from tag `2.31.0`, cherry-pick the fix, and release `2.31.1` from it. This is a
+**one-off backport**, not the start of a maintained 2.x line: no support policy is stated
+anywhere, and the branch goes dormant after the tag. It exists afterwards only so a second
+backport, if one is ever warranted, has somewhere to land.
+
+## Motivation
+
+Each container stored itself in its own `_scope_map`, so no container — root or child —
+could be freed by reference counting; every one waited for a generational GC pass. An
+application building a container per request hands the collector work at its request rate.
+On 3.x this measured as 100 closed REQUEST children leaving 792 objects reclaimable only by
+the GC, versus 0 after the fix.
+
+2.x users get the bug with no remedy but a major upgrade. The fix is six lines at a site
+2.31.0 shares verbatim with the pre-fix 3.x code, so the cost of removing that dead end is
+close to zero.
+
+## Design
+
+### Branch and release mechanics
+
+Cut `2.x` from tag `2.31.0`. Work on `backport/2.31.1-container-reference-cycles`, PR into
+`2.x`, then tag `2.31.1` off green `2.x`.
+
+The existing automation needs no change on `main`:
+
+- `ci.yml` triggers on `pull_request: {}` with no base filter, so the PR is fully gated.
+- `docs.yml` and the benchmarks push job are `branches: [main]`, so a dormant branch
+  publishes nothing stale.
+- `release.yml` matches any bare-semver tag and checks out that tag with no branch
+  restriction; `just publish` runs `uv version $GITHUB_REF_NAME`, yielding `2.31.1`.
+
+### The cherry-pick
+
+`git cherry-pick 64b7cec` onto `2.31.0` auto-merges every file but one. Verified, not
+predicted:
+
+| File | Result |
+|---|---|
+| `modern_di/container.py` | auto-merges; byte-identical to the 3.x fix |
+| `tests/test_container.py` | auto-merges; updated contract test plus the new `test_closed_children_are_freed_without_the_cycle_collector` |
+| `architecture/containers.md`, `architecture/scopes.md`, `docs/providers/advanced-api.md` | auto-merge; the `architecture/` promotion rides along as the convention requires |
+| `planning/changes/2026-07-27.03-container-reference-cycles.md` | modify/delete conflict — the file postdates 2.31.0. Drop it. |
+
+The `2.x` branch carries **no** planning bundle: this file is the record and it lands on
+`main`, so the change index stays complete on the branch that owns it.
+
+### Two branch-only guards
+
+Neither is ever merged to `main`.
+
+**1. `release.yml` — don't steal the Latest badge.** The `softprops/action-gh-release@v3`
+step passes no `make_latest`, so GitHub defaults to marking the newest-published release as
+Latest. Tagging `2.31.1` after `3.1.2` would flip the repo badge backwards. PyPI is
+unaffected — resolvers pick the highest version, so `pip install modern-di` still gets 3.x,
+and only a `modern-di<3` pin picks up the backport. Because the workflow runs from the
+tagged commit, the guard must live on the branch:
+
+```yaml
+    prerelease: ${{ steps.meta.outputs.prerelease }}
+    make_latest: false   # backport branch: never merge to main
+    draft: false
+```
+
+**2. `pyproject.toml` — pin `ruff<0.16` in the `lint` group.** `just lint-ci` fails on
+**pristine** `2.31.0`, before any backport edit. `ruff` is unpinned and `uv.lock` is
+git-ignored, so CI resolves the newest ruff; 0.16.0 began formatting markdown code blocks
+(30 `.md` files, zero `.py`) and added rules 2.31.0 predates (`CPY001` and five others).
+Commit `80bf88e` adopted 0.16.0 on `main` and is not in 2.31.0. Under 0.15.22 both
+`ruff format --check` and `ruff check --no-fix` are clean. A frozen branch gets a frozen
+toolchain; backporting `80bf88e`'s config and 31 files of markdown churn onto a dormant
+branch buys nothing.
+
+### Release notes
+
+`planning/releases/2.31.1.md` is **mandatory** — `release.yml` aborts before PyPI if the
+file is missing on the tagged commit. Contents: the same fix and the same
+`Container.scope_map` contents change 3.1.1 documented (a root's map is now empty, a child's
+holds only ancestors; the property already emits a `DeprecationWarning` and no sibling
+integration reads it). **No benchmark figures.** 3.1.1's numbers were measured on the 3.x
+tree after the benchmark-suite fidelity rebuild, which 2.x predates; reprinting them as 2.x
+measurements would be a fabricated claim. Link to 3.1.1 for the measured effect.
+
+## Non-goals
+
+- **A maintained 2.x support policy.** One-off. Nothing in the repo promises future 2.x patches.
+- **Backporting anything else to 2.x** — no other 3.x fix, and not `80bf88e`'s lint adoption.
+- **Re-measuring benchmarks on the 2.x tree.** The fix's correctness does not depend on a 2.x figure.
+- **Removing the deprecated `scope_map` property.** Its contents change; its removal is not in scope.
+- **Changing `main`.** Every workflow and config edit is branch-local.
+
+## Testing
+
+Already run on a scratch worktree of the cherry-picked tree:
+
+- `just test-ci` — **433 passed, 100% line coverage.** The gate CI runs.
+- `just lint-ci` — green once `ruff<0.16` is pinned; `ty`, `eof-fixer` and
+  `planning/index.py --check` pass either way.
+
+On the branch, additionally: confirm `test_closed_children_are_freed_without_the_cycle_collector`
+fails before the `container.py` hunk and passes after (TDD order, the property that matters —
+reclaimed by refcount alone — not the shape of the map behind it), and confirm cross-scope
+resolution across a depth-3 chain.
+
+Post-tag: confirm PyPI shows `2.31.1` with `3.1.2` still the highest version, and that the
+GitHub Releases page still marks `3.1.2` as Latest.
+
+## Risk
+
+- **The `make_latest` guard is forgotten or mis-set** → the repo advertises `2.31.1` as its
+  latest release, which reads as a version rollback. Highest-likelihood failure here because
+  it is invisible until after an irreversible publish. Mitigation: it is a line in the same
+  PR as the fix, and the post-tag check above names it explicitly.
+- **PyPI is irreversible.** A bad `2.31.1` cannot be withdrawn, only yanked, and anyone
+  pinned `modern-di<3` picks it up automatically. Mitigation: tag only off a green `2.x`,
+  same rule as `main`.
+- **A consumer reads `scope_map` and depends on the self-entry** — a behavior change inside a
+  patch bump. The property is documented as internal, already warns on access, and a survey of
+  all 12 sibling `modern-di-*` integration repos found no references. Mitigation: state it in
+  the notes.
+- **The dormant branch rots.** Unpinned tooling drifts further; a future revival re-runs this
+  same lint archaeology. Accepted — the `ruff<0.16` pin freezes the one axis that already bit.


### PR DESCRIPTION
Specs a one-off backport of 64b7cec (shipped in 3.1.1) to the 2.x line as 2.31.1.

See `planning/changes/2026-07-28.02-backport-gc-fix-to-2x.md` for the rationale,
the verified cherry-pick result, and the two branch-only guards it requires.

No code change; `main` is untouched by the backport itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)