### PR TITLE
fix(container): backport the reference-cycle fix as 2.31.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,4 +79,7 @@ jobs:
           body_path: ${{ steps.meta.outputs.body_path }}
           generate_release_notes: ${{ steps.meta.outputs.generate_notes }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
+          # 2.x is a backport branch: 3.x is the current line, so a tag cut here must never
+          # take the "Latest release" badge. NEVER merge this line to main.
+          make_latest: false
           draft: false

--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -61,8 +61,11 @@ Rules:
   `ContainerClosedWarning` and self-reopens the container instead of raising `ContainerClosedError`
   (see [Lifecycle: close and reopen](#lifecycle-close-and-reopen) below).
 
-The child gets its own, independent `_scope_map` dict that includes all ancestors plus itself,
-enabling `find_container(scope)` to walk up to any ancestor scope in O(1).
+The child gets its own, independent `_scope_map` dict holding all of its ancestors, enabling
+`find_container(scope)` to reach any ancestor scope in O(1). The map never contains the container
+itself: a `scope: self` entry would make every container a reference cycle, so no container could
+be freed by reference counting and each would wait for a generational GC pass. `find_container`
+short-circuits on its own scope before consulting the map, so the self-entry was never read.
 
 ## Registry sharing
 

--- a/architecture/scopes.md
+++ b/architecture/scopes.md
@@ -35,15 +35,19 @@ the base one-liner with no breadcrumb prepended.
 
 ## How the container locates the right-scope container
 
-Each `Container` maintains a `scope_map: dict[IntEnum, Container]`. When a root container is created, the map is
-`{scope: self}`. Each child container extends the map: `{**parent.scope_map, child_scope: child}`.
+Each `Container` maintains a `scope_map: dict[IntEnum, Container]` of its **ancestors**. A root container's
+map is empty; each child extends its parent's: `{**parent.scope_map, parent_scope: parent}`. A container is
+never in its own map — that self-reference would make every container a reference cycle, leaving each one to
+be reclaimed by the garbage collector rather than by reference counting.
 
 `Container.find_container(scope)` performs the lookup:
 
-1. If `scope` is in `scope_map`, return the corresponding container immediately — no tree walk needed.
-2. If `scope` is not in `scope_map` and `scope > self.scope`, raise `ScopeNotInitializedError` (the required
+1. If `scope` is this container's own scope, return `self` — checked first, before the map, which is why the
+   map does not need a self-entry.
+2. If `scope` is in `scope_map`, return the corresponding container immediately — no tree walk needed.
+3. If `scope` is not in `scope_map` and `scope > self.scope`, raise `ScopeNotInitializedError` (the required
    child container has not been built yet).
-3. If `scope` is not in `scope_map` and `scope <= self.scope`, raise `ScopeSkippedError` (the scope was
+4. If `scope` is not in `scope_map` and `scope <= self.scope`, raise `ScopeSkippedError` (the scope was
    never present in this chain).
 
 The `scope_map` is built incrementally at construction time, so lookups are O(1). There is no runtime

--- a/docs/providers/advanced-api.md
+++ b/docs/providers/advanced-api.md
@@ -34,8 +34,9 @@ emits a `DeprecationWarning`; pass `cache=True` (defaults) or `cache=CacheSettin
 
 ### `find_container(scope)`
 
-`find_container(scope)` walks `_scope_map` and returns the container registered at
-`scope`; raises `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
+`find_container(scope)` returns `self` immediately when `scope` is the resolving container's own
+scope; otherwise it looks `scope` up in `_scope_map` and returns the ancestor registered there,
+raising `ScopeNotInitializedError` or `ScopeSkippedError` if the scope is absent.
 It is the primitive the compiled resolvers use to locate the container at a provider's
 scope when it differs from the resolving container's.
 
@@ -48,8 +49,11 @@ scope when it differs from the resolving container's.
 
 - **`parent_container`** — constructor kwarg and slot; the direct parent of a child container,
   or `None` for a root. Passing a `scope ≤ parent.scope` raises `InvalidChildScopeError`.
-- **`_scope_map`** — `dict[IntEnum, Container]` mapping every scope in the chain to its
-  container; built at construction time and inherited (plus the new scope) by each child.
+- **`_scope_map`** — `dict[IntEnum, Container]` mapping each **ancestor's** scope to its container;
+  built at construction time, a child inheriting its parent's map plus the parent itself. A root's
+  map is empty. The container is never in its own map — that self-reference would make every
+  container a reference cycle — and `find_container` never needs it, since it short-circuits on
+  its own scope first.
 - **`_lock`** — a `threading.RLock` instance, or `None` when the container was created with
   `use_lock=False`. A cached `Factory`'s compiled resolver hands it to `CacheItem.get_or_create`,
   which gates the cold-miss build so one instance is created per cache key.

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -94,8 +94,13 @@ class Container:
         self.closed = False
         self.scope = scope
         self.parent_container = parent_container
+        # Ancestors only, never self: a `scope: self` entry would make every container a reference
+        # cycle, so none could be freed by refcounting. `find_container` short-circuits on its own
+        # scope before consulting this map, so the self-entry was never read anyway.
         self._scope_map: dict[enum.IntEnum, typing_extensions.Self] = (
-            {**parent_container._scope_map, scope: self} if parent_container else {scope: self}  # noqa: SLF001
+            {**parent_container._scope_map, parent_container.scope: parent_container}  # noqa: SLF001
+            if parent_container
+            else {}
         )
         self.cache_registry = CacheRegistry()
         self.context_registry = ContextRegistry(context=context or {})

--- a/planning/releases/2.31.1.md
+++ b/planning/releases/2.31.1.md
@@ -1,0 +1,54 @@
+# modern-di 2.31.1 — containers stop being garbage the refcounter can't free
+
+A backport of the 3.1.1 fix to the 2.x line. Every container stored itself inside
+its own scope map, which made it a reference cycle: no container — root or child —
+could be freed by reference counting, so each one waited for a generational GC
+pass. An application that builds a container per request was handing the collector
+work at its request rate.
+
+**No API changes.** No integration needs updating.
+
+## Fix
+
+- **Containers are no longer reference cycles.** `Container.__init__` seeded
+  `_scope_map` with `{scope: self}`, so the container referenced a dict that
+  referenced the container. The map is now seeded from the parent instead — it
+  holds ancestors only. `find_container` already returned `self` for its own
+  scope *before* consulting the map, so the self-entry was never read and
+  resolution is unaffected.
+
+  For the measured effect, see the
+  [3.1.1 release notes](https://github.com/modern-python/modern-di/releases/tag/3.1.1).
+  Those figures were taken on the 3.x tree after its benchmark suite was rebuilt
+  for measurement fidelity, which this line predates; they are not restated here
+  as 2.x measurements.
+
+## Behavior change
+
+- **`Container.scope_map` no longer contains the container itself.** A root's map
+  is now empty and a child's holds only its ancestors. The property is documented
+  as an internal surface with no stability guarantee and already emits a
+  `DeprecationWarning`; a survey of all 12 sibling `modern-di-*` integration
+  repositories found no references to it. `find_container` is unaffected on both
+  its own-scope and ancestor paths.
+
+## Scope of this release
+
+2.31.1 is a **one-off backport**, not the start of a maintained 2.x line. Active
+development continues on 3.x, and upgrading remains the supported path — see the
+[3.x migration guide](https://modern-di.modern-python.org/migration/to-3.x/).
+
+## Packaging
+
+- The `lint` dependency group pins `ruff<0.16` on this branch, freezing the
+  toolchain alongside the code. Development-only: not a runtime dependency, and
+  no effect on installers.
+
+## Downstream
+
+No action needed. No API changed, and no integration reads the affected property.
+
+## Internals
+
+- 433 tests, 100% line coverage, Python 3.10–3.14 including the free-threaded
+  3.14t build.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ dev = [
     "pytest-benchmark",
 ]
 lint = [
-    "ruff",
+    # 2.x is a dormant backport branch, so its toolchain is frozen too. ruff 0.16 began
+    # formatting markdown code blocks and added rules this tree predates; `80bf88e` adopted
+    # both on main and is not in 2.31.0. Dev-only; not a runtime dependency.
+    "ruff<0.16",
     "ty",
     "eof-fixer",
     "typing-extensions",

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,10 +1,12 @@
 import copy
 import dataclasses
+import gc
 import inspect
 import pathlib
 import re
 import typing
 import warnings
+import weakref
 
 import pytest
 
@@ -533,9 +535,51 @@ def test_private_lock_and_scope_map_back_the_machinery() -> None:
     assert root._lock.acquire()  # reentrant  # noqa: SLF001
     root._lock.release()  # noqa: SLF001
     root._lock.release()  # noqa: SLF001
-    # child inherits the parent's scope map plus its own scope
-    assert set(child._scope_map) == {Scope.APP, Scope.REQUEST}  # noqa: SLF001
+    # The map holds ancestors only — never the container itself, which would be a reference cycle.
+    # `find_container` short-circuits on its own scope, so a self-entry would be dead weight.
+    assert set(child._scope_map) == {Scope.APP}  # noqa: SLF001
     assert child._scope_map[Scope.APP] is root  # noqa: SLF001
+    assert root._scope_map == {}  # noqa: SLF001
+    assert child.find_container(Scope.REQUEST) is child  # own scope still resolves
+    assert child.find_container(Scope.APP) is root
+
+
+def test_closed_children_are_freed_without_the_cycle_collector() -> None:
+    # A container must not reference itself: a self-reference makes every container cyclic garbage,
+    # so a request-scoped app produces work for the collector at its request rate. Asserts the
+    # property that matters (reclaimable by refcount alone), not the shape of the map behind it.
+    class Sentinel:  # rides in each child's context so liveness is observable
+        pass
+
+    freed = 0
+
+    def _count(_: object) -> None:
+        nonlocal freed
+        freed += 1
+
+    n_children = 100
+    root = Container(scope=Scope.APP)
+    root.open()
+    gc.collect()
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        children = []
+        for _ in range(n_children):
+            sentinel = Sentinel()
+            child = root.build_child_container(scope=Scope.REQUEST, context={Sentinel: sentinel})
+            weakref.finalize(sentinel, _count, None)
+            child.open()
+            child.close_sync()
+            children.append(child)
+        del children, child, sentinel
+        # Both halves matter: the children really did become garbage (freed == n_children), AND
+        # refcounting alone reclaimed them, leaving the cycle collector nothing to do.
+        assert freed == n_children
+        assert gc.collect() == 0
+    finally:
+        if was_enabled:
+            gc.enable()
 
 
 def test_use_lock_false_yields_no_private_lock() -> None:


### PR DESCRIPTION
One-off backport of 64b7cec (shipped in 3.1.1) to the 2.x line.

See `planning/changes/2026-07-28.02-backport-gc-fix-to-2x.md` on `main` for the
rationale and the verified cherry-pick result.

Alongside the fix, two guards that exist only on this branch and must never reach
`main`:

- `make_latest: false` in `release.yml`, so tagging 2.31.1 after 3.1.2 does not
  move the GitHub "Latest release" badge backwards. PyPI is unaffected.
- `ruff<0.16` in the `lint` group. Pristine 2.31.0 already fails `just lint-ci`:
  ruff is unpinned, uv.lock is git-ignored, and 0.16.0 began formatting markdown
  code blocks while adding rules this tree predates. `80bf88e` adopted both on
  main and is not in 2.31.0.

`Container.scope_map` (deprecated, warns on access) no longer contains the
container itself; documented in the 2.31.1 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)