### PR TITLE
perf(container): unlock container reopen, drop the context-resolve cast

### DIFF
--- a/architecture/concurrency.md
+++ b/architecture/concurrency.md
@@ -1,16 +1,13 @@
 # Concurrency and free-threaded (PEP 703) safety
 
 modern-di is safe to resolve from multiple threads, and supported on free-threaded
-CPython (PEP 703, the `3.14t` build) at trove level **`2 - Beta`**: production-ready
+CPython (PEP 703, the `3.14t` build) at level **`2 - Beta`**: production-ready
 and tested under real multithreading, with the caveats below documented. This
 page is the standing contract.
 
 ## The lifecycle
 
-A container has three phases, and thread-safety is defined per phase — the same
-build → resolve → dispose shape every comparable DI framework assumes (a survey
-of the field found no framework that supports tearing a container down while
-other threads resolve from it):
+A container has three phases, and thread-safety is defined per phase — build → resolve → dispose shape:
 
 1. **Configure — single-threaded (startup).** Registering providers
    (`add_providers`, group construction) mutates the registry under its own lock,
@@ -25,9 +22,9 @@ other threads resolve from it):
 3. **Close — single-threaded (shutdown).** `close_sync` / `close_async` run
    finalizers and reset caches/overrides; `open` reopens a closed container so it
    can resolve and build children again. Close (or reopen) a container at a
-   single-threaded edge, after concurrent resolution has quiesced — **closing or
-   reopening a container while other threads still resolve from it is not
-   supported.**
+   single-threaded edge, after all concurrent resolution has finished —
+   **closing or reopening a container while other threads still resolve from it
+   is not supported.**
 
 Reuse-after-close is a race the concurrent resolve phase does handle, distinct
 from the unsupported race above: once a container has settled into the closed
@@ -36,13 +33,15 @@ independently calling `resolve` on that (now-closed) container at once — each
 unaware the others are doing the same. A container is open from construction
 (see [containers.md](containers.md#optional-open-lifecycle)), so this is the
 only path back to `closed = True` in the first place. `resolve_provider` calls
-`_prepare()` whenever `self.closed` is `True`, under the container's own
-`_lock` when `use_lock=True`. It re-checks `closed` after acquiring the lock,
-so a thread that loses the race to reopen simply finds the container already
-open and returns without warning again. `closed = False` is the last thing
-`_prepare()` does, after the warning is already emitted, so N threads racing a
-closed container produce exactly one `ContainerClosedWarning` and one reopen —
-never a double-warn.
+`_prepare()` whenever `self.closed` is `True`; `_prepare()` warns and sets
+`closed = False`, unlocked. The reopen needs no lock because it is idempotent —
+N threads racing a closed container all write the same `False`, and they go on
+to share one singleton via the cache lock below. What is *not* serialized is the
+warning: each racing thread may emit its own `ContainerClosedWarning`. The
+contract is **at least one** warning per reuse-after-close, not exactly one.
+Under the default warning filters Python's own per-location registry collapses
+the duplicates anyway; `simplefilter("always")` reveals them. `open()` is the
+same unlocked idempotent write, minus the warning.
 
 ## The model
 

--- a/architecture/containers.md
+++ b/architecture/containers.md
@@ -159,10 +159,12 @@ close, ready to be returned again without re-running the creator.
 
 `_prepare()` — not `open()` — is the primitive the resolve path calls: `resolve_provider` (and the
 compiled-resolver dispatch it wraps) calls it whenever `self.closed` is `True`, before doing anything
-else. Under the container's `_lock` it re-checks `closed` (another thread may have reopened the
-container already); if still closed, it warns with `ContainerClosedWarning` and clears `closed`. `open()`
-is a separate, public entry point that clears `closed` unconditionally, with no closed-check and no
-warning — a deliberate reopen is not a diagnostic-worthy event. Neither method runs validation; `open()`
+else. That caller-side `if closed` check is the only guard: `_prepare()` itself takes no lock and makes
+no re-check, warning with `ContainerClosedWarning` and clearing `closed` unconditionally. Concurrent
+reuse of one closed container therefore warns **at least once**, not exactly once — see
+[concurrency.md](concurrency.md#the-lifecycle). `open()` is a separate, public entry point that clears
+`closed` unconditionally, with no closed-check and no warning — a deliberate reopen is not a
+diagnostic-worthy event. Neither method runs validation; `open()`
 is a plain lifecycle op, symmetric with `close_sync()` / `close_async()`. `Container` implements both
 sync (`__enter__` / `__exit__`) and async (`__aenter__` / `__aexit__`) context managers; both call
 `open()` on entry and `close_sync()` / `close_async()` on exit.

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -1,4 +1,3 @@
-import contextlib
 import enum
 import os
 import pathlib
@@ -344,18 +343,19 @@ class Container:
         container deliberately — an implicit reuse reopens too, but warns. Opening an
         open container is a no-op. Validation is not run here; call :meth:`validate`.
         """
-        with self._lock or contextlib.nullcontext():
-            self.closed = False
+        self.closed = False
 
     def _prepare(self) -> None:
-        """Reopen a closed container on implicit reuse, warning once."""
-        with self._lock or contextlib.nullcontext():
-            if self.closed:  # re-checked under the lock: another thread may have reopened already
-                warnings.warn(
-                    exceptions.ContainerClosedWarning(container_scope=self.scope),
-                    stacklevel=_caller_stacklevel(),
-                )
-                self.closed = False
+        """Reopen a closed container on implicit reuse, warning the caller.
+
+        Callers guard with ``if closed``. Unlocked: threads racing a closed container
+        may each warn, but every one of them writes the same ``closed = False``.
+        """
+        warnings.warn(
+            exceptions.ContainerClosedWarning(container_scope=self.scope),
+            stacklevel=_caller_stacklevel(),
+        )
+        self.closed = False
 
     def __enter__(self) -> "typing_extensions.Self":
         self.open()

--- a/modern_di/providers/context_provider.py
+++ b/modern_di/providers/context_provider.py
@@ -41,10 +41,12 @@ class ContextProvider(AbstractProvider[types.T_co]):
         if value is types.UNSET:
             resolving = container.find_container(self.scope)
             raise exceptions.ContextValueNotSetError(context_type=self.context_type, scope_name=resolving.scope.name)
-        return typing.cast(types.T_co, value)
+        # `is UNSET` does not narrow in ty (UNSET is a Final instance, not a tracked singleton);
+        # isinstance would narrow but costs ~10ns on the context resolve path.
+        return value  # ty: ignore[invalid-return-type]
 
-    def fetch_context_value(self, container: "Container") -> types.T_co | object:
+    def fetch_context_value(self, container: "Container") -> "types.T_co | types.UnsetType":
         container = container.find_container(self.scope)
-        if container.closed:  # guarded: `_prepare()` takes the lock before re-checking `closed`
+        if container.closed:  # guarded: `_prepare()` warns and reopens unconditionally
             container._prepare()  # noqa: SLF001
         return container.context_registry.find_context(self.context_type)

--- a/modern_di/registries/context_registry.py
+++ b/modern_di/registries/context_registry.py
@@ -8,7 +8,7 @@ from modern_di import types
 class ContextRegistry:
     context: dict[type[typing.Any], typing.Any]
 
-    def find_context(self, context_type: type[types.T]) -> types.T | object:
+    def find_context(self, context_type: type[types.T]) -> "types.T | types.UnsetType":
         if context_type is not None and context_type in self.context:
             return typing.cast(types.T, self.context[context_type])
 

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -71,13 +71,13 @@ def test_concurrent_resolution_shares_app_singletons() -> None:
     assert all(request_ok)  # every child resolved that same singleton through its request object
 
 
-def test_concurrent_reuse_after_close_warns_exactly_once() -> None:
+def test_concurrent_reuse_after_close_warns_and_reopens() -> None:
     class G(Group):
         leaf = providers.Factory(creator=_Leaf, scope=Scope.APP, cache=True)
 
     container = Container(scope=Scope.APP, groups=[G])
     container.open()
-    container.close_sync()  # explicit close: the next resolve must warn — once, not per thread
+    container.close_sync()  # explicit close: the next resolve must warn and reopen
     n = 8
     results: list[_Leaf] = []
     barrier = threading.Barrier(n)
@@ -87,7 +87,7 @@ def test_concurrent_reuse_after_close_warns_exactly_once() -> None:
         results.append(container.resolve_provider(G.leaf))
 
     with warnings.catch_warnings(record=True) as recorded:
-        warnings.simplefilter("always")  # no per-location dedup: a second warning must be visible
+        warnings.simplefilter("always")  # no per-location dedup: every warning must be visible
         threads = [threading.Thread(target=worker) for _ in range(n)]
         for thread in threads:
             thread.start()
@@ -95,6 +95,8 @@ def test_concurrent_reuse_after_close_warns_exactly_once() -> None:
             thread.join()
 
     assert len(results) == n
-    assert all(result is results[0] for result in results)  # reopened once; one singleton
+    assert all(result is results[0] for result in results)  # one singleton, whatever the reopen race
     assert container.closed is False
-    assert len([w for w in recorded if issubclass(w.category, ContainerClosedWarning)]) == 1
+    # Reopen is unlocked, so racing threads may each warn; the contract is at least one, and the
+    # reopen itself is idempotent — every thread writes the same `closed = False`.
+    assert len([w for w in recorded if issubclass(w.category, ContainerClosedWarning)]) >= 1


### PR DESCRIPTION
## Why

Two locks on the resolve path that bought nothing.

`_prepare()` — the self-heal the resolve path calls whenever it finds `closed = True` — acquired the container's `RLock` and re-checked `closed` under it, so that N threads racing one closed container produced exactly one `ContainerClosedWarning` and one reopen. But every caller already guards with `if closed`, and the write itself is idempotent: each racing thread stores the same `closed = False`. The lock was serialising threads to deduplicate a *warning*, on a path whose entire job is to recover from misuse. `open()` took the same lock for the same single store.

Separately, `ContextProvider.resolve` ended with `typing.cast(types.T_co, value)`. `typing.cast` is a real Python function call, so it cost a frame on every context resolve (the G9 path) purely to satisfy the type checker.

## Design

Both reopens become plain unlocked stores. `_prepare()` warns and clears `closed` unconditionally; the caller's `if closed` is the only guard.

The trade-off is a genuinely weaker contract, and it is stated rather than hidden: **concurrent reuse of one closed container warns at least once, not exactly once.** Threads that race all warn. Under default warning filters, Python's own per-location `__warningregistry__` collapses the duplicates, so this is invisible unless a caller sets `simplefilter("always")`. What is preserved is what actually matters: all racing threads still converge on one open container and share one singleton, via the cache lock, which is untouched.

For the cast: rather than delete it and widen the annotation, the annotations are corrected to what these methods actually return. `fetch_context_value` and `ContextRegistry.find_context` said `T | object`, which is true but useless — they return `T` or `UNSET`, never arbitrary `object`. They now say `T | UnsetType`.

`is UNSET` does not narrow in `ty` (`UNSET` is a `Final` instance, not a tracked singleton), so a choice remained. Measured, per call, including ~20ns of harness overhead in each:

| | ns/call | vs before |
|---|---|---|
| `is UNSET` + `typing.cast` (before) | 42.7 | baseline |
| `isinstance(value, UnsetType)` | 34.0 | -8.7 ns |
| `is UNSET` + `ty: ignore` (chosen) | 24.0 | **-18.7 ns** |

Chose the fastest and paid for it with one scoped, commented `ty: ignore` on a single return.

## Non-goals

- **Does not make close/reopen thread-safe against concurrent resolution.** Closing a container while other threads resolve from it remains unsupported, exactly as `architecture/concurrency.md` already documents. This PR only changes the reuse-after-close path, which is the race that *is* handled.
- **Does not touch the cache creation lock.** Double-checked singleton creation is unchanged; that lock is what still guarantees one instance.
- **Does not remove the remaining `typing.cast` in `ContextRegistry.find_context`.** Same micro-cost, same path, but out of scope here.
- **Does not chase the last ~10ns** anywhere else on the context path.

## Verification

- `just test-ci` — 452 passed, **100% line coverage** (the gate).
- `just lint-ci` — clean, including `ruff`, `ty`, planning validation, and link checking.
- `tests/test_free_threading.py` run **200x under the GIL build** and **100x under free-threaded 3.14t** (`cpython-3.14.6+freethreaded`), all passing — this is where an unlocked reopen would surface if it were unsafe.
- Cast removal measured directly (table above): **-18.7 ns per context resolve**. Not read off `just bench`, whose guard medians are quantised to a 41ns tick and cannot resolve a move this size — the method `benchmarks/README.md` prescribes for small changes.

One honesty note for review: `test_concurrent_reuse_after_close_warns_and_reopens` now asserts `>= 1` warnings, so it no longer distinguishes this implementation from the locked one. That is inherent to relaxing the contract — "at least once" is not falsifiable by counting. Its load-bearing assertions are the ones that survived: all threads receive the same singleton, and the container ends open.

---

### Before merging

- [x] **Behaviour changed?** `architecture/concurrency.md` rewritten for the at-least-once contract; `architecture/containers.md` "Open and reopen" corrected — it still described the under-lock re-check.
- [x] **Rejected an alternative?** None needing a decision record.
- [x] **Found real work you are not doing now?** Nothing beyond the non-goals above.
- [x] **New or sharpened domain term?** None.
- [x] `just lint-ci` and `just test-ci` pass.
