### PR TITLE
perf(context): drop the typing.cast and dead None check from find_context

### DIFF
--- a/modern_di/registries/context_registry.py
+++ b/modern_di/registries/context_registry.py
@@ -9,9 +9,10 @@ class ContextRegistry:
     context: dict[type[typing.Any], typing.Any]
 
     def find_context(self, context_type: type[types.T]) -> "types.T | types.UnsetType":
-        if context_type is not None and context_type in self.context:
-            return typing.cast(types.T, self.context[context_type])
-
+        # `in` + `[]` rather than `.get(key, UNSET)`: two specialized opcodes beat one method call
+        # with a default, and they keep honouring a dict subclass's `__contains__`/`__getitem__`.
+        if context_type in self.context:
+            return self.context[context_type]
         return types.UNSET
 
     def set_context(self, context_type: type[types.T], obj: types.T) -> None:


### PR DESCRIPTION
## Why

`ContextRegistry.find_context` runs on every context-backed resolve and did four things, two of them waste:

```python
if context_type is not None and context_type in self.context:   # 1. dead check, 2. hash lookup
    return typing.cast(types.T, self.context[context_type])     # 3. second lookup, 4. Python call
return types.UNSET
```

`typing.cast` is a real Python function (`def cast(typ, val): return val`) — a whole frame, at runtime, purely to satisfy a type checker. `context_type is not None` is dead given the parameter is annotated `type[types.T]`.

## Design

Delete both. Keep the `in` + `[]` pair.

The obvious alternative — collapsing the body to `self.context.get(context_type, types.UNSET)` — is worse on both counts, and measurably so:

- **It regresses the miss path**, +4.4 ns. `in` short-circuits and never pays the second lookup or the cast; `.get` pays a fixed cost either way. A miss is a genuine warm path, not an error path: an optional context parameter that is unset resolves to `_Absent.OMIT` and falls back to the creator default.
- **It silently bypasses `dict` subclasses.** `dict.get` is a C slot that reads the underlying storage directly, so an overridden `__contains__`/`__getitem__` never runs.

Isolated method cost, CPython 3.14, Apple M4:

| variant | hit | miss | subclass semantics |
|---|---|---|---|
| before | 83.6 | 39.3 | preserved |
| `try`/`except KeyError` | 32.2 | **117.5** | partly |
| `.get(key, UNSET)` | 44.2 | 43.0 | **broken** |
| **`in` + `[]` (this PR)** | **41.6** | **36.7** | **preserved** |

On 3.14 `in` + `[]` wins both paths, because `CONTAINS_OP` and `BINARY_SUBSCR` are specialized opcodes while `.get` costs a method call plus a default argument. On 3.10 and 3.12 the two candidates trade: `.get` is 2-4 ns better on the hit, `in` + `[]` is 5-6 ns better on the miss. Both roughly **halve** the isolated cost either way, so the ~2-4 ns between them is not the deciding factor — the semantics are.

## Non-goals

- **Does not change `find_context`'s contract.** Same return, same sentinel, same subclass behaviour.
- **Does not touch `set_context`** or the `ContextRegistry` dataclass shape.
- **Does not remove the remaining `ty: ignore` in `ContextProvider.resolve`** (#404), which exists for a different reason: `is UNSET` does not narrow in `ty`.

## Verification

- `just test-ci` — **457 passed, 100% line coverage**. `just lint-ci` — clean.
- **End-to-end A/B against `main`** (median of 3 x 5 runs, n=200k, same machine, `modern_di/` swapped between measurements):

  | path | main | this PR | delta |
  |---|---|---|---|
  | direct `ContextProvider` resolve | 232.5 ns | 204.9 ns | **-27.6 ns (-11.9%)** |
  | handler with context kwarg + APP dep | 729.1 ns | 717.6 ns | -11.5 ns (-1.6%) |

  Not read off `just bench`, whose guard medians are quantized to a 41 ns tick and cannot resolve a move this size.
- **Subclass semantics verified preserved**, not merely argued: resolving through a `dict` subclass that logs both hooks still calls `__contains__` and `__getitem__`.
- **Byte-identity**: all 33 compiled resolvers unchanged vs `main`, so the frame budget and the rest of the warm path are provably untouched.

---

### Before merging

- [x] **Behaviour changed?** No — same contract, same subclass behaviour, byte-identical resolvers. `architecture/performance.md` already covers why a Python-level call on the resolve path is worth deleting; no page needs an edit.
- [x] **Rejected an alternative** with reasoning that would otherwise be re-litigated? The `.get` one-liner, with its measurements, is recorded in the Design section above — it is the obvious "simplification" a future reader would propose, and this body is why it was not taken.
- [x] **Found real work you are not doing now?** No.
- [x] **New or sharpened domain term?** No.
- [x] `just lint-ci` and `just test-ci` pass.
