### PR TITLE
chore(lint): relocate structural suppressions, sharpen error annotations

### DIFF
--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -221,7 +221,7 @@ class InvalidScopeTypeError(ContainerError):
 
     __slots__ = ("scope_value",)
 
-    def __init__(self, *, scope_value: typing.Any) -> None:  # noqa: ANN401
+    def __init__(self, *, scope_value: object) -> None:
         self.scope_value = scope_value
         super().__init__(f"Scope must be an enum.IntEnum member; got {scope_value!r} ({type(scope_value).__name__}).")
 
@@ -348,8 +348,8 @@ class ArgumentResolutionError(ResolutionError):
         self,
         *,
         arg_name: str,
-        arg_type: typing.Any,  # noqa: ANN401
-        bound_type: typing.Any,  # noqa: ANN401
+        arg_type: type | None,
+        bound_type: "type | typing.Callable[..., typing.Any]",
         suggestions: "list[suggester.Suggestion] | None" = None,
         member_types: list[type] | None = None,
     ) -> None:
@@ -383,7 +383,7 @@ class CreatorCallError(ResolutionError):
 
     __slots__ = ("creator", "original_error")
 
-    def __init__(self, *, creator: typing.Any, original_error: Exception) -> None:  # noqa: ANN401
+    def __init__(self, *, creator: "typing.Callable[..., typing.Any]", original_error: Exception) -> None:
         self.creator = creator
         self.original_error = original_error
         creator_name = getattr(creator, "__name__", repr(creator))
@@ -395,7 +395,7 @@ class CreatorCallError(ResolutionError):
     def from_type_error(
         cls,
         *,
-        creator: typing.Any,  # noqa: ANN401
+        creator: "typing.Callable[..., typing.Any]",
         exc: TypeError,
         resolution_step: "typing.Callable[[], ResolutionStep]",
     ) -> "CreatorCallError | None":
@@ -557,7 +557,7 @@ class UnknownFactoryKwargError(RegistrationError):
     def __init__(
         self,
         *,
-        creator: typing.Any,  # noqa: ANN401
+        creator: "typing.Callable[..., typing.Any]",
         unknown_keys: list[str],
         known_keys: list[str],
     ) -> None:
@@ -591,7 +591,7 @@ class UnsupportedCreatorParameterError(RegistrationError):
 
     __slots__ = ("creator", "parameter_name", "reason")
 
-    def __init__(self, *, creator: typing.Any, parameter_name: str, reason: str) -> None:  # noqa: ANN401
+    def __init__(self, *, creator: "typing.Callable[..., typing.Any]", parameter_name: str, reason: str) -> None:
         self.creator = creator
         self.parameter_name = parameter_name
         self.reason = reason

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -39,12 +39,12 @@ def _positional_names(f: "Factory[typing.Any]", plan: "WiringPlan") -> "tuple[st
     """
     if not plan.pure_provider:  # pure_provider already means no static and no context kwargs
         return None
-    names = tuple(f._parsed_kwargs)  # noqa: SLF001
+    names = tuple(f._parsed_kwargs)
     if tuple(plan.provider_kwargs) != names:
         return None  # a param was omitted/reordered, or a kwargs-overlay added an extra -> not a clean prefix
-    if any(item.is_keyword_only for item in f._parsed_kwargs.values()):  # noqa: SLF001
+    if any(item.is_keyword_only for item in f._parsed_kwargs.values()):
         return None
-    if names and f._has_positional_only_gap:  # noqa: SLF001
+    if names and f._has_positional_only_gap:
         return None  # positional-only param, dropped from _parsed_kwargs by the parser, would shift positional binding
     return names
 
@@ -70,7 +70,7 @@ def compile_resolver(
 def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: positional + kwargs, each flat to hold the per-node frame at 1)
     f: "Factory[typing.Any]", registry: "ProvidersRegistry"
 ) -> "typing.Callable[[Container], typing.Any]":
-    plan = registry.plan_for(f, f._parsed_kwargs, f._kwargs)  # noqa: SLF001
+    plan = registry.plan_for(f, f._parsed_kwargs, f._kwargs)
     if plan.unwireable:
         return _compile_unwireable_factory(f, plan)
     prov: _ProvResolvers = tuple((name, registry.resolver_for(p)) for name, p in plan.provider_kwargs.items())
@@ -79,16 +79,16 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
     pure = plan.pure_provider
     scope = f.scope
     pid = f.provider_id
-    resolution_step = f._resolution_step  # noqa: SLF001
-    resolve_context = f._resolve_context_value  # noqa: SLF001
-    creator = f._creator  # noqa: SLF001
+    resolution_step = f._resolution_step
+    resolve_context = f._resolve_context_value
+    creator = f._creator
 
     if _positional_names(f, plan) is not None:
         # Fast path: the whole signature is provider deps, in order — call positionally, skipping
         # the measured 4-6x **kwargs cost. `pure` is True here, so no static/context folding runs.
         pos = tuple(r for _name, r in prov)
 
-        def resolve_positional(container: "Container") -> typing.Any:  # noqa: ANN401
+        def resolve_positional(container: "Container") -> typing.Any:
             # Override front-guard is inlined into every closure (not extracted): the compiled dispatch
             # checks no overrides centrally, and a helper would add one Python frame per node.
             overrides = container.overrides_registry
@@ -98,7 +98,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
                     return override
             target = container if container.scope == scope else _navigate(container, scope, resolution_step)
             if target.closed:
-                target._prepare()  # noqa: SLF001
+                target._prepare()
             try:  # build the positional args from the dependency resolvers (a dependency can raise ResolutionError)
                 args = [r(target) for r in pos]
             except _STEP_ERRORS as exc:
@@ -116,7 +116,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
 
         return resolve_positional
 
-    def resolve(container: "Container") -> typing.Any:  # noqa: ANN401
+    def resolve(container: "Container") -> typing.Any:
         overrides = container.overrides_registry
         if overrides.has_overrides:
             override = overrides.fetch_override(pid)
@@ -125,7 +125,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
         # Navigate once; same-scope deps (the common case) skip the find_container call.
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
-            target._prepare()  # noqa: SLF001
+            target._prepare()
         try:  # build the kwargs dict from provider/static/context bindings
             kwargs = {name: r(target) for name, r in prov}
             if not pure:
@@ -153,7 +153,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
 def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: positional + kwargs, plus the warm-hit resolve closure)
     f: "Factory[typing.Any]", registry: "ProvidersRegistry"
 ) -> "typing.Callable[[Container], typing.Any]":
-    plan = registry.plan_for(f, f._parsed_kwargs, f._kwargs)  # noqa: SLF001
+    plan = registry.plan_for(f, f._parsed_kwargs, f._kwargs)
     if plan.unwireable:
         return _compile_unwireable_factory(f, plan)
     prov: _ProvResolvers = tuple((name, registry.resolver_for(p)) for name, p in plan.provider_kwargs.items())
@@ -162,10 +162,10 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
     pure = plan.pure_provider
     scope = f.scope
     pid = f.provider_id
-    resolution_step = f._resolution_step  # noqa: SLF001
-    resolve_context = f._resolve_context_value  # noqa: SLF001
-    creator = f._creator  # noqa: SLF001  # cold-miss only (not hot)
-    call_creator = f._call_creator  # noqa: SLF001  # cold-miss only; reused (not hot)
+    resolution_step = f._resolution_step
+    resolve_context = f._resolve_context_value
+    creator = f._creator  # cold-miss only (not hot)
+    call_creator = f._call_creator  # cold-miss only; reused (not hot)
 
     # cold-miss builder + creator call: positional when the whole signature is provider deps in
     # order (skips the **kwargs cost), else the kwargs pair. Both share the two-phase error handling.
@@ -179,7 +179,7 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
                 exc.prepend_step(resolution_step())
                 raise
 
-        def create_positional(args: list[typing.Any]) -> typing.Any:  # noqa: ANN401
+        def create_positional(args: list[typing.Any]) -> typing.Any:
             try:
                 return creator(*args)
             except TypeError as exc:
@@ -211,7 +211,7 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
         build_cold = build_kwargs
         create_cold = call_creator
 
-    def resolve(container: "Container") -> typing.Any:  # noqa: ANN401
+    def resolve(container: "Container") -> typing.Any:
         overrides = container.overrides_registry
         if overrides.has_overrides:
             override = overrides.fetch_override(pid)
@@ -219,19 +219,19 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
                 return override
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
-            target._prepare()  # noqa: SLF001
+            target._prepare()
         # Inlined memo hit: `fetch_cache_item` opens with exactly this lookup and returns, and the
         # method frame costs ~23ns of a ~170ns warm hit. Call it only on a miss, where its
         # `setdefault` is what makes concurrent first-resolvers share one CacheItem.
         cache_registry = target.cache_registry
-        cache_item = cache_registry._items.get(pid)  # noqa: SLF001
+        cache_item = cache_registry._items.get(pid)
         if cache_item is None:
             cache_item = cache_registry.fetch_cache_item(f)
         cached = cache_item.cache
         if cached is not types.UNSET:
             return cached  # warm hit: skip the get_or_create frame (same sentinel check it makes)
         value, created = cache_item.get_or_create(
-            target._lock,  # noqa: SLF001
+            target._lock,
             resolve=lambda: build_cold(target),
             # positional/kwargs builders have distinct arg types; get_or_create feeds each its own.
             create=typing.cast("typing.Callable[[typing.Any], typing.Any]", create_cold),
@@ -255,11 +255,11 @@ def _compile_unwireable_factory(
     """
     pid = f.provider_id
     scope = f.scope
-    resolution_step = f._resolution_step  # noqa: SLF001
-    build_error = f._argument_resolution_error  # noqa: SLF001
+    resolution_step = f._resolution_step
+    build_error = f._argument_resolution_error
     arg_name, item = plan.unwireable[0]
 
-    def resolve(container: "Container") -> typing.Any:  # noqa: ANN401
+    def resolve(container: "Container") -> typing.Any:
         overrides = container.overrides_registry
         if overrides.has_overrides:
             override = overrides.fetch_override(pid)
@@ -267,7 +267,7 @@ def _compile_unwireable_factory(
                 return override
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
-            target._prepare()  # noqa: SLF001
+            target._prepare()
         error = build_error(arg_name=arg_name, item=item, registry=target.providers_registry)
         error.prepend_step(resolution_step())
         raise error
@@ -282,10 +282,10 @@ def _compile_alias(a: "Alias[typing.Any]") -> "typing.Callable[[Container], typi
     missing source and a source's own scope error each carry this alias's resolution step.
     """
     pid = a.provider_id
-    resolution_step = a._resolution_step  # noqa: SLF001
-    find_source = a._find_source  # noqa: SLF001
+    resolution_step = a._resolution_step
+    find_source = a._find_source
 
-    def resolve(container: "Container") -> typing.Any:  # noqa: ANN401
+    def resolve(container: "Container") -> typing.Any:
         overrides = container.overrides_registry
         if overrides.has_overrides:
             override = overrides.fetch_override(pid)
@@ -304,7 +304,7 @@ def _compile_container_provider() -> "typing.Callable[[Container], typing.Any]":
     """Resolve to the resolving container itself — no scope navigation."""
     pid = container_provider.provider_id
 
-    def resolve(container: "Container") -> typing.Any:  # noqa: ANN401
+    def resolve(container: "Container") -> typing.Any:
         overrides = container.overrides_registry
         if overrides.has_overrides:
             override = overrides.fetch_override(pid)
@@ -324,7 +324,7 @@ def _compile_context_provider(cp: "ContextProvider[typing.Any]") -> "typing.Call
     pid = cp.provider_id
     resolve_bound = cp.resolve
 
-    def resolve(container: "Container") -> typing.Any:  # noqa: ANN401
+    def resolve(container: "Container") -> typing.Any:
         overrides = container.overrides_registry
         if overrides.has_overrides:
             override = overrides.fetch_override(pid)
@@ -337,7 +337,7 @@ def _compile_context_provider(cp: "ContextProvider[typing.Any]") -> "typing.Call
 
 def _navigate(
     container: "Container",
-    scope: typing.Any,  # noqa: ANN401
+    scope: typing.Any,
     resolution_step: "typing.Callable[[], exceptions.ResolutionStep]",
 ) -> "Container":
     """Cross-scope target lookup; prepends the resolution step to a scope error, as the interpreted path does."""

--- a/planning/deferred/2026-08-01-compiler-provider-compile-spec.md
+++ b/planning/deferred/2026-08-01-compiler-provider-compile-spec.md
@@ -1,0 +1,50 @@
+---
+summary: The resolver compiler reads provider internals across module lines (22 reads, 5 attributes, 4 provider types); a compile-spec handoff would remove the coupling, but it is a design change and the coupling is currently static, so SLF001 is suppressed per-file instead.
+---
+
+# Hand the compiler a compile-spec instead of reading provider internals
+
+`modern_di/resolver_compiler.py` builds each provider's resolver by reaching
+directly into that provider's private attributes — `Factory._creator`,
+`_parsed_kwargs`, `_kwargs`, `_resolution_step`, `_resolve_context_value`,
+`_call_creator`, `_argument_resolution_error`, `_has_positional_only_gap`,
+`Alias._find_source`. `SLF001` is now suppressed for that whole file via
+`per-file-ignores` rather than on individual lines. The alternative — giving
+each provider type a method that returns an explicit compile-spec, so no
+underscored attribute crosses a module boundary — was not taken.
+
+## Why it is open
+
+The coupling is real but it is **static and small**: 22 private reads across 5
+attribute groups on 4 provider types (`Factory`, `Alias`, `ContextProvider`,
+`_ContainerProvider`), and it has not grown as the compiler has. A per-file
+suppression is an honest description of a file whose documented job is exactly
+this: CLAUDE.md's key-files entry calls `resolver_compiler.py` "the **single
+resolve path**", and the coupling is what lets each resolver hold its per-node
+frame budget at 1.
+
+Doing the spec handoff properly is a design change, not a refactor, and it has
+a cost on both sides:
+
+- Every provider type gains a compile-spec method, and the spec object becomes
+  a second surface that must stay in sync with the attributes it mirrors.
+- `compile_resolver` already requires a new branch per provider type (it raises
+  `TypeError` for an unknown one); a spec adds a second thing a new provider
+  type must implement, so the "add a provider type" cost goes up, not down.
+- It is compile-time only, so it buys **no** hot-path nanoseconds — the reads
+  are hoisted into closure locals once per provider. The whole case for it is
+  coupling hygiene.
+
+The reason not to do it opportunistically is that the per-file suppression is
+only defensible while the coupling stays still. A suppression that quietly
+absorbs new private reads stops being a description and becomes a blindfold.
+
+## Revisit trigger
+
+`resolver_compiler.py` needs to read a private attribute it does not already
+read — most likely because a new provider type was added and `compile_resolver`
+grew a branch. That is the signal that the coupling is growing rather than
+sitting still, and it is checkable in a diff against the baseline recorded
+above (22 reads, 5 attribute groups, 4 provider types). At that point the
+per-file `SLF001` ignore should be replaced by the compile-spec handoff rather
+than extended.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,15 @@ ignore = [
 isort.lines-after-imports = 2
 isort.no-lines-before = ["standard-library", "local-folder"]
 
+[tool.ruff.lint.per-file-ignores]
+# The single resolve path compiles closures over provider internals: reading `Factory._creator`
+# and friends is the design, not an incident, and every compiled resolver returns `typing.Any`.
+# Suppressed per-file rather than on 31 individual lines. Growing this coupling is the revisit
+# trigger on planning/deferred/2026-08-01-compiler-provider-compile-spec.md.
+"modern_di/resolver_compiler.py" = ["SLF001", "ANN401"]
+# White-box tests assert on container and registry internals; that is what they are for.
+"tests/**" = ["SLF001"]
+
 [tool.pytest.ini_options]
 addopts = ""
 testpaths = ["tests"]

--- a/tests/registries/test_providers_registry.py
+++ b/tests/registries/test_providers_registry.py
@@ -46,14 +46,14 @@ def test_mutation_clears_the_resolver_and_plan_memos() -> None:
     dep_factory = providers.Factory(scope=Scope.APP, creator=_Dep, bound_type=_Dep)
     registry.add_providers(dep_factory)
     registry.resolver_for(dep_factory)  # populates _resolvers (and _plans via compile)
-    assert registry._resolvers  # noqa: SLF001
-    assert registry._plans  # noqa: SLF001
+    assert registry._resolvers
+    assert registry._plans
 
     class _Other: ...
 
     registry.add_providers(providers.Factory(scope=Scope.APP, creator=_Other, bound_type=_Other))
-    assert registry._resolvers == {}  # noqa: SLF001  # mutation cleared the memos
-    assert registry._plans == {}  # noqa: SLF001
+    assert registry._resolvers == {}  # mutation cleared the memos
+    assert registry._plans == {}
 
 
 def test_providers_registry_add_provider_duplicates() -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -348,7 +348,7 @@ def test_walk_errors_returns_flat_list_in_walk_order() -> None:
         svc = providers.Factory(creator=_NeedsMissing)
 
     container = Container(scope=Scope.APP, groups=[G])
-    errors = container._walk_errors()  # noqa: SLF001
+    errors = container._walk_errors()
 
     # Root order is registration order (a, b, svc): the cycle closes while walking from root
     # `a`, so it is appended before `svc`'s missing dependency is reached.
@@ -392,8 +392,8 @@ def test_build_child_container_propagates_use_lock_false() -> None:
     root = Container(use_lock=False)
     root.open()
     child = root.build_child_container(scope=Scope.REQUEST)
-    assert root._lock is None  # noqa: SLF001
-    assert child._lock is None  # noqa: SLF001
+    assert root._lock is None
+    assert child._lock is None
 
 
 def test_container_provider_resolves_on_subclasses() -> None:
@@ -534,11 +534,11 @@ def test_caller_stacklevel_does_not_skip_sibling_packages() -> None:
     # `modern_di_fastapi/` is a *sibling* of `modern_di/`, not part of it: a warning raised through
     # an integration must stop at the integration, not walk past it into framework code. Driven with
     # a synthesized frame so the test needs no sibling package installed.
-    package_dir = container_module._PACKAGE_DIR  # noqa: SLF001
+    package_dir = container_module._PACKAGE_DIR
     sibling = f"{package_dir.rstrip(os.sep)}_fastapi{os.sep}routing.py"
     namespace: dict[str, typing.Any] = {}
     exec(compile("def integration(fn):\n    return fn()\n", sibling, "exec"), namespace)  # noqa: S102
-    assert namespace["integration"](container_module._caller_stacklevel) == 1  # noqa: SLF001
+    assert namespace["integration"](container_module._caller_stacklevel) == 1
 
 
 def test_container_closed_warning_message() -> None:
@@ -611,16 +611,16 @@ def test_private_lock_and_scope_map_back_the_machinery() -> None:
 
     # _lock is a reentrant lock (threading.RLock is a factory, not a type, so
     # assert behavior, not isinstance)
-    assert root._lock is not None  # noqa: SLF001
-    assert root._lock.acquire()  # noqa: SLF001
-    assert root._lock.acquire()  # reentrant  # noqa: SLF001
-    root._lock.release()  # noqa: SLF001
-    root._lock.release()  # noqa: SLF001
+    assert root._lock is not None
+    assert root._lock.acquire()
+    assert root._lock.acquire()  # reentrant
+    root._lock.release()
+    root._lock.release()
     # The map holds ancestors only — never the container itself, which would be a reference cycle.
     # `find_container` short-circuits on its own scope, so a self-entry would be dead weight.
-    assert set(child._scope_map) == {Scope.APP}  # noqa: SLF001
-    assert child._scope_map[Scope.APP] is root  # noqa: SLF001
-    assert root._scope_map == {}  # noqa: SLF001
+    assert set(child._scope_map) == {Scope.APP}
+    assert child._scope_map[Scope.APP] is root
+    assert root._scope_map == {}
     assert child.find_container(Scope.REQUEST) is child  # own scope still resolves
     assert child.find_container(Scope.APP) is root
 
@@ -667,22 +667,22 @@ def test_use_lock_false_yields_no_private_lock() -> None:
     root = Container(use_lock=False)
     root.open()
     child = root.build_child_container(scope=Scope.REQUEST)
-    assert root._lock is None  # noqa: SLF001
-    assert child._lock is None  # noqa: SLF001
+    assert root._lock is None
+    assert child._lock is None
 
 
 def test_scope_map_alias_warns_and_forwards() -> None:
     container = Container()
     with pytest.warns(DeprecationWarning, match="scope_map"):
         aliased = container.scope_map
-    assert aliased is container._scope_map  # noqa: SLF001
+    assert aliased is container._scope_map
 
 
 def test_lock_alias_warns_and_forwards() -> None:
     container = Container(use_lock=True)
     with pytest.warns(DeprecationWarning, match="lock"):
         aliased = container.lock
-    assert aliased is container._lock  # noqa: SLF001
+    assert aliased is container._lock
 
 
 def test_resolve_emits_no_deprecation_warning() -> None:

--- a/tests/test_error_rendering.py
+++ b/tests/test_error_rendering.py
@@ -18,7 +18,7 @@ def test_error_without_docs_slug_renders_body_unchanged() -> None:
 def test_render_chain_is_a_pure_function_of_its_steps() -> None:
     # The drawer is exercisable without a container, a cycle, or a raise — it is the
     # single home of the indent-and-arrow glyphs, shared by every chain-shaped error.
-    assert exceptions._render_chain([_step("A"), _step("B", location="app:31"), _step("A")]) == [  # noqa: SLF001
+    assert exceptions._render_chain([_step("A"), _step("B", location="app:31"), _step("A")]) == [
         "  APP  A",
         "  APP  └─> B (app:31)",
         "  APP      └─> A",
@@ -26,7 +26,7 @@ def test_render_chain_is_a_pure_function_of_its_steps() -> None:
 
 
 def test_render_chain_aligns_the_scope_column_to_the_widest_name() -> None:
-    lines = exceptions._render_chain([_step("A"), _step("B", scope=Scope.REQUEST)])  # noqa: SLF001
+    lines = exceptions._render_chain([_step("A"), _step("B", scope=Scope.REQUEST)])
     assert lines == ["  APP      A", "  REQUEST  └─> B"]
 
 
@@ -49,13 +49,13 @@ def test_render_chain_aligns_the_scope_column_to_the_widest_name() -> None:
 )
 def test_render_suggestion_lines_covers_every_format(suggestion: suggester.Suggestion, expected: str) -> None:
     # One bullet format for all three suggestion kinds — the registry no longer owns half of it.
-    assert exceptions._render_suggestion_lines([suggestion]) == [expected]  # noqa: SLF001
+    assert exceptions._render_suggestion_lines([suggestion]) == [expected]
 
 
 def test_render_suggestions_prepends_the_header_and_is_empty_when_there_is_nothing_to_say() -> None:
-    assert exceptions._render_suggestions([]) == ""  # noqa: SLF001
+    assert exceptions._render_suggestions([]) == ""
     assert (
-        exceptions._render_suggestions(  # noqa: SLF001
+        exceptions._render_suggestions(
             [suggester.Suggestion(name="Repository", reason="similar name", scope=Scope.APP)]
         )
         == "Did you mean:\n  - Repository (similar name, scope=APP)"

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -53,7 +53,7 @@ def _make(a: _A, b: _B, c: _C) -> _Ordered:
 
 def _plan(registry: ProvidersRegistry, owner: "providers.Factory[object]") -> WiringPlan:
     """Build ``owner``'s wiring plan the way production does (via the registry memo)."""
-    return registry.plan_for(owner, owner._parsed_kwargs, owner._kwargs)  # noqa: SLF001
+    return registry.plan_for(owner, owner._parsed_kwargs, owner._kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -77,8 +77,8 @@ def test_wiring_plan_partitioning() -> None:
     )
 
     plan = WiringPlan.build(
-        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
-        kwargs=owner._kwargs,  # noqa: SLF001
+        parsed_kwargs=owner._parsed_kwargs,
+        kwargs=owner._kwargs,
         registry=registry,
         owner=owner,
     )
@@ -109,7 +109,7 @@ def test_wiring_plan_nullable_no_default_goes_to_static_kwargs() -> None:
     owner = providers.Factory(scope=Scope.APP, creator=_NullableNoDefaultCreator)
 
     plan = WiringPlan.build(
-        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
+        parsed_kwargs=owner._parsed_kwargs,
         kwargs=None,
         registry=registry,
         owner=owner,
@@ -136,7 +136,7 @@ def test_wiring_plan_unwireable_no_raise() -> None:
     owner = providers.Factory(scope=Scope.APP, creator=_UnwirableCreator)
 
     plan = WiringPlan.build(
-        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
+        parsed_kwargs=owner._parsed_kwargs,
         kwargs=None,
         registry=registry,
         owner=owner,
@@ -179,8 +179,8 @@ def test_wiring_plan_edges_include_static_supplied_providers() -> None:
     )
 
     plan = WiringPlan.build(
-        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
-        kwargs=owner._kwargs,  # noqa: SLF001
+        parsed_kwargs=owner._parsed_kwargs,
+        kwargs=owner._kwargs,
         registry=registry,
         owner=owner,
     )
@@ -299,11 +299,11 @@ def test_provider_kwargs_preserves_signature_order() -> None:
     owner = providers.Factory(scope=Scope.APP, creator=_OrderedDeps)
 
     plan = WiringPlan.build(
-        parsed_kwargs=owner._parsed_kwargs,  # noqa: SLF001
-        kwargs=owner._kwargs,  # noqa: SLF001
+        parsed_kwargs=owner._parsed_kwargs,
+        kwargs=owner._kwargs,
         registry=registry,
         owner=owner,
     )
 
     assert tuple(plan.provider_kwargs) == ("first", "second", "third")
-    assert tuple(plan.provider_kwargs) == tuple(owner._parsed_kwargs)  # noqa: SLF001
+    assert tuple(plan.provider_kwargs) == tuple(owner._parsed_kwargs)


### PR DESCRIPTION
## Why

`modern_di/` carried 59 `noqa` comments. 47 of them were **two** suppressions repeated on individual lines:

- `SLF001` x28, of which 22 sit in `resolver_compiler.py`, where reading `Factory._creator` and friends is not an incident but the file's documented job. CLAUDE.md calls it "the **single resolve path**"; the coupling is what lets each resolver hold its per-node frame budget at 1.
- `ANN401` x19, of which 9 are the `typing.Any` return on every compiled closure.

Repeated 31 times in one file, these convey nothing per line while making the most performance-sensitive file in the package harder to read. `tests/` carried ~50 more, nearly all `SLF001` from white-box assertions on `_lock`, `_scope_map`, `_resolvers`.

The repo also had **no `per-file-ignores` section at all**, so every suppression anywhere was inline regardless of whether it was structural or incidental.

## Design

Three different treatments, chosen per case rather than uniformly.

**Suppress in config where the coupling is structural.** `per-file-ignores` for `modern_di/resolver_compiler.py` (`SLF001`, `ANN401`) and `tests/**` (`SLF001`), each with its reason stated once. This is honest about a file whose entire purpose is the coupling, and about tests that are supposed to poke internals.

**Fix at source where the annotation was simply wrong.** The seven `ANN401`s in `exceptions.py` were `typing.Any` on parameters the constructors only ever format (`repr()`, f-strings, `getattr(x, "__name__", ...)`). Precise types existed:

| Parameter | Was | Now |
|---|---|---|
| `ArgumentResolutionError.arg_type` | `typing.Any` | `type \| None` |
| `ArgumentResolutionError.bound_type` | `typing.Any` | `type \| Callable[..., Any]` |
| `creator` x4 (`CreatorCallError` x2, `UnknownFactoryKwargError`, `UnsupportedCreatorParameterError`) | `typing.Any` | `Callable[..., Any]` |
| `InvalidScopeTypeError.scope_value` | `typing.Any` | `object` |

Ruff goes quiet here because the code got *more precise*, not because it was silenced. These are documented public attributes ("Inspect `.creator`"), so the annotation is API surface worth getting right.

**Leave the good ones alone.** `SLF001` in `container.py`/`group.py`/`exceptions.py` and `ARG002` x3 in `providers/abstract.py` stay inline. They are few, precise, and true — `ARG002`'s parameter name is part of the override contract for `get_dependencies`/`redirect_target`/`iter_validation_issues`, so renaming to `_container` would change what every subclass and keyword-caller sees. Deleting good `noqa` was never the point.

Result: **59 to 20** in the package, **~50 to 20** in tests. Every survivor now means something.

## Non-goals

- **Does not decouple the compiler from provider internals.** Handing each provider type an explicit compile-spec is the fix `SLF001` is actually asking for, but it is a design change, it buys no hot-path nanoseconds (the reads are hoisted to closure locals once per provider), and it makes adding a provider type *more* expensive. Filed as [`planning/deferred/2026-08-01-compiler-provider-compile-spec.md`](planning/deferred/2026-08-01-compiler-provider-compile-spec.md), with the coupling baseline recorded (22 reads, 5 attribute groups, 4 provider types) and a trigger that fires when it grows.
- **Does not touch comments, docstrings, or any code structure.** No behaviour, no control flow, no naming.
- **Does not widen `per-file-ignores` beyond the two entries**, in particular not to `container.py`, where a new accidental private access should still be caught.
- **Does not touch `benchmarks/`.**

## Verification

- `just lint-ci` — clean (`ruff`, `ty`, planning validation, link check). For a suppression-relocation PR this is the substantive proof: ruff re-checks all 67 previously-suppressed lines and finds only what the config now covers.
- `just test-ci` — 452 passed, **100% line coverage** (the gate).
- **Byte-identity check on the resolve path.** Every compiled resolver's code object was fingerprinted (recursive over nested closures: `co_code`, non-code `co_consts`, `co_names`, `co_varnames`, `co_freevars`) across all 7 benchmark provider graphs, on `main` and on this branch:

  ```
  === DIFF (main vs branch) ===
  IDENTICAL: all 33 compiled resolvers byte-for-byte unchanged
  ```

  So the performance claim here is structural, not statistical — there is nothing for a benchmark to measure. That matters because `benchmarks/README.md` documents guard medians as quantised to a 41 ns tick, which cannot resolve small moves anyway.

---

### Before merging

- [x] **Behaviour changed?** No. Byte-identical compiled resolvers, above.
- [x] **Rejected an alternative** with reasoning that would otherwise be re-litigated? Yes — the compile-spec handoff, filed in `planning/deferred/` with a revisit trigger (real work not scheduled, rather than an alternative rejected outright).
- [x] **Found real work you are not doing now?** Same file.
- [x] **New or sharpened domain term?** None.
- [x] `just lint-ci` and `just test-ci` pass.
