### PR TITLE
docs(release): add the missing Downstream caveat to the 2.31.1 notes

### DIFF
--- a/planning/releases/2.31.1.md
+++ b/planning/releases/2.31.1.md
@@ -46,7 +46,16 @@ development continues on 3.x, and upgrading remains the supported path — see t
 
 ## Downstream
 
-No action needed. No API changed, and no integration reads the affected property.
+No action needed to adopt this release: no API changed, and no integration reads the
+affected property.
+
+One caveat if you use `modern-di-aiohttp` or `modern-di-starlette`. Those integrations
+carried a second, independent per-request reference cycle in their own middleware, fixed
+only in their 3.1.0 releases — and those require `modern-di>=3.1.1,<4`, so they cannot be
+used on this line. The newest 2.x-compatible release of either integration (2.2.0, pinning
+`modern-di>=2.28.0,<3`) still contains it. On 2.31.1 those two therefore still leave a
+per-request container that only the collector can free; only the 3.x line clears both
+cycles.
 
 ## Internals
 


### PR DESCRIPTION
Follow-up to #388. This commit was pushed after that PR was squash-merged, so it did not
make it onto `2.x`.

It adds the Downstream caveat to `planning/releases/2.31.1.md`: `modern-di-aiohttp` and
`modern-di-starlette` each carry a second, independent per-request reference cycle in their
own middleware, fixed only in their 3.1.0 releases, which pin `modern-di>=3.1.1,<4` and so
cannot be used on this line. Their newest 2.x-compatible releases (both 2.2.0) still carry
it.

`release.yml` publishes this file verbatim as the GitHub Release body, so this needs to be
on `2.x` before the `2.31.1` tag is cut.

Generated with Claude Code