### PR TITLE
docs(release): stop the 2.31.1 opening reading as a blanket all-clear

### DIFF
--- a/planning/releases/2.31.1.md
+++ b/planning/releases/2.31.1.md
@@ -6,7 +6,9 @@ could be freed by reference counting, so each one waited for a generational GC
 pass. An application that builds a container per request was handing the collector
 work at its request rate.
 
-**No API changes.** No integration needs updating.
+**No API changes**, and no integration has to change its `modern-di` pin to adopt
+this release. That is not the same as every integration benefiting equally — see
+the Downstream section below for the aiohttp and Starlette caveat.
 
 ## Fix
 


### PR DESCRIPTION
Follow-up to #390. The notes opened with "**No API changes.** No integration needs
updating", which sat directly above a Downstream caveat explaining that
`modern-di-aiohttp` and `modern-di-starlette` users keep a second per-request cycle
on this line. Both statements were true — the opening was about version pins, the
caveat about a different bug — but together they read as a contradiction.

Rewords the opening to say what it means and point down at the caveat.

Docs only; the `2.31.1` tag and the PyPI artifact are unaffected. The published
GitHub Release body is edited separately to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)