### PR TITLE
refactor: promote hot-path rationale to architecture/, guard the frame budget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Where the detail lives — read the matching capability file before changing beh
 | [architecture/testing-and-overrides.md](architecture/testing-and-overrides.md) | overrides + the `modern-di-pytest` integration |
 | [architecture/integration-kit.md](architecture/integration-kit.md) | framework-agnostic primitives for building an integration adapter |
 | [architecture/concurrency.md](architecture/concurrency.md) | thread-safety + free-threaded (PEP 703) support, at Beta |
+| [architecture/performance.md](architecture/performance.md) | why the warm resolve path is shaped as it is: the per-node frame budget, inlined memo hits, how to measure |
 
 ### Key files
 
@@ -44,7 +45,7 @@ Every module under `modern_di/` except the package `__init__.py` re-exports. If
 you add a module, add it here.
 
 - `modern_di/container.py` — Container class, the main entry point
-- `modern_di/resolver_compiler.py` — the **single resolve path**: one flat closure compiled per provider, memoized on the registry. Each resolver front-guards its own override, navigates its scope once, and inlines the kwargs build and creator call to hold the per-node frame budget at 1. A new provider type must add a branch here or `compile_resolver` raises
+- `modern_di/resolver_compiler.py` — the **single resolve path**: one flat closure compiled per provider, memoized on the registry. Each resolver front-guards its own override, navigates its scope once, and inlines the kwargs build and creator call to hold the per-node frame budget at 1 — the rationale lives in [architecture/performance.md](architecture/performance.md), and the budget is enforced by a test, so **do not extract a helper from these closures**. A new provider type must add a branch here or `compile_resolver` raises
 - `modern_di/wiring.py` — `WiringPlan`: partitions a creator's parsed parameters into provider / static / context buckets plus `unwireable`. A pure function of its inputs (no cache, scope, or live context), so it runs outside the container lock and is exercisable without a Container
 - `modern_di/providers/factory.py` — Factory and CacheSettings (singleton pattern via caching + optional finalizer)
 - `modern_di/providers/context_provider.py` — ContextProvider for runtime-injected values

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -36,6 +36,9 @@ cross-link — see [containers.md](containers.md#validate) pointing at
   `modern-di-pytest` integration.
 - [concurrency.md](concurrency.md) — thread-safety and free-threaded (PEP 703)
   support, at Beta.
+- [performance.md](performance.md) — why the warm resolve path is shaped as it
+  is: the per-node frame budget, the inlined memo hits, and how to measure a
+  change without misreading the guard tier.
 - [glossary.md](glossary.md) — the project's ubiquitous language.
 - [integration-kit.md](integration-kit.md) — framework-agnostic primitives for
   building a framework integration adapter.

--- a/architecture/performance.md
+++ b/architecture/performance.md
@@ -38,6 +38,15 @@ popped mid-resolve still counts) across two chain depths and asserts the per-nod
 slope is exactly 2 — one resolver frame, one creator. Extracting the override
 guard into a helper moves it to 3 and fails the test by name.
 
+**On CPython below 3.12 the real slope is 3, not 2.** Each resolver's argument
+build is a comprehension — `<listcomp>` on the positional path, `<dictcomp>` on
+the kwargs path — and before [PEP 709](https://peps.python.org/pep-0709/) a
+comprehension is a separate code object, so it costs its own frame per resolved
+node. From 3.12 both are inlined into the resolver and the cost disappears. This
+is a genuine per-version difference in what a resolve costs, not a measurement
+artifact; the test carries the version-conditional constant rather than relaxing
+the assertion, so the budget stays enforced on every supported interpreter.
+
 The corollary for anyone adding a provider type: put the whole resolver in the
 closure. `compile_resolver` raising `TypeError` for an unknown provider type is
 deliberate — there is no interpreted fallback to inherit shared behaviour from.

--- a/architecture/performance.md
+++ b/architecture/performance.md
@@ -1,0 +1,138 @@
+# Hot-path performance design
+
+Why the resolve path is shaped the way it is. Several places in `modern_di/` look
+like duplication a reviewer would want to collapse, or like a method call that
+was needlessly hand-inlined. They are deliberate, and this page is why. The rules
+below are the contract; the numbers that motivated them are quarantined in
+[Measurements](#measurements), because a measurement ages and a rule does not.
+
+The scope is the **warm resolve path** only — what runs on every `resolve_provider`
+once the graph is compiled. Compile-time work (`compile_resolver`, `WiringPlan`)
+runs once per provider per registry and is not optimized for; `validate()` and
+error rendering are cold by construction.
+
+## The per-node frame budget
+
+**Resolving one node in a dependency graph costs exactly one Python frame — the
+node's own compiled resolver.** Nothing else. A chain of depth 6 costs 6 resolver
+frames plus the 6 creator calls the user asked for.
+
+This is the rule the rest of the page serves, and it is why
+[`resolver_compiler.py`](../modern_di/resolver_compiler.py) contains what reads as
+copy-paste. Each compiled closure independently:
+
+- front-guards its own override (`overrides.has_overrides`, then `fetch_override`),
+- navigates to its own scope target,
+- reopens a closed target,
+- inlines the kwargs (or positional) argument build,
+- inlines the creator call and its `TypeError` handling.
+
+Extracting any of that into a shared helper is correct, tidy, and costs **one
+Python frame per resolved node** — a cost that scales with graph depth on the
+hottest path in the library. Python has no inlining to give it back.
+
+**This is enforced, not merely documented.**
+`tests/test_resolver_compiler.py::test_resolve_costs_exactly_one_resolver_frame_per_node`
+counts Python-level calls (via `sys.setprofile`, so a frame that is pushed and
+popped mid-resolve still counts) across two chain depths and asserts the per-node
+slope is exactly 2 — one resolver frame, one creator. Extracting the override
+guard into a helper moves it to 3 and fails the test by name.
+
+The corollary for anyone adding a provider type: put the whole resolver in the
+closure. `compile_resolver` raising `TypeError` for an unknown provider type is
+deliberate — there is no interpreted fallback to inherit shared behaviour from.
+
+## Inlined memo hits
+
+Two lookups are hand-inlined at their call site, with the method called only on
+a miss:
+
+| Call site | Inlines | Method still owns |
+|---|---|---|
+| `Container.resolve_provider` | `providers_registry._resolvers.get(pid)` | the cycle guard and memo write, on a miss |
+| `_compile_cached_factory`'s `resolve` | `cache_registry._items.get(pid)` | `setdefault`, which is what makes concurrent first-resolvers share one `CacheItem` |
+
+In both cases the method being inlined *opens with exactly that lookup and
+returns*, so the inline is not a reimplementation that can drift — it is the
+method's own fast path, hoisted past its frame. Both keep calling the real method
+on a miss, so the miss-path invariants (cycle detection, single shared `CacheItem`)
+are untouched.
+
+The warm cached resolve also returns before `CacheItem.get_or_create`, having
+already made the same `is UNSET` sentinel check that method opens with.
+
+## The positional fast path
+
+When a creator's entire signature is provider dependencies in declaration order,
+the compiled resolver calls `creator(*args)` instead of `creator(**kwargs)`,
+skipping the dict build and the keyword-binding cost.
+
+Eligibility is deliberately narrow — `_can_call_positionally` returns `False` on
+any static kwarg, context kwarg, omitted defaulted param, keyword-only param,
+kwargs-overlay reordering, or positional-only gap. **When in doubt, exclude**: a
+wrong `True` here silently binds arguments to the wrong parameters, which is a
+correctness bug, not a slow path. `tests/test_resolver_compiler.py` pins all four
+exclusion rules plus the positive case directly.
+
+## Scope navigation
+
+A resolver navigates to its target container **once**, and same-scope
+dependencies — the common case — skip navigation entirely via an int compare
+(`container if container.scope == scope else _navigate(...)`) rather than calling
+`find_container`. `Container._scope_map` then makes any genuine cross-scope hop
+O(1), and holds ancestors only: a `scope: self` entry would make every container
+a reference cycle, so none could be freed by refcounting.
+
+`Scope._next_deeper` is memoized because it is a constant function of an immutable
+enum member, consulted per child on the default `build_child_container()` path.
+
+## Allocation and lock avoidance
+
+- **`CacheRegistry.fetch_cache_item` has a get-before-setdefault fast path**, because
+  a plain `setdefault` eagerly constructs a throwaway `CacheItem` on every hit.
+  The creation path still goes through `setdefault`, whose atomicity is what makes
+  concurrent first-resolvers share one item.
+- **`Container.__init__` inlines its registry wiring** rather than calling a helper:
+  it is on the per-request child-build path.
+- **The cached-read path takes no lock at all**, and reopening a closed container
+  takes none either. See [concurrency.md](concurrency.md) — that page owns the
+  thread-safety contract, this one only notes that the absence of a lock is
+  intentional rather than an oversight.
+- **`WiringPlan`s are memoized on the shared providers registry**, so a
+  deeper-scope factory builds its plan once tree-wide, not once per child
+  container.
+
+## How to measure a change here
+
+**Do not read a `just bench` median to judge a small change.** Guard-tier
+scenarios are auto-calibrated and land on `iterations=1`, so their medians are
+quantized to one `time.perf_counter` tick — 41 ns on an Apple M4, which is 23% of
+G2's whole value. Two runs of unchanged code report numbers a tick apart, and that
+has already caused one false reading of a real change.
+[`benchmarks/README.md`](../benchmarks/README.md) documents this in full.
+
+Measure the specific call directly, with enough iterations to escape the grid.
+The A/B/A harness under `.superpowers/spike/` (git-ignored, so it survives
+`git checkout <rev> -- modern_di/`) does this: it measures base, then candidate,
+then base again, and reports the delta against the baseline's own drift.
+
+For a change that claims to be *free*, there is a stronger check than any
+benchmark: fingerprint the compiled resolvers' code objects (`co_code`,
+`co_consts`, `co_names`, `co_varnames`, `co_freevars`, recursively) before and
+after. Byte-identical output means there is nothing to measure.
+
+## Measurements
+
+> Measured 2026-08 on an Apple M4, CPython 3.14. **Absolutes age and are
+> machine-specific — the rules above are the contract, these are only the
+> evidence that motivated them.** Re-measure before citing.
+
+| What | Cost | Context |
+|---|---|---|
+| `creator(**kwargs)` vs `creator(*args)` | **4-6x** | the positional fast path's whole justification |
+| `resolver_for` method frame | ~34 ns | of a ~170 ns warm resolve (~20%) |
+| `fetch_cache_item` method frame | ~23 ns | of the same ~170 ns warm resolve (~14%) |
+| `typing.cast` on the context resolve path | ~19 ns | removed in #404 |
+| `isinstance` vs an `is` identity check | ~10 ns | why the `UNSET` check is `is`, with a scoped `ty: ignore` |
+| A redundant `open()` lock acquire | ~81 ns | found in the comparative C6 body |
+| One `time.perf_counter` tick | 41 ns | the guard tier's resolution floor |

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -129,8 +129,9 @@ class Container:
         self.context_registry = ContextRegistry(context=context or {})
         self.providers_registry: ProvidersRegistry
         self.overrides_registry: OverridesRegistry
-        # Inlined, not a helper: __init__ is on the per-request child-build path, so avoid the extra
-        # call frame. A root seeds container_provider so `Container` resolves to the resolving container.
+        # Inlined, not a helper: __init__ is on the per-request child-build path
+        # (architecture/performance.md). A root seeds container_provider so `Container`
+        # resolves to the resolving container.
         if parent_container:
             self.providers_registry = parent_container.providers_registry
             self.overrides_registry = parent_container.overrides_registry
@@ -216,10 +217,9 @@ class Container:
         if self.closed:
             self._prepare()
         try:
-            # Inlined memo hit: `resolver_for` opens with exactly this lookup and returns, and the
-            # method frame costs ~34ns of a ~170ns warm hit. Call it only on a miss, where it owns
-            # the cycle guard and the memo write. Stays inside the try so a RecursionError while
-            # compiling still becomes CircularDependencyError.
+            # Inlined memo hit; `resolver_for` is called only on a miss, where it owns the cycle
+            # guard and the memo write (architecture/performance.md). Inside the try so a
+            # RecursionError while compiling still becomes CircularDependencyError.
             registry = self.providers_registry
             resolver = registry._resolvers.get(provider.provider_id)  # noqa: SLF001
             if resolver is None:
@@ -371,10 +371,8 @@ class Container:
     async def __aexit__(self, *_: object) -> None:
         await self.close_async()
 
-    def __deepcopy__(self, *_: object, **__: object) -> "typing_extensions.Self":
-        """Prevent cloning object."""
+    def __copy__(self, *_: object, **__: object) -> "typing_extensions.Self":
+        """Never clone: a copied container would own a detached cache whose finalizers never run."""
         return self
 
-    def __copy__(self, *_: object, **__: object) -> "typing_extensions.Self":
-        """Prevent cloning object."""
-        return self
+    __deepcopy__ = __copy__

--- a/modern_di/dependency_graph.py
+++ b/modern_di/dependency_graph.py
@@ -66,7 +66,7 @@ def build_cycle_error(
     rotation of the same ring is the same cycle — anchoring on a stable per-process id makes the
     rendered message path- and seed-independent.
     """
-    ring = providers[:-1]  # drop the repeated first node to get the bare cycle
+    ring = providers[:-1]  # drop the repeated first node
     lead = min(range(len(ring)), key=lambda i: ring[i].provider_id)  # lowest-id node becomes the canonical lead
     rotated = [*ring[lead:], *ring[:lead]]
     canonical = [*rotated, rotated[0]]  # re-close the ring on the lead node

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -165,11 +165,10 @@ class Factory(AbstractProvider[types.T_co]):
         )
 
     def _plan(self, container: "Container") -> WiringPlan:
-        # The plan is memoized on the providers registry (shared by a container and every child), so a
-        # deeper-scope factory builds it once and shares it tree-wide, not once per child container. Passing
-        # the build inputs to plan_for (rather than a closure) keeps the hot cache-hit path allocation-free.
-        # Building runs outside the container lock — a deterministic function of the registry's current
-        # contents, so a race at worst repeats the build (see architecture/concurrency.md).
+        # Memoized on the shared providers registry, so a deeper-scope factory builds its plan once
+        # tree-wide (architecture/performance.md). Building runs outside the container lock — a
+        # deterministic function of the registry's contents, so a race at worst repeats the build
+        # (architecture/concurrency.md).
         return container.providers_registry.plan_for(self, self._parsed_kwargs, self._kwargs)
 
     def _resolve_context_value(

--- a/modern_di/registries/cache_registry.py
+++ b/modern_di/registries/cache_registry.py
@@ -86,11 +86,10 @@ class CacheRegistry:
         return sum(1 for item in self._items.values() if item.cache is not types.UNSET)
 
     def fetch_cache_item(self, provider: Factory[types.T_co]) -> CacheItem:
-        # Fast path: return an existing item without building a throwaway CacheItem (plain
-        # setdefault eagerly constructs one on every hit). The creation path still uses
-        # setdefault so first-resolvers share one CacheItem via a single atomic op — fetch runs outside
-        # the container lock (free-threaded-safe; see architecture/concurrency.md),
-        # and concurrent first-resolvers must share one CacheItem because the singleton cache
+        # Get before setdefault: a plain setdefault eagerly builds a throwaway CacheItem on every
+        # hit (architecture/performance.md). The creation path keeps setdefault, whose atomicity is
+        # what makes concurrent first-resolvers share one CacheItem — and it runs outside the
+        # container lock (see architecture/concurrency.md), because the singleton cache
         # and its double-checked lock live on that object.
         item = self._items.get(provider.provider_id)
         if item is not None:

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -29,8 +29,8 @@ _SCOPE_ERRORS = (exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedErr
 _STEP_ERRORS = (exceptions.ResolutionError, *_SCOPE_ERRORS)
 
 
-def _positional_names(f: "Factory[typing.Any]", plan: "WiringPlan") -> "tuple[str, ...] | None":
-    """Return the ordered param names to pass positionally, or None if the creator must use kwargs.
+def _can_call_positionally(f: "Factory[typing.Any]", plan: "WiringPlan") -> bool:
+    """Whether `f`'s creator can be called positionally instead of with `**kwargs`.
 
     Eligible only when every parsed parameter is a positional-or-keyword provider dependency, in
     signature order, with nothing omitted (no static, no context, no default-omitted, no
@@ -38,15 +38,15 @@ def _positional_names(f: "Factory[typing.Any]", plan: "WiringPlan") -> "tuple[st
     else keeps `creator(**kwargs)`. When in doubt, exclude.
     """
     if not plan.pure_provider:  # pure_provider already means no static and no context kwargs
-        return None
+        return False
     names = tuple(f._parsed_kwargs)
     if tuple(plan.provider_kwargs) != names:
-        return None  # a param was omitted/reordered, or a kwargs-overlay added an extra -> not a clean prefix
+        return False  # a param was omitted/reordered, or a kwargs-overlay added an extra -> not a clean prefix
     if any(item.is_keyword_only for item in f._parsed_kwargs.values()):
-        return None
-    if names and f._has_positional_only_gap:
-        return None  # positional-only param, dropped from _parsed_kwargs by the parser, would shift positional binding
-    return names
+        return False
+    # A positional-only param is dropped from _parsed_kwargs by the parser, so the remaining names
+    # can look like a clean prefix while a positional call would bind them to the wrong slots.
+    return not (names and f._has_positional_only_gap)
 
 
 def compile_resolver(
@@ -83,14 +83,13 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
     resolve_context = f._resolve_context_value
     creator = f._creator
 
-    if _positional_names(f, plan) is not None:
-        # Fast path: the whole signature is provider deps, in order — call positionally, skipping
-        # the measured 4-6x **kwargs cost. `pure` is True here, so no static/context folding runs.
+    if _can_call_positionally(f, plan):
+        # Positional fast path; `pure` is True here, so no static/context folding runs.
+        # See architecture/performance.md.
         pos = tuple(r for _name, r in prov)
 
         def resolve_positional(container: "Container") -> typing.Any:
-            # Override front-guard is inlined into every closure (not extracted): the compiled dispatch
-            # checks no overrides centrally, and a helper would add one Python frame per node.
+            # Inlined per closure, not extracted: frame budget — see architecture/performance.md.
             overrides = container.overrides_registry
             if overrides.has_overrides:
                 override = overrides.fetch_override(pid)
@@ -111,7 +110,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
                     creator=creator, exc=exc, resolution_step=resolution_step
                 )
                 if error is None:
-                    raise  # a TypeError from inside the creator body propagates unchanged
+                    raise
                 raise error from exc
 
         return resolve_positional
@@ -122,7 +121,6 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
             override = overrides.fetch_override(pid)
             if override is not types.UNSET:
                 return override
-        # Navigate once; same-scope deps (the common case) skip the find_container call.
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
             target._prepare()
@@ -144,7 +142,7 @@ def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: p
                 creator=creator, exc=exc, resolution_step=resolution_step
             )
             if error is None:
-                raise  # a TypeError from inside the creator body propagates unchanged
+                raise
             raise error from exc
 
     return resolve
@@ -167,9 +165,8 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
     creator = f._creator  # cold-miss only (not hot)
     call_creator = f._call_creator  # cold-miss only; reused (not hot)
 
-    # cold-miss builder + creator call: positional when the whole signature is provider deps in
-    # order (skips the **kwargs cost), else the kwargs pair. Both share the two-phase error handling.
-    if _positional_names(f, plan) is not None:
+    # Cold-miss builder + creator call, positional or kwargs. Both share the two-phase error handling.
+    if _can_call_positionally(f, plan):
         pos = tuple(r for _name, r in prov)
 
         def build_args(target: "Container") -> list[typing.Any]:
@@ -187,7 +184,7 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
                     creator=creator, exc=exc, resolution_step=resolution_step
                 )
                 if error is None:
-                    raise  # a TypeError from inside the creator body propagates unchanged
+                    raise
                 raise error from exc
 
         build_cold = build_args
@@ -220,16 +217,15 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
             target._prepare()
-        # Inlined memo hit: `fetch_cache_item` opens with exactly this lookup and returns, and the
-        # method frame costs ~23ns of a ~170ns warm hit. Call it only on a miss, where its
-        # `setdefault` is what makes concurrent first-resolvers share one CacheItem.
+        # Inlined memo hit; the method is called only on a miss, where its `setdefault` makes
+        # concurrent first-resolvers share one CacheItem. See architecture/performance.md.
         cache_registry = target.cache_registry
         cache_item = cache_registry._items.get(pid)
         if cache_item is None:
             cache_item = cache_registry.fetch_cache_item(f)
         cached = cache_item.cache
         if cached is not types.UNSET:
-            return cached  # warm hit: skip the get_or_create frame (same sentinel check it makes)
+            return cached
         value, created = cache_item.get_or_create(
             target._lock,
             resolve=lambda: build_cold(target),

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -95,7 +95,12 @@ _CHAIN: tuple[type, ...] = (_L0, _L1, _L2, _L3, _L4, _L5)
 #: The creator is the user's own object construction and is irreducible; the **1**
 #: resolver frame is the budget this module exists to hold. See
 #: ``architecture/performance.md``.
-_CALLS_PER_NODE = 2
+#:
+#: Before 3.12 each resolver's argument build is a *separate* code object -- the
+#: positional path's ``<listcomp>`` and the kwargs path's ``<dictcomp>`` -- so it
+#: costs a third frame per node. PEP 709 inlines both from 3.12, which is a real
+#: per-version cost difference, not a measurement artifact.
+_CALLS_PER_NODE = 2 if sys.version_info >= (3, 12) else 3
 
 
 def _warm_chain(depth: int) -> "tuple[Container, providers.Factory[typing.Any]]":
@@ -298,6 +303,6 @@ def test_resolve_costs_exactly_one_resolver_frame_per_node() -> None:
 
     assert (deep - shallow) == (6 - 2) * _CALLS_PER_NODE, (
         f"per-node cost is {(deep - shallow) / (6 - 2)} Python calls, expected {_CALLS_PER_NODE} "
-        f"(1 resolver frame + 1 creator). A helper extracted from the compiled resolvers "
-        f"costs one frame per node -- see architecture/performance.md."
+        f"on Python {sys.version_info.major}.{sys.version_info.minor}. A helper extracted from "
+        f"the compiled resolvers costs one frame per resolved node -- see architecture/performance.md."
     )

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -1,21 +1,24 @@
 """Direct tests for compiled-resolver path selection.
 
 The differential-harness suite in ``tests/providers/test_factory.py`` characterizes each
-compiled path black-box through ``resolve_provider``. These pin the two things it leaves
+compiled path black-box through ``resolve_provider``. These pin the three things it leaves
 unguarded: the argument-ordering invariant the positional fast path silently depends on,
-and ``_positional_names``' full contract (four exclusion rules plus the positive case),
-called directly.
+``_can_call_positionally``'s full contract (four exclusion rules plus the positive case)
+called directly, and the per-node frame budget the compiled path exists to hold.
 """
 
 import dataclasses
 import inspect
+import sys
+import types as _pytypes
+import typing
 
 import pytest
 
 from modern_di import Container, Group, Scope, providers
 from modern_di.providers import ContextProvider
 from modern_di.registries.providers_registry import ProvidersRegistry
-from modern_di.resolver_compiler import _positional_names
+from modern_di.resolver_compiler import _can_call_positionally
 from modern_di.wiring import WiringPlan
 
 
@@ -56,6 +59,79 @@ def _plan(registry: ProvidersRegistry, owner: "providers.Factory[object]") -> Wi
     return registry.plan_for(owner, owner._parsed_kwargs, owner._kwargs)
 
 
+@dataclasses.dataclass(slots=True)
+class _L0:
+    pass
+
+
+@dataclasses.dataclass(slots=True)
+class _L1:
+    dep: _L0
+
+
+@dataclasses.dataclass(slots=True)
+class _L2:
+    dep: _L1
+
+
+@dataclasses.dataclass(slots=True)
+class _L3:
+    dep: _L2
+
+
+@dataclasses.dataclass(slots=True)
+class _L4:
+    dep: _L3
+
+
+@dataclasses.dataclass(slots=True)
+class _L5:
+    dep: _L4
+
+
+_CHAIN: tuple[type, ...] = (_L0, _L1, _L2, _L3, _L4, _L5)
+
+#: Python calls one extra chain node costs: its resolver closure, plus its creator.
+#: The creator is the user's own object construction and is irreducible; the **1**
+#: resolver frame is the budget this module exists to hold. See
+#: ``architecture/performance.md``.
+_CALLS_PER_NODE = 2
+
+
+def _warm_chain(depth: int) -> "tuple[Container, providers.Factory[typing.Any]]":
+    """Build and warm a transient chain of ``depth`` nodes; return it and its root provider."""
+    members = {f"p{i}": providers.Factory(creator=node, scope=Scope.APP) for i, node in enumerate(_CHAIN[:depth])}
+    group = _pytypes.new_class(f"_Chain{depth}", (Group,), exec_body=lambda ns: ns.update(members))
+    container = Container(scope=Scope.APP, groups=[group])
+    root = members[f"p{depth - 1}"]
+    container.resolve_provider(root)  # compile the whole graph before measuring
+    return container, root
+
+
+def _count_python_calls(fn: "typing.Callable[[], object]") -> int:
+    """Count Python-level calls made by ``fn``.
+
+    Uses ``sys.setprofile`` rather than stack-depth sampling so a helper frame that is
+    *pushed and popped* during resolution (an extracted override guard, say) is still
+    counted -- sampling the depth inside a creator would miss exactly that regression.
+    """
+    calls = 0
+
+    def profiler(_frame: object, event: str, _arg: object) -> None:
+        # pragma: no cover - CPython does not trace inside a profile callback, so coverage
+        # cannot see this body. That it runs is exactly what the caller's assertion proves.
+        nonlocal calls
+        if event == "call":  # pragma: no cover
+            calls += 1  # pragma: no cover
+
+    sys.setprofile(profiler)
+    try:
+        fn()
+    finally:
+        sys.setprofile(None)
+    return calls
+
+
 # ---------------------------------------------------------------------------
 # Ordering invariant — the positional fast path binds args in signature order
 # ---------------------------------------------------------------------------
@@ -74,7 +150,7 @@ def test_positional_path_binds_args_in_signature_order() -> None:
     container = Container(groups=[G])
     container.open()
     plan = _plan(container.providers_registry, G.ordered)
-    assert _positional_names(G.ordered, plan) is not None  # self-guard: positional path selected
+    assert _can_call_positionally(G.ordered, plan)  # self-guard: positional path selected
 
     result = container.resolve(_Ordered)
     assert isinstance(result.a, _A)
@@ -83,12 +159,12 @@ def test_positional_path_binds_args_in_signature_order() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _positional_names — the full predicate contract, called directly
+# _can_call_positionally — the full predicate contract, called directly
 # ---------------------------------------------------------------------------
 
 
-def test_positional_names_returns_ordered_names() -> None:
-    # positive: every param is a provider dep in signature order -> the ordered names tuple.
+def test_can_call_positionally_accepts_ordered_provider_signature() -> None:
+    # positive: every param is a provider dep in signature order -> the positional path is eligible.
     registry = ProvidersRegistry()
     registry.add_providers(
         providers.Factory(creator=_A, scope=Scope.APP),
@@ -98,10 +174,10 @@ def test_positional_names_returns_ordered_names() -> None:
     owner = providers.Factory(creator=_make, scope=Scope.APP)
     registry.add_providers(owner)
 
-    assert _positional_names(owner, _plan(registry, owner)) == ("a", "b", "c")
+    assert _can_call_positionally(owner, _plan(registry, owner)) is True
 
 
-def test_positional_names_rejects_static_or_context_kwarg() -> None:
+def test_can_call_positionally_rejects_static_or_context_kwarg() -> None:
     # rule 1: a context param makes the plan non-pure, so kwargs folding must run.
     def creator(dep: _A, req: _Req) -> _Ordered:
         raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
@@ -114,10 +190,10 @@ def test_positional_names_rejects_static_or_context_kwarg() -> None:
     owner = providers.Factory(creator=creator, scope=Scope.APP)
     registry.add_providers(owner)
 
-    assert _positional_names(owner, _plan(registry, owner)) is None
+    assert _can_call_positionally(owner, _plan(registry, owner)) is False
 
 
-def test_positional_names_rejects_defaulted_omitted_param() -> None:
+def test_can_call_positionally_rejects_defaulted_omitted_param() -> None:
     # rule 2a: `opt` has a default and no provider, so it is omitted -> provider_kwargs is a
     # strict prefix of the signature, not the whole of it.
     def creator(dep: _A, opt: int = 5) -> _Ordered:
@@ -128,10 +204,10 @@ def test_positional_names_rejects_defaulted_omitted_param() -> None:
     owner = providers.Factory(creator=creator, scope=Scope.APP)
     registry.add_providers(owner)
 
-    assert _positional_names(owner, _plan(registry, owner)) is None
+    assert _can_call_positionally(owner, _plan(registry, owner)) is False
 
 
-def test_positional_names_rejects_kwargs_overlay_reorder() -> None:
+def test_can_call_positionally_rejects_kwargs_overlay_reorder() -> None:
     # rule 2b: supplying `a` via the kwargs overlay defers it to the end of provider_kwargs,
     # so the binding order (b, a) no longer matches the signature (a, b).
     def creator(a: _A, b: _B) -> _Ordered:
@@ -145,10 +221,10 @@ def test_positional_names_rejects_kwargs_overlay_reorder() -> None:
 
     plan = _plan(registry, owner)
     assert tuple(plan.provider_kwargs) == ("b", "a")  # overlay put `a` last
-    assert _positional_names(owner, plan) is None
+    assert _can_call_positionally(owner, plan) is False
 
 
-def test_positional_names_rejects_keyword_only_param() -> None:
+def test_can_call_positionally_rejects_keyword_only_param() -> None:
     # rule 3: a keyword-only dep can never be passed positionally.
     def creator(*, dep: _A) -> _Ordered:
         raise NotImplementedError  # pragma: no cover - parsed for wiring, never resolved
@@ -158,10 +234,10 @@ def test_positional_names_rejects_keyword_only_param() -> None:
     owner = providers.Factory(creator=creator, scope=Scope.APP)
     registry.add_providers(owner)
 
-    assert _positional_names(owner, _plan(registry, owner)) is None
+    assert _can_call_positionally(owner, _plan(registry, owner)) is False
 
 
-def test_positional_names_rejects_positional_only_param() -> None:
+def test_can_call_positionally_rejects_positional_only_param() -> None:
     # rule 4: `prefix` is positional-only WITH a default, dropped from parsed_kwargs so the
     # remaining names look like a clean prefix ("dep",) -- but a positional call would bind
     # `dep` to the `prefix` slot. The parser's has_positional_only_gap flag must reject it.
@@ -173,7 +249,7 @@ def test_positional_names_rejects_positional_only_param() -> None:
     owner = providers.Factory(creator=creator, scope=Scope.APP)
     registry.add_providers(owner)
 
-    assert _positional_names(owner, _plan(registry, owner)) is None
+    assert _can_call_positionally(owner, _plan(registry, owner)) is False
 
 
 def test_first_resolve_does_not_reintrospect_creator(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -199,3 +275,29 @@ def test_first_resolve_does_not_reintrospect_creator(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(inspect, "signature", _spy)
     container.resolve_provider(G.ordered)  # triggers compile of the whole graph
     assert calls == []  # no re-introspection at compile
+
+
+# ---------------------------------------------------------------------------
+# Frame budget — one resolver frame per chain node, and no more
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_costs_exactly_one_resolver_frame_per_node() -> None:
+    # Every compiled resolver front-guards its own override, navigates its own scope and
+    # inlines its own kwargs build + creator call. That duplication is deliberate: any of it
+    # extracted into a shared helper would cost one Python frame *per resolved node*, which
+    # is the whole reason the compiled path exists (architecture/performance.md).
+    #
+    # Measured as a difference between two chain depths, so the fixed cost of the harness
+    # and of `resolve_provider` itself cancels and only the per-node slope is asserted.
+    shallow_container, shallow_root = _warm_chain(2)
+    deep_container, deep_root = _warm_chain(6)
+
+    shallow = _count_python_calls(lambda: shallow_container.resolve_provider(shallow_root))
+    deep = _count_python_calls(lambda: deep_container.resolve_provider(deep_root))
+
+    assert (deep - shallow) == (6 - 2) * _CALLS_PER_NODE, (
+        f"per-node cost is {(deep - shallow) / (6 - 2)} Python calls, expected {_CALLS_PER_NODE} "
+        f"(1 resolver frame + 1 creator). A helper extracted from the compiled resolvers "
+        f"costs one frame per node -- see architecture/performance.md."
+    )


### PR DESCRIPTION
## Why

CLAUDE.md's code style is explicit: *"Never narrate implementation or justify code to a reviewer — cross-file rationale lives in `architecture/`."* The hottest files in the package did precisely that, carrying measurements on the lines they justified:

```python
# Fast path: ... skipping the measured 4-6x **kwargs cost.
# ... the method frame costs ~34ns of a ~170ns warm hit.
# Override front-guard is inlined into every closure (not extracted): ...
#   a helper would add one Python frame per node.
```

They stayed because **there was nowhere else to put them.** No `architecture/performance.md` existed, and `resolution.md` has zero mentions of frames, inlining or nanoseconds. The frame-budget concept lived only in CLAUDE.md's key-files table — the orientation doc, not the truth home.

That leaves a trap: delete those comments and the next reader tidies seven identical override front-guards into a helper, silently costing a Python frame per resolved node.

## Design

**A truth home, then a gate — not prose swapped for prose.**

`architecture/performance.md` holds the invariants as the normative content: the per-node frame budget, the two inlined memo hits, the positional fast path, scope navigation, allocation and lock avoidance, and how to measure a change here. Measurements are quarantined in one fenced block marked *"Measured 2026-08 on an Apple M4, CPython 3.14"*, so a reader can tell contract from observation, and a stale number is labelled as one rather than masquerading as truth in the living-truth directory.

Inline comments collapse to pointers:

```python
# Inlined per closure, not extracted: frame budget — see architecture/performance.md.
```

Comments that merely restated the code are deleted, including `# a TypeError from inside the creator body propagates unchanged` repeated verbatim at three `raise` sites — `CreatorCallError.from_type_error`'s own docstring already states that contract, so it now lives in exactly one place.

**A doc doesn't fail CI, so the budget becomes executable.** `test_resolve_costs_exactly_one_resolver_frame_per_node` counts Python-level calls with `sys.setprofile` across two chain depths and asserts the per-node slope exactly — **2 on CPython 3.12+** (one resolver frame, one creator), **3 below it**. Differencing two depths cancels the fixed harness cost. `setprofile` rather than stack-depth sampling matters: an extracted override guard is pushed and popped *before* the creator runs, so sampling inside a creator would miss exactly the regression this guards.

**The 3.10/3.11 difference is real, and was found by CI.** The first push failed on those two versions at a slope of 3. Each resolver builds its arguments with a comprehension — `<listcomp>` positional, `<dictcomp>` kwargs — and before [PEP 709](https://peps.python.org/pep-0709/) a comprehension is a separate code object costing its own frame per node. Confirmed by walking nested code objects: 3.11 has both, 3.14 has neither. So a resolve genuinely costs one more frame per node below 3.12. The constant is version-conditional rather than the assertion relaxed, so the budget stays enforced on every supported interpreter, and the finding is recorded in the new page.

**Verified to discriminate.** Extracting the override front-guard into a helper — the specific tidy-up the deleted comments warned against — makes it fail by name:

```
E  AssertionError: per-node cost is 3.0 Python calls, expected 2 (1 resolver frame
E  + 1 creator). A helper extracted from the compiled resolvers costs one frame per
E  node -- see architecture/performance.md.
E  assert (20 - 8) == ((6 - 2) * 2)
```

**Two small code changes.** `_positional_names` becomes `_can_call_positionally` returning `bool`: both production call sites only tested `is not None`, and the ordered names tuple it built was discarded — only a test ever read it. And `__deepcopy__`/`__copy__`, which had identical bodies and identical docstrings, collapse to `__deepcopy__ = __copy__` with a docstring that says *why* cloning is refused rather than restating that it is.

## Non-goals

- **Does not deduplicate the hot path.** The seven override front-guards and the repeated `try/except _STEP_ERRORS` blocks stay. That is now a tested contract, not an accident.
- **Does not amend CLAUDE.md's comment rule.** The rule was right; the missing truth home was the problem.
- **Does not touch `Container.__init__`'s dead `validate` parameter** (deprecated no-op, and the reason for its `PLR0913, PLR0917` suppression). Removing it is an API break needing its own deprecation cycle.
- **Does not collapse `close_sync`/`close_async` or the `scope_map`/`lock` deprecated property pair.** Cosmetic symmetry on cold paths; churn without signal.
- **Publishes no new performance claims.** `docs/introduction/performance.md` stays the user-facing, generated, ratio-based page; this one is maintainer-facing mechanism.

## Verification

- `just test-ci` — **453 passed, 100% line coverage** (the gate).
- `just lint-ci` — clean, including the link checker against the new page.
- **Mutation-tested the new guard**, output above — it fails on exactly the change it exists to prevent, with a message that names the file to read.
- **Byte-identity on the resolve path.** Every compiled resolver's code object fingerprinted (recursive over nested closures: `co_code`, non-code `co_consts`, `co_names`, `co_varnames`, `co_freevars`) across all 7 benchmark provider graphs, `main` vs this branch:

  ```
  === DIFF (main vs PR2 branch) ===
  IDENTICAL: all 33 compiled resolvers byte-for-byte unchanged
  ```

  The rename is compile-time and the rest is comments, so the warm path is provably untouched — there is nothing for a benchmark to measure, which is fortunate given guard medians cannot resolve moves this size anyway.
- **Frame-budget test run on 3.10, 3.11, 3.12 and 3.14**, all passing; the extraction mutation re-run on 3.10 and 3.14, failing on both (3→4 and 2→3 respectively).

One note for review: the new test's profiler callback carries `# pragma: no cover`. CPython does not trace inside a profile callback, so coverage cannot see that body — but the assertion it feeds is what proves it ran.

---

### Before merging

- [x] **Behaviour changed?** No — byte-identical compiled resolvers. `architecture/performance.md` added as the new truth home; `architecture/README.md` and CLAUDE.md's key-files table both updated, the latter now warning against extracting a helper.
- [x] **Rejected an alternative?** Hot-path deduplication, rejected on the 0%-regression constraint — recorded here and enforced by the new test rather than filed, since the test is the durable record.
- [x] **Found real work you are not doing now?** The `validate` parameter removal and the cold-path symmetry cleanups, both scoped out above.
- [x] **New or sharpened domain term?** "Frame budget" now has a definition in `architecture/performance.md`; it is mechanism rather than domain vocabulary, so `glossary.md` is unchanged.
- [x] `just lint-ci` and `just test-ci` pass.

