### PR TITLE
fix(group): freeze a provider's scope once it is registered

### DIFF
--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -36,7 +36,14 @@ its own kwarg overrides it for its own body); otherwise the provider falls back 
 participates in stamping — its scope is always derived from its source, never chosen (see below). A
 scope-defaulted provider instance shared between two group bodies with different defaults raises
 `GroupScopeConflictError` (a `RegistrationError` subclass) at the second group's class-creation time, rather than
-letting import order decide; sharing the same instance with the same default scope across groups is a no-op. See
+letting import order decide; sharing the same instance with the same default scope across groups is a no-op.
+
+A group body **without** a `scope=` kwarg stamps nothing, so a provider listed only there stays unclaimed and a
+later group may still stamp it. That is sound only until the provider is registered: `add_providers`/`register`
+set `AbstractProvider._registered`, and a compiled resolver captures `scope` in its closure, so a change after
+that point would apply to later-compiled resolvers only. `_stamp_group_scope` therefore raises
+`ProviderScopeFrozenError` when a stamp would *change* the scope of a registered provider. A same-scope stamp
+still returns early and stays legal, so the shared-instance pattern above is unaffected. See
 [docs/providers/scopes.md#group-level-default-scope](../docs/providers/scopes.md#group-level-default-scope) for
 the user-facing walkthrough.
 

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -32,6 +32,7 @@ ModernDIError (RuntimeError)
 │   ├── DuplicateProviderTypeError
 │   ├── ChildContainerRegistrationError
 │   ├── GroupScopeConflictError
+│   ├── ProviderScopeFrozenError
 │   ├── UnknownFactoryKwargError
 │   ├── UnsupportedCreatorParameterError
 │   └── InvalidScopeDependencyError
@@ -145,6 +146,12 @@ Catch `RegistrationError` for declaration- and registration-time problems.
   cannot follow both defaults at once, and import order must never be what decides it. Inspect
   `.provider_name`, `.first_group`/`.first_scope`, and `.second_group`/`.second_scope`. See
   [Troubleshooting: GroupScopeConflictError](../troubleshooting/group-scope-conflict-error.md).
+- **`ProviderScopeFrozenError`** — raised when a `Group` would change the scope of a provider that
+  is already registered with a container. Resolvers compiled before the change captured the old
+  scope, so applying it would make the same provider resolve differently through an existing
+  container than through a fresh one. Inspect `.provider_name`, `.group_name`, `.current_scope`,
+  `.new_scope`. See
+  [Troubleshooting: ProviderScopeFrozenError](../troubleshooting/provider-scope-frozen-error.md).
 - **`UnknownFactoryKwargError`** — raised when `Factory(kwargs={...})` contains a key that is not a
   parameter of the creator's signature; lists the known parameters and "did you mean" hints. See
   [Troubleshooting: UnknownFactoryKwargError](../troubleshooting/unknown-factory-kwarg-error.md).

--- a/docs/providers/scopes.md
+++ b/docs/providers/scopes.md
@@ -151,6 +151,8 @@ Scope resolution follows a priority order:
 
 A scope-defaulted provider instance that is shared between two `Group` subclasses with different defaults raises [`GroupScopeConflictError`](../troubleshooting/group-scope-conflict-error.md) at class-creation time. Sharing the same provider instance with the same default scope across multiple groups is allowed.
 
+A group declared without a `scope=` kwarg stamps nothing, so a provider listed only in such a group keeps the `Scope.APP` default and can still be stamped by a later group — but only until it is registered with a container. After that, a group that would *change* its scope raises [`ProviderScopeFrozenError`](../troubleshooting/provider-scope-frozen-error.md), because resolvers compiled before the change already captured the old scope. Declare every group that lists a provider before building the container, or set `scope=` on the provider explicitly.
+
 ## See also
 
 - [Lifecycle](lifecycle.md) — finalizers and `close_async()` work per-scope.

--- a/docs/troubleshooting/provider-scope-frozen-error.md
+++ b/docs/troubleshooting/provider-scope-frozen-error.md
@@ -1,0 +1,66 @@
+# ProviderScopeFrozenError
+
+**Symptom**
+
+Defining a `Group` subclass raises at class-creation (import) time. The error names a provider, the
+group that tried to change its scope, and the two scopes involved — and says the provider is
+already registered with a container.
+
+**Cause**
+
+A provider created without an explicit `scope=` takes its scope from whichever
+`class ...(Group, scope=...)` body stamps it first. A group declared **without** a `scope=` kwarg
+stamps nothing, so a provider listed only in such a group keeps the `Scope.APP` default and stays
+unclaimed — a later group is still free to stamp it.
+
+That is fine until the provider has been registered with a container. Registration compiles a
+resolver for the provider, and that resolver **captures the scope as it was at compile time**.
+Changing the scope afterwards would apply only to resolvers compiled later, so the same provider
+would resolve one way through the existing container and another way through a fresh one. Rather
+than let the two disagree silently, the scope is frozen at registration and the change is rejected.
+
+```python
+shared = providers.Factory(SomeService)          # no explicit scope -> APP default, unclaimed
+
+class PlainGroup(Group):                          # no scope= -> stamps nothing
+    svc = shared
+
+container = Container(scope=Scope.APP, groups=[PlainGroup])   # registers + compiles
+
+class ScopedGroup(Group, scope=Scope.REQUEST):    # ProviderScopeFrozenError
+    svc = shared
+```
+
+**Fix**
+
+```python
+# 1. Set scope= explicitly on the provider — explicit always wins over a group default,
+#    and the provider is never left unclaimed in the first place.
+shared = providers.Factory(SomeService, scope=Scope.REQUEST)
+
+# 2. Declare every group that lists the provider before building the container.
+class PlainGroup(Group):
+    svc = shared
+
+class ScopedGroup(Group, scope=Scope.REQUEST):
+    svc = shared
+
+container = Container(scope=Scope.APP, groups=[ScopedGroup])   # now consistent
+
+# 3. Give the scoped group its own provider instance instead of sharing one.
+class ScopedGroup(Group, scope=Scope.REQUEST):
+    svc = providers.Factory(SomeService)
+```
+
+Inspect `.provider_name`, `.group_name`, `.current_scope`, and `.new_scope` on the exception to see
+exactly which provider and group collided.
+
+Note the difference from
+[`GroupScopeConflictError`](group-scope-conflict-error.md): that one fires when two groups *both*
+declare a scope and disagree, whether or not anything is registered. This one fires when a single
+group would change the scope of a provider that a container has already compiled.
+
+## See also
+
+- [Scopes](../providers/scopes.md) — the scope hierarchy and how a provider's scope is chosen.
+- [GroupScopeConflictError](group-scope-conflict-error.md) — two groups disagreeing about a scope.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Duplicate Type Error: troubleshooting/duplicate-type-error.md
       - Child Container Registration: troubleshooting/child-container-registration-error.md
       - Group Scope Conflict: troubleshooting/group-scope-conflict-error.md
+      - Provider Scope Frozen: troubleshooting/provider-scope-frozen-error.md
       - Unknown Factory Kwarg: troubleshooting/unknown-factory-kwarg-error.md
       - Unsupported Creator Parameter: troubleshooting/unsupported-creator-parameter-error.md
       - Scope Chain Violation: troubleshooting/scope-chain.md
@@ -203,6 +204,7 @@ plugins:
           - troubleshooting/duplicate-type-error.md: Diagnosing duplicate bound_type registration errors
           - troubleshooting/child-container-registration-error.md: Diagnosing ChildContainerRegistrationError
           - troubleshooting/group-scope-conflict-error.md: Diagnosing GroupScopeConflictError
+          - troubleshooting/provider-scope-frozen-error.md: Diagnosing ProviderScopeFrozenError
           - troubleshooting/unknown-factory-kwarg-error.md: Diagnosing UnknownFactoryKwargError
           - troubleshooting/unsupported-creator-parameter-error.md: Diagnosing UnsupportedCreatorParameterError
           - troubleshooting/scope-chain.md: Diagnosing scope chain violation errors

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -516,6 +516,37 @@ class ChildContainerRegistrationError(RegistrationError):
         )
 
 
+class ProviderScopeFrozenError(RegistrationError):
+    """A group tried to change the scope of a provider that is already registered.
+
+    Inspect ``.provider_name``, ``.group_name``, ``.current_scope``, ``.new_scope``.
+    """
+
+    docs_slug = "provider-scope-frozen-error"
+
+    __slots__ = ("current_scope", "group_name", "new_scope", "provider_name")
+
+    def __init__(
+        self,
+        *,
+        provider_name: str,
+        group_name: str,
+        current_scope: enum.IntEnum,
+        new_scope: enum.IntEnum,
+    ) -> None:
+        self.provider_name = provider_name
+        self.group_name = group_name
+        self.current_scope = current_scope
+        self.new_scope = new_scope
+        super().__init__(
+            f"Group {group_name} would change the scope of provider {provider_name} from "
+            f"{current_scope.name} to {new_scope.name}, but it is already registered with a "
+            f"container. Resolvers compiled before this point captured {current_scope.name}, so the "
+            f"change would apply inconsistently. Declare {group_name} before building the container, "
+            f"or set scope= explicitly on the provider."
+        )
+
+
 class GroupScopeConflictError(RegistrationError):
     """A scope-defaulted provider is shared by two groups with different default scopes.
 

--- a/modern_di/providers/abstract.py
+++ b/modern_di/providers/abstract.py
@@ -14,7 +14,7 @@ _provider_id_counter = itertools.count()
 
 
 class AbstractProvider(abc.ABC, typing.Generic[types.T_co]):
-    __slots__ = ("_scope_defaulted", "_stamping_group", "bound_type", "provider_id", "scope")
+    __slots__ = ("_registered", "_scope_defaulted", "_stamping_group", "bound_type", "provider_id", "scope")
 
     def __init__(
         self,
@@ -25,11 +25,16 @@ class AbstractProvider(abc.ABC, typing.Generic[types.T_co]):
         self._scope_defaulted = isinstance(scope, types.UnsetType)
         self.scope: enum.IntEnum = Scope.APP if isinstance(scope, types.UnsetType) else scope
         self._stamping_group: str | None = None
+        self._registered = False
         self.bound_type = bound_type
         self.provider_id: typing.Final = next(_provider_id_counter)
 
     def _stamp_group_scope(self, scope: enum.IntEnum, group_name: str) -> None:
-        """Apply a Group-level default scope; no-op when the provider's scope was chosen explicitly."""
+        """Apply a Group-level default scope; no-op when the provider's scope was chosen explicitly.
+
+        Frozen once registered: a compiled resolver captures `scope`, so a later change would apply
+        only to resolvers compiled after it.
+        """
         if not self._scope_defaulted:
             return
         if self._stamping_group is not None:
@@ -42,6 +47,13 @@ class AbstractProvider(abc.ABC, typing.Generic[types.T_co]):
                     second_scope=scope,
                 )
             return
+        if self._registered and self.scope != scope:
+            raise exceptions.ProviderScopeFrozenError(
+                provider_name=self.display_name,
+                group_name=group_name,
+                current_scope=self.scope,
+                new_scope=scope,
+            )
         self.scope = scope
         self._stamping_group = group_name
 

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -103,6 +103,7 @@ class ProvidersRegistry:
             if provider_type in self._providers:
                 raise exceptions.DuplicateProviderTypeError(provider_type=provider_type)
             self._providers[provider_type] = provider
+            provider._registered = True  # noqa: SLF001
             self._invalidate()
 
     def add_providers(self, *args: AbstractProvider[typing.Any]) -> None:
@@ -119,6 +120,11 @@ class ProvidersRegistry:
                 if provider_type in self._providers:
                     raise exceptions.DuplicateProviderTypeError(provider_type=provider_type)
             self._providers.update(new_providers)
+            # Only once the registration has actually succeeded, and over `args` rather than
+            # `new_providers`: a reference-only provider never enters `_providers`, but its
+            # resolver is still compiled and still captures its scope.
+            for provider in args:
+                provider._registered = True  # noqa: SLF001
             self._invalidate()
 
     def _invalidate(self) -> None:

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -8,6 +8,7 @@ from modern_di.exceptions import (
     GroupInstantiationError,
     GroupScopeConflictError,
     InvalidScopeTypeError,
+    ProviderScopeFrozenError,
 )
 
 
@@ -251,3 +252,73 @@ def test_group_scope_rejects_non_intenum() -> None:
 
         class BadGroup(Group, scope=99):  # ty: ignore[invalid-argument-type]
             svc = providers.Factory(_Svc)
+
+
+def test_group_cannot_change_scope_of_registered_provider() -> None:
+    # A group with no `scope=` never stamps, so it never claims the provider. Before the freeze a
+    # later scoped group could restamp it, and any resolver already compiled kept the old scope --
+    # so the same provider resolved from the same container gave a different answer than a fresh one.
+    shared = providers.Factory(_Svc)
+
+    class PlainGroup(Group):
+        svc = shared
+
+    container = Container(scope=Scope.APP, groups=[PlainGroup])
+    container.resolve_provider(shared)
+
+    with pytest.raises(ProviderScopeFrozenError, match="ScopedGroup") as exc_info:
+
+        class ScopedGroup(Group, scope=Scope.REQUEST):
+            svc = shared
+
+    assert exc_info.value.current_scope is Scope.APP
+    assert exc_info.value.new_scope is Scope.REQUEST
+    assert shared.scope is Scope.APP  # unchanged: the raise happens before the mutation
+
+
+def test_group_may_restamp_provider_that_was_never_registered() -> None:
+    # The freeze is keyed on registration, not on group membership: an unregistered provider is
+    # still free to take a group default, which is the ordinary declaration order.
+    shared = providers.Factory(_Svc)
+
+    class PlainGroup(Group):
+        svc = shared
+
+    class ScopedGroup(Group, scope=Scope.REQUEST):
+        svc = shared
+
+    assert shared.scope is Scope.REQUEST
+
+
+def test_group_same_scope_restamp_allowed_after_registration() -> None:
+    # docs/providers/scopes.md: sharing one provider instance across groups at the same scope is
+    # supported. Registration must not break that -- the freeze only rejects an actual change.
+    shared = providers.Factory(_Svc, scope=Scope.REQUEST)
+
+    class GroupA(Group, scope=Scope.REQUEST):
+        svc = shared
+
+    Container(scope=Scope.APP, groups=[GroupA])
+
+    class GroupB(Group, scope=Scope.REQUEST):
+        svc = shared
+
+    assert shared.scope is Scope.REQUEST
+
+
+def test_failed_registration_does_not_freeze_scope() -> None:
+    # The freeze must key on a registration that actually happened. A rejected add_providers
+    # leaves the provider unregistered, so a later group may still stamp it.
+    shared = providers.Factory(_Svc)
+
+    class PlainGroup(Group):
+        svc = shared
+
+    container = Container(scope=Scope.APP)
+    with pytest.raises(DuplicateProviderTypeError):
+        container.add_providers(shared, providers.Factory(_Svc))  # same bound_type twice
+
+    class ScopedGroup(Group, scope=Scope.REQUEST):
+        svc = shared
+
+    assert shared.scope is Scope.REQUEST


### PR DESCRIPTION
## Why

A `Group` declared **without** a `scope=` kwarg stamps nothing, so a provider listed only in such a group keeps the `Scope.APP` default and stays *unclaimed* — `_stamping_group` is never set, leaving a later scoped group free to restamp it.

That is unsound once the provider has been registered. A compiled resolver captures `scope` in its closure, and `_stamp_group_scope` touches no registry — so `_invalidate()` never fires and the memoized resolver is never dropped. The same provider then answers differently depending on whether a resolver happened to be compiled before the restamp:

```
provider.scope before : APP
resolved once at APP  : ok
provider.scope after  : REQUEST
RESOLVE FROM APP      : SUCCEEDED   <- stale resolver, provider now says REQUEST
fresh container       : raised ScopeNotInitializedError
```

Same provider, same semantic registry state, two different answers. A REQUEST-scoped provider silently resolving from an APP container also means its instance lands in the wrong `cache_registry`, so the wrong `close_async()` runs its finalizer.

`GroupScopeConflictError` does not catch this. It fires only when `_stamping_group` is already set, i.e. when two groups **both** declare a scope and disagree. The documented rule in `docs/providers/scopes.md` covers "two different defaults" and has nothing to say about "no default, then a default".

## Design

The precondition is precise: the provider must already be registered and compiled when the restamp happens. Declared in the other order, everything is consistent — so the fix freezes at exactly that boundary rather than forbidding the pattern.

`add_providers`/`register` set `AbstractProvider._registered`; `_stamp_group_scope` raises the new `ProviderScopeFrozenError` when a stamp would **change** the scope of a registered provider.

Three properties this preserves deliberately:

- **A same-scope stamp still returns early**, so sharing one provider instance across multiple groups at the same scope — explicitly documented as supported — is unaffected.
- **The mark is applied only after registration actually succeeds.** Marking it in the first loop meant a rejected `add_providers` (duplicate `bound_type`) still froze the scope. Pinned by `test_failed_registration_does_not_freeze_scope`.
- **It marks over `args`, not `new_providers`.** A reference-only provider (`bound_type=None`) never enters `_providers` and is skipped by that filter, but its resolver is still compiled and still captures its scope.

Alternatives considered and rejected: making a scope-less group claim the provider anyway would fire even when nothing could go wrong, breaking a scope-less "catalog" group combined with scoped groups; reading `scope` live in the resolver is correct unconditionally but adds an attribute load per node, which the 0% hot-path gate forbids.

## Non-goals

- **Does not change `GroupScopeConflictError`.** It keeps its own case (two groups, both scoped, disagreeing, registered or not); the new error covers a single group changing the scope of an already-compiled provider. The new troubleshooting page states the difference in both directions.
- **Does not forbid cross-group provider sharing**, which stays supported.
- **Does not make the registry observe provider mutation.** A provider has no back-reference to registries and gaining one would be a much larger change for a narrower problem.
- **Does not touch the hot path.**

## Verification

Written test-first: the three group tests and `test_failed_registration_does_not_freeze_scope` were each confirmed failing before the corresponding fix.

- `just test-ci` — **457 passed, 100% line coverage**.
- `just lint-ci` — clean. `just docs-build --strict` — clean.
- The original repro (above) now raises `ProviderScopeFrozenError` at class-creation time, naming the provider, the group, and both scopes.
- **Byte-identity on the resolve path**: all 33 compiled resolvers unchanged vs `main`, so the frame budget and warm-path cost are provably untouched.
- `tests/test_free_threading.py` + `tests/test_group.py` run **50x under free-threaded 3.14t**, 1300 passed.

## Provenance

Found by an independent from-scratch inventory of the resolve path, as a by-product of adversarially refuting two unrelated optimisation candidates — two reviewers hit the same mutable-state hazard from different directions. It is a pre-existing defect, not a regression from any recent change.

---

### Before merging

- [x] **Behaviour changed?** Yes. `architecture/providers.md` documents the freeze and why a compiled resolver forces it; `docs/providers/scopes.md` and `docs/providers/errors-and-exceptions.md` state the user-facing rule; new `docs/troubleshooting/provider-scope-frozen-error.md`, wired into both `mkdocs.yml` nav sections.
- [x] **Rejected an alternative?** The two above are recorded in this body; neither is likely to be re-litigated independently of this change.
- [x] **Found real work you are not doing now?** No.
- [x] **New or sharpened domain term?** No new term; "stamping" already exists in `architecture/providers.md`.
- [x] `just lint-ci` and `just test-ci` pass.
