### PR TITLE
docs(roadmap): mark the C2 warm-singleton inlining shipped in 3.1.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,20 +47,25 @@ Strawberry, Quart, RQ, APScheduler, Jobify, Flet, ag2.
 - **Public, reproducible benchmark suite** with neutral methodology —
   shipped; see [Performance](https://modern-di.modern-python.org/introduction/performance/).
 - **Optional OpenTelemetry instrumentation** of resolution and finalization.
-- **Trim the warm-singleton path (C2)** — the one published scenario where
-  modern-di is clearly last: ~3.9x dependency-injector and ~2.8x that-depends.
-  A warm hit costs ~170 ns, of which two Python method calls are pure
-  indirection — `ProvidersRegistry.resolver_for` on every top-level resolve
-  (~56 ns) and `CacheRegistry.fetch_cache_item` inside the compiled resolver
-  (~44 ns). Inlining each one's dict-lookup hit path, and calling the method
-  only on a miss, keeps the cycle-safe compilation thunk and the shared-item
-  guarantee intact. Bounded win: it should roughly halve the cell, not close
-  it — dependency-injector's ~47 ns is a C-level slot read on a Cython core,
-  which pure Python does not reach. A third step exists and is **deliberately
-  deferred**: an APP-scoped resolver could close over its `CacheItem` and reach
-  ~16 ns, but the target is only invariant because one registry belongs to one
-  root, so the registry would have to reference its root — the container
-  reference cycle removed in 3.1.1. That needs a weakref and a proof, for ~30 ns.
+- **Trim the warm-singleton path (C2)** — the published scenario where modern-di
+  trails by the widest margin, now 2.94x dependency-injector and 2.13x
+  that-depends. Two Python method calls that were pure indirection on a warm hit
+  — `ProvidersRegistry.resolver_for` on every top-level resolve and
+  `CacheRegistry.fetch_cache_item` inside the compiled resolver — are inlined on
+  their dict-lookup hit paths, with the method called only on a miss, keeping the
+  cycle-safe compilation thunk and the shared-item guarantee intact;
+  **shipped in 3.1.2**. The guard tier measured a ~25% faster warm hit
+  (170 → 128 ns), and the published cell moved from 3.88x to 2.94x against
+  dependency-injector and 2.80x to 2.13x against that-depends, with both rivals'
+  absolutes unchanged — the check that the movement is modern-di's and not
+  measurement drift. The bound stated when this was planned held: it trimmed the
+  cell, it did not close it. dependency-injector's ~48 ns is a C-level slot read
+  on a Cython core, which pure Python does not reach.
+  A third step remains open and is **deliberately deferred**: an APP-scoped
+  resolver could close over its `CacheItem` and reach ~16 ns, but the target is
+  only invariant because one registry belongs to one root, so the registry would
+  have to reference its root — the container reference cycle removed in 3.1.1.
+  That needs a weakref and a proof, for ~30 ns.
 
 ### Docs & ecosystem
 - **Canonical on-ramp per integration** — every official integration ships a

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -25,7 +25,11 @@ lifecycle, and trails the two `exec`-codegen frameworks by 1.3-1.9x on transient
 - **C2 warm-singleton whole-aggregate memoization (highest leverage).** modern-di's warm hit (292 ns) is
   3-4.8x slower than the slot/memoized rivals (`dependency-injector` 61 ns C-level slot; `that-depends`
   85 ns lock-free slot; `wireup` 98 ns self-modifying closure) — it still pays the `resolver_for` dispatch
-  + override front-guard + `fetch_cache_item` on every warm hit. The wireup technique — after first build,
+  + override front-guard + `fetch_cache_item` on every warm hit. **Superseded in part by 3.1.2:** the
+  `resolver_for` and `fetch_cache_item` hit paths are now inlined at their call sites (the method runs only
+  on a miss), which cut the warm hit ~25% and moved the published C2 cell to 2.94x dependency-injector /
+  2.13x that-depends. The override front-guard and the resolve→`resolver_for` dispatch remain, so the
+  verdict below is unchanged. The wireup technique — after first build,
   swap the cached provider's stored resolver to a bare `return value` closure — would make the warm hit
   near-free. It was deferred from `2026-07-16.02` as a Non-goal because it is **non-trivial in modern-di**
   (unlike wireup): the resolver is shared tree-wide on the registry while the cached value is


### PR DESCRIPTION
The ROADMAP was describing shipped work as pending.

## The problem

`ROADMAP.md`'s **Trim the warm-singleton path (C2)** entry proposed inlining `ProvidersRegistry.resolver_for` and `CacheRegistry.fetch_cache_item` on their hit paths — which is exactly what shipped in #384 and released as **3.1.2**. It still quoted the pre-3.1.2 figures (`~170 ns`, `~3.9x` dependency-injector, `~2.8x` that-depends), so the one published cell modern-di had just improved read as untouched.

Every other completed item in that section is marked **shipped**. This one slipped because 3.1.2 was cut in a separate session — the exact rot the repo's promotion rule exists to prevent.

## What changed

**`ROADMAP.md`** — the entry now states what shipped and carries the current numbers, keeping the two harnesses distinct rather than conflating them:

- guard tier: a ~25% faster warm hit, 170 → 128 ns
- published comparative cell: 3.88 → **2.94** vs dependency-injector, 2.80 → **2.13** vs that-depends, both rivals' absolutes unchanged

It also records that the bound stated when the work was planned held — it trimmed the cell, it did not close it, because dependency-injector's ~48 ns is a C-level slot read on a Cython core. The deliberately-deferred third step (an APP-scoped resolver closing over its `CacheItem`, ~16 ns, requiring a weakref and a proof against the reference cycle removed in 3.1.1) stays as the open item.

**`planning/deferred.md`** — carried the same claim in the present tense: that a warm hit "still pays the `resolver_for` dispatch + override front-guard + `fetch_cache_item`". Two of those three are now inlined. Its 2026-07-17 comparison table is an explicitly dated snapshot and is left alone; only the superseded sentence is marked. The override front-guard and the resolve→`resolver_for` dispatch do remain, so that entry's verdict — the wireup-style swap stays dropped — is unchanged.

Docs only; nothing in `modern_di/` is touched. Figures taken from the published performance page and the 3.1.2 release notes, not from memory. `just lint-ci` clean.