### PR TITLE
perf(compiler): drop MAKE_CELL from the cached resolver's warm path

### DIFF
--- a/architecture/performance.md
+++ b/architecture/performance.md
@@ -70,6 +70,28 @@ are untouched.
 The warm cached resolve also returns before `CacheItem.get_or_create`, having
 already made the same `is UNSET` sentinel check that method opens with.
 
+### No cell on the warm path
+
+The cached-factory resolver's cold-miss thunk is built with
+`functools.partial(build_cold, target)` and **must never be a lambda closing over
+`target`**. A closure promotes `target` to a cell variable for the *whole*
+resolver, so `MAKE_CELL` runs in the prologue on **every** call — including the
+warm hit that returns two lines later, and the override hit that never reaches
+`target` at all. It also turns four `LOAD_FAST` into `LOAD_DEREF`.
+
+The mechanism is worth stating precisely, because the obvious rationale is wrong:
+`functools.partial` is **not** cheaper than a lambda. On CPython 3.14 it costs
+~69 ns to construct against the lambda's ~36 ns, and ~105 ns against ~75 ns for
+construct-plus-call. It is chosen *despite* that, because it is constructed once
+per cold miss while the cell it avoids was charged on every call. The thunk must
+therefore stay inside the cell-bearing resolver; hoisting its construction
+elsewhere would flip the trade.
+
+Enforced by
+`tests/test_resolver_compiler.py::test_cached_resolver_has_no_cell_on_the_warm_path`,
+which asserts `co_cellvars == ()` on the compiled resolver — nothing else in the
+suite would catch a revert to a lambda.
+
 ## The positional fast path
 
 When a creator's entire signature is provider dependencies in declaration order,
@@ -141,6 +163,8 @@ after. Byte-identical output means there is nothing to measure.
 | `creator(**kwargs)` vs `creator(*args)` | **4-6x** | the positional fast path's whole justification |
 | `resolver_for` method frame | ~34 ns | of a ~170 ns warm resolve (~20%) |
 | `fetch_cache_item` method frame | ~23 ns | of the same ~170 ns warm resolve (~14%) |
+| `MAKE_CELL` + 4 `LOAD_DEREF` in the cached resolver prologue | ~18 ns | of a ~162 ns warm cached hit (~11%); no path regressed, including a one-shot cold miss |
+| `functools.partial` vs a `lambda`, construct + call | +30 ns | why the partial is a deliberate trade, not a free swap |
 | `typing.cast` on the context resolve path | ~19 ns | removed in #404 |
 | `isinstance` vs an `is` identity check | ~10 ns | why the `UNSET` check is `is`, with a scoped `ty: ignore` |
 | A redundant `open()` lock acquire | ~81 ns | found in the comparative C6 body |

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -6,6 +6,7 @@ dependencies' resolvers by reference. Behavior-sensitive helpers (`_resolution_s
 `_resolve_context_value`, `prepend_step`) are reused, not reimplemented.
 """
 
+import functools
 import typing
 
 from modern_di import exceptions, types
@@ -228,7 +229,10 @@ def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: pos
             return cached
         value, created = cache_item.get_or_create(
             target._lock,
-            resolve=lambda: build_cold(target),
+            # `partial`, never a lambda closing over `target`: a closure promotes `target` to a cell,
+            # so MAKE_CELL runs in this resolver's prologue on every warm hit too. See
+            # architecture/performance.md.
+            resolve=functools.partial(build_cold, target),
             # positional/kwargs builders have distinct arg types; get_or_create feeds each its own.
             create=typing.cast("typing.Callable[[typing.Any], typing.Any]", create_cold),
         )

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -306,3 +306,21 @@ def test_resolve_costs_exactly_one_resolver_frame_per_node() -> None:
         f"on Python {sys.version_info.major}.{sys.version_info.minor}. A helper extracted from "
         f"the compiled resolvers costs one frame per resolved node -- see architecture/performance.md."
     )
+
+
+def test_cached_resolver_has_no_cell_on_the_warm_path() -> None:
+    # The cold-miss thunk must not close over `target`: a closure promotes it to a cell, so
+    # MAKE_CELL runs in the resolver's prologue on every call -- including the warm hit that
+    # returns early, and the override hit that never reaches `target` at all. Measured at ~18 ns
+    # of a ~162 ns warm resolve. Nothing else in the suite would catch a revert to a lambda.
+    class G(Group):
+        cached = providers.Factory(creator=_A, scope=Scope.APP, cache=True)
+
+    container = Container(scope=Scope.APP, groups=[G])
+    resolver = container.providers_registry.resolver_for(G.cached)
+    code = typing.cast("_pytypes.FunctionType", resolver).__code__
+
+    assert code.co_cellvars == (), (
+        f"the cached-factory resolver grew cell variables {code.co_cellvars}; "
+        f"a MAKE_CELL now runs on every warm hit -- see architecture/performance.md"
+    )


### PR DESCRIPTION
## Why

A warm cached resolve is the most common operation in a DI container, and it was paying for a cell it never used.

`_compile_cached_factory` built its cold-miss thunk as `lambda: build_cold(target)`. Closing over `target` promotes it to a cell variable for the **whole** resolver, so `MAKE_CELL` ran in the prologue on **every** call — including the warm hit that returns two lines later at `if cached is not types.UNSET`, and the override hit that never reaches `target` at all. It also turned four `LOAD_FAST` into `LOAD_DEREF`.

## Design

`functools.partial(build_cold, target)` carries the argument instead of capturing it:

```
co_cellvars ('target',) -> ()      MAKE_CELL 1 -> 0      LOAD_DEREF 12 -> 8
```

**The obvious rationale for this is wrong, and the PR would be misleading without saying so.** `functools.partial` is *not* cheaper than a lambda. On CPython 3.14 it costs ~69 ns to construct against the lambda's ~36 ns, and ~105 ns against ~75 ns for construct-plus-call. It wins anyway for two reasons: it is constructed once per **cold miss**, while the cell it removes was charged on **every** call; and the cold path also sheds the prologue cell and the four `DEREF` loads, which more than covers the construction penalty.

The consequence is a constraint worth writing down: the thunk must stay constructed *inside* the cell-bearing resolver. Hoisting it elsewhere would flip the trade.

## Non-goals

- **Does not change `CacheItem.get_or_create`'s contract**, the double-checked creation lock, or anything about concurrent first-resolve.
- **Does not touch the transient, alias, context, or container-provider resolvers.** Byte-identity below confirms it.
- **Does not apply the same treatment anywhere else.** This is the only closure with a cell on a warm path.

## Verification

Measured A/B against `main` (`modern_di/` swapped between runs, median of 3 x 5, n=300k, CPython 3.14.6, Apple M4):

| path | main | this PR | delta |
|---|---|---|---|
| warm cached hit | 162.5 ns | 144.2 ns | **-18.3 (-11.3%)** |
| warm cross-scope hit | 217.2 ns | 199.2 ns | -18.0 (-8.3%) |
| **override HIT** (returns before `target` is assigned) | 153.4 ns | 142.0 ns | **-11.4** — the cell alone |
| 1 cold miss, 0 warm hits (REQUEST-cached, one-shot) | 1453.2 ns | 1417.4 ns | -35.8 |
| CONTROL transient resolve | 177.6 ns | 179.0 ns | +1.4 (noise, expected flat) |

**No path regressed.** The override-hit row is the load-bearing one: that path returns before `target` is ever assigned, so its gain is `MAKE_CELL` and nothing else — the mechanism is isolated, not inferred from the headline number. The one-shot cold-miss row is the case that *could* have regressed, since it pays the partial's construction with no warm hit to amortise it; measured, it does not.

- `just test-ci` — **458 passed, 100% line coverage**. `just lint-ci` clean.
- Full suite at 100% coverage on **CPython 3.10** as well, and 458 passed under **free-threaded 3.14t**.
- **New guard test**, `test_cached_resolver_has_no_cell_on_the_warm_path`, asserting `co_cellvars == ()`. Nothing in the existing 457 would catch a revert to a lambda. Verified it fails on exactly that revert.
- **Byte-identity**: only the two cached-factory resolvers change; the other 31 compiled resolvers are unchanged.

## Provenance

Proposed by an automated inventory, then prototyped and independently re-measured by two agents that did not build it. Its stated mechanism ("partial replaces a Python frame with a C call") was **wrong** and is corrected above and in `architecture/performance.md`; the effect is real and reproduced by three independent measurements.

---

### Before merging

- [x] **Behaviour changed?** No observable behaviour change. `architecture/performance.md` gains a "No cell on the warm path" subsection stating the constraint and the corrected mechanism, plus two Measurements rows.
- [x] **Rejected an alternative?** The lambda is the alternative, and why it loses is recorded in the Design section and the architecture page.
- [x] **Found real work you are not doing now?** Yes, two items from the same investigation — filed separately, not here.
- [x] **New or sharpened domain term?** No.
- [x] `just lint-ci` and `just test-ci` pass.
