### PR TITLE
docs(planning): record the seven findings from the resolve-path inventory

### DIFF
--- a/planning/decisions/2026-08-01-contextprovider-resolver-inline-declined.md
+++ b/planning/decisions/2026-08-01-contextprovider-resolver-inline-declined.md
@@ -1,0 +1,55 @@
+---
+summary: Declined inlining the ContextProvider resolver into its compiled closure — it freezes cp.scope against a live mutation, buys 0 ns on the factory-dependency path that actually matters, and was dominated by a one-line find_context change that is faster on both paths.
+---
+
+# Declined: inlining the ContextProvider resolver into its closure
+
+**Decision:** `_compile_context_provider` keeps delegating to the bound
+`ContextProvider.resolve`. Its body is not inlined into the compiled closure.
+
+## Context
+
+`_compile_context_provider` is the one Factory-style resolver that does not
+inline its own body: it delegates to `cp.resolve`, which calls
+`fetch_context_value`, which calls `find_container` (always — with no same-scope
+int-compare fast path, unlike every Factory closure) and then `find_context`.
+An automated inventory measured a direct `ContextProvider` resolve at ~233 ns
+against a plain factory's ~196 ns, with 8 Python calls against 4, and proposed
+capturing `cp.context_type` and `cp.scope` at compile time to remove four frames.
+
+## Decision & rationale
+
+Three independent reasons, any one sufficient.
+
+**It freezes `cp.scope` against a mutation that is live at the time.** Capturing
+the scope in the closure is only sound if the scope cannot change after compile.
+It could: `AbstractProvider._stamp_group_scope` mutated `provider.scope` and
+touched no registry, so `_invalidate()` never fired and the memoized resolver was
+never dropped. A `Group` subclass declared after first resolve could restamp a
+shared `ContextProvider` from APP to REQUEST; today's delegating resolver raises
+`ScopeNotInitializedError`, and the inlined one would return a silently stale
+value. That hazard has since been closed at its source — see
+[`architecture/providers.md`](../../architecture/providers.md) and
+`ProviderScopeFrozenError` — but it was closed by *freezing the scope at
+registration*, not by making the capture safe in general, and it was found while
+refuting this candidate rather than before proposing it.
+
+**It buys nothing where it matters.** The measured win is on a *direct*
+`resolve_provider(context_provider)` call. On the factory-dependency path — a
+`Factory` with a context kwarg, which is what every integration actually does —
+the gain measured **0 ns**, because that path goes through
+`Factory._resolve_context_value`, not through the compiled ContextProvider
+resolver at all.
+
+**It was dominated.** A one-line change to `ContextRegistry.find_context`
+(dropping a `typing.cast` and a dead `None` check) was faster on *both* paths for
+a net **-1 line**, against this candidate's +27 lines and 0 deleted. That shipped
+instead; see the `find_context` PR body for its numbers and for why the
+`.get(key, UNSET)` variant was rejected in turn.
+
+## Revisit trigger
+
+A profile from a real integration shows direct `ContextProvider` resolution — not
+context *kwargs* on a factory — as a measurable cost, **and** the scope capture
+can be licensed by something stronger than the current freeze-at-registration
+rule. Absent the first, this optimises a path nobody takes.

--- a/planning/decisions/2026-08-01-scope-map-inline-declined.md
+++ b/planning/decisions/2026-08-01-scope-map-inline-declined.md
@@ -1,0 +1,58 @@
+---
+summary: Declined inlining Container._scope_map at the four resolver navigation sites — the measured ~24% cross-scope win requires bypassing find_container, a blessed extension point, and silently relocates cached-singleton and finalizer ownership for any Container subclass that overrides it.
+---
+
+# Declined: inlining `_scope_map` at the resolver navigation sites
+
+**Decision:** The compiled resolvers keep calling `_navigate` →
+`Container.find_container` for a cross-scope hop. The `_scope_map` lookup is not
+inlined into the closures.
+
+## Context
+
+Same-scope dependencies skip navigation via an int compare, but every
+*cross-scope* node pays a `_navigate` frame plus a `find_container` frame. Four
+of the inventory's lenses independently proposed replacing the ternary at the
+four navigation sites with an inlined `container._scope_map.get(scope)`, falling
+back to `_navigate` only on a miss — the same hand-inlined-memo-hit pattern
+already used for `resolver_for` and `fetch_cache_item`. Measured cross-scope
+resolve 185.4 → 140.7 ns (**-24%**), with a flat same-scope control.
+
+## Decision & rationale
+
+The measurement is real and was reproduced. It is declined on the invariant, not
+the number.
+
+**The invariant audits a function body while the code being changed is a
+dispatch.** Every formulation justified itself by what `find_container`'s body
+does. But `find_container` is a public method on a subclassable class, and
+`Container.__init__` builds children via `self.__class__`, so a subclass is
+carried down the whole container tree. Inlining the hit path means a subclass
+that overrides `find_container` is **silently bypassed** — its override runs on
+the miss path only. `unittest.mock.patch.object` makes this visible directly:
+calls recorded on the override go from `['APP', 'APP']` to `[]`.
+
+**The consequence is worse than a missed hook.** The container returned by
+navigation is the one whose `cache_registry` receives the singleton. Bypassing an
+override that redirects navigation therefore relocates *cached-instance
+ownership*, so a different container's `close_async()` runs that instance's
+finalizer. That is a lifecycle bug, not a perf regression, and nothing in the
+suite would catch it.
+
+**It contradicts a standing decision.** `find_container` is a blessed extension
+point;
+[`2026-07-15-provider-facing-seam-declined.md`](2026-07-15-provider-facing-seam-declined.md)
+rests on that seam existing. Demoting it is a design change, and it should be
+argued on its own terms rather than absorbed as a side effect of an optimisation.
+
+**It also failed the gates as submitted**: coverage 99% (two unreachable lines
+where the fallback never fires) and `lint-ci` red, at +20 lines with none
+deleted, and six new rules a maintainer must hold. `ContextProvider` would still
+call `find_container`, leaving two navigation conventions in one codebase.
+
+## Revisit trigger
+
+`find_container` stops being an extension point — an explicit decision that
+`Container` subclasses may not redirect navigation, with the lifecycle
+consequence above stated and accepted. Then this becomes a plain inlining and the
+measured 24% is available.

--- a/planning/deferred/2026-08-01-alias-source-binding.md
+++ b/planning/deferred/2026-08-01-alias-source-binding.md
@@ -1,0 +1,55 @@
+---
+summary: Binding an Alias to its source's compiled resolver at compile time measures -36% on every alias resolve (~100 ns and 3 frames per hop), blocked on eager compilation escaping the override front-guard and on the resolver-memo publication race.
+---
+
+# Bind an `Alias` to its source's compiled resolver
+
+`_compile_alias` is the only compiled closure that does not use the
+`registry.resolver_for(p)` direct-reference pattern every `Factory` closure uses.
+It calls `a._find_source(container)` per resolve and re-enters
+`Container.resolve_provider`, paying three Python frames and two dict lookups on
+every alias hop. Resolving the source once at compile time and closing over its
+resolver would reduce the body to `source_resolver(container)` inside the
+existing try/except that prepends the alias's resolution step.
+
+## Why it is open
+
+The prize is real and was reproduced by two independent verifiers: alias resolve
+305.5 → 192.0 ns (**-36%**), roughly **-100 ns and -3 frames per alias hop**. A
+control that overrides the alias itself stayed flat, as it must.
+
+Two blockers, and **neither is alias-specific** — which is why this is deferred
+rather than rejected.
+
+**Eager compilation escapes the override front-guard.** Binding at compile time
+makes alias compilation recursive and eager: it compiles the alias's entire
+source subtree *even when the alias is overridden and the source is never
+touched* — which is exactly the `modern-di-pytest` mock pattern. Shown
+structurally rather than by timing: `len(providers_registry._resolvers)` after
+resolving an overridden alias goes from 1 to 1+depth (11 at depth 10), and cold
+cost from 6652 to 33539 ns (**+404%**). It also raises `TypeError` eagerly for a
+source whose provider type `compile_resolver` does not know, and drops the
+maximum pure-alias chain from 494 to 329 hops (`RecursionError` at compile time).
+Any future attempt must bind **lazily on first miss**, or bind only after the
+override front-guard has been cleared.
+
+**The resolver-memo publication race.** The licensing invariant — that a source
+registered after the alias compiles is picked up via `_invalidate()` — is false,
+because of a pre-existing window in `ProvidersRegistry.resolver_for`. See
+[`2026-08-01-resolver-memo-publication-race.md`](2026-08-01-resolver-memo-publication-race.md).
+Today's alias is accidentally immune because it re-looks-up its source on every
+resolve; binding the source is precisely what removes that immunity, turning a
+transient staleness window into a permanent `AliasSourceNotRegisteredError`. A
+verifier measured 377/400 trials failing under plain threads against 0/400 on
+`main` — a figure recorded here as reported and **not independently reproduced**;
+see that record for what is and is not confirmed.
+
+A working prototype is preserved at `prototype-alias-bind.diff` in this session's
+workflow transcript directory.
+
+## Revisit trigger
+
+Resolver-memo publication becomes generation-checked under the registry lock
+(closing the second blocker), **and** alias source binding can be made lazy
+enough not to compile a subtree behind an active override (closing the first).
+Both are prerequisites; neither alone unblocks this.

--- a/planning/deferred/2026-08-01-arity-specialised-creator-call.md
+++ b/planning/deferred/2026-08-01-arity-specialised-creator-call.md
@@ -1,0 +1,52 @@
+---
+summary: Arity-specialised creator calls measure ~-30% on transient chains (~45 ns/node) with call semantics verified identical across 3.10-3.14, but shipping needs a ruling on transient-dependency finalization order (reversed below 3.12) and an arity-aware frame-budget constant.
+---
+
+# Arity-specialise the positional creator call
+
+`resolve_positional` builds its arguments with a comprehension and star-calls the
+creator (`args = [r(target) for r in pos]`, then `creator(*args)`), even though
+`len(pos)` is fixed the moment the resolver is compiled. Specialising on arity —
+`creator()` for 0 deps, `a0 = r0(target); creator(a0)` for 1, and so on up to a
+small cap — removes the list build and the `CALL_FUNCTION_EX` unpack.
+
+## Why it is open
+
+This is the largest measured single win found on the resolve path, and it applies
+to essentially every node. In-process interleaved A/B (CPython 3.14.6, Apple M4,
+medians of 9x500k, real containers, candidate closures injected into
+`providers_registry._resolvers`): 0 deps 122.2 → 93.0 ns, and a depth-6 transient
+chain 794 → 571 ns (**~-30%**, ~45 ns per node).
+
+The semantics survived unusually hard probing: 56 callable kinds x 5
+interpreters, 19 scenarios, with byte-identical error messages and breadcrumb
+chains. Nothing about argument binding broke.
+
+It was killed on two things it never claimed, both found by adversarial review:
+
+- **Finalization order changes below 3.12.** The star-call's intermediate list
+  owns the arguments, and `list_dealloc` frees them back-to-front. Removing the
+  list changes the order in which transient dependencies with no finalizer hook
+  are collected — reversed on 3.10/3.11/3.12, unchanged on 3.14. That is a
+  cross-version behavioural divergence introduced by a performance change, and it
+  is a maintainer call, not an implementation detail.
+- **It breaks the frame-budget test as written.** Per-node Python calls drop from
+  3 to 2 below 3.12, which red-fails
+  `tests/test_resolver_compiler.py::test_resolve_costs_exactly_one_resolver_frame_per_node`
+  and falsifies the PEP 709 paragraph in
+  [`architecture/performance.md`](../../architecture/performance.md). The test is
+  right and the candidate is right; the constant simply has to become
+  arity-aware.
+
+Two lesser notes for whoever picks it up: the cited cached-factory half is off
+the warm path and was never measured, and one binding site becomes five, of which
+four are untested by the single existing ordering test.
+
+## Revisit trigger
+
+A maintainer ruling on transient-dependency finalization order — either accepting
+the below-3.12 reversal as immaterial, or CPython unifying frame-teardown order
+across supported versions — **or** the transient-chain benchmark becoming the
+binding constraint on a real workload. Any attempt must land with an arity-aware
+`_CALLS_PER_NODE`, an arity-parameterised binding-order test, and a cap of
+3-4 deps.

--- a/planning/deferred/2026-08-01-context-kwarg-inline.md
+++ b/planning/deferred/2026-08-01-context-kwarg-inline.md
@@ -1,0 +1,55 @@
+---
+summary: The context-kwarg path in the Factory closures still pays ~5 Python frames per kwarg; a narrow -9.2% variant is unrefuted, while the full -16.2% inline needs a ruling that ContextProvider.scope and context_type are frozen after registration.
+---
+
+# Inline the context-kwarg path in the Factory closures
+
+A `Factory` parameter backed by a `ContextProvider` is resolved per resolve
+through `Factory._resolve_context_value`, which calls
+`overrides_registry.fetch_override`, then `ContextProvider.fetch_context_value`,
+which calls `find_container` and `ContextRegistry.find_context` — roughly five
+Python frames per context kwarg, on the path every framework integration takes
+for its per-request values.
+
+## Why it is open
+
+Measured on a REQUEST factory with one context kwarg: 312-329 ns → 225 ns
+(**~-28%**) for the full inline; a narrower variant measured -9.2%. The work
+splits into three parts of increasing invasiveness, and they do not stand or fall
+together:
+
+- **(i) Gate `fetch_override` on `has_overrides`.** `_resolve_context_value`
+  calls `overrides_registry.fetch_override(...)` unconditionally, while all seven
+  compiled closures gate the identical lookup behind `has_overrides` first.
+  Measured ~-41 ns (-5.3%) on every no-overrides resolve. This part was **not
+  refuted** — its invariant was verified by exhaustion — and it needs no ruling.
+  It is a small PR on its own, not a blocked item.
+- **(ii) Give the context hop the same-scope int-compare fast path** the Factory
+  closures already have, instead of always calling `find_container`.
+- **(iii) Fold the bindings at compile time**, capturing `cp.context_type`,
+  `cp.scope`, `cp.provider_id` and `absent_disposition(item)` into the closure
+  instead of re-reading them per resolve.
+
+Part (iii) is what is actually blocked. It freezes `cp.scope` and
+`cp.context_type` in the closure, and an adversarial review showed that a
+`Group` subclass declared after first resolve could restamp a shared
+`ContextProvider`'s scope, so the inline would inject an APP-scoped value into a
+REQUEST-scoped parameter — silently, with the whole suite green. That specific
+hazard has since been closed at its source by `ProviderScopeFrozenError`
+(scope is frozen once the provider is registered), which removes the
+demonstrated counterexample but does **not** by itself license the capture:
+`context_type` is still mutable in principle, and no rule yet says a
+`ContextProvider`'s identity is fixed at registration.
+
+The submitted prototype also failed the gates: +12 executable statements,
+coverage 100% → 99% (eight new uncovered lines, five in the cold cached copy),
+and two *new* ruff violations (`C901` 15>10, `PLR0912` 14>12) on the hot closure.
+The obvious `_navigate`-based implementation of (ii) double-prepends the
+resolution-step breadcrumb, and CI stays green while it does.
+
+## Revisit trigger
+
+A maintainer ruling that a `ContextProvider`'s `scope` **and** `context_type` are
+fixed once it is registered — the same shape as the scope freeze, extended to
+identity — **or** context kwargs showing up hot in a profile from a real
+integration. Part (i) needs neither and can be picked up at any time.

--- a/planning/deferred/2026-08-01-resolve-by-type-inline.md
+++ b/planning/deferred/2026-08-01-resolve-by-type-inline.md
@@ -1,0 +1,65 @@
+---
+summary: Inlining find_provider and resolve_provider into Container.resolve is a reproduced flat ~30 ns per by-type resolve (~60 ns on 3.10), held back by a CPython 3.10 coverage-gate failure and an 8-line duplicated body that must be edited in lockstep with resolve_provider.
+---
+
+# Inline the by-type resolve entry point
+
+`Container.resolve(dependency_type)` calls
+`providers_registry.find_provider(...)` and then tail-calls
+`self.resolve_provider(provider)`, paying a second Python frame on the by-type
+path — the one every `@inject` marker and framework integration takes. Inlining
+the `_providers.get` lookup and the `resolve_provider` body (closed guard,
+`_resolvers.get` memo hit, `resolver(self)`) removes that frame.
+
+## Why it is open
+
+Not killed on merit. Both verifiers reproduced a flat win with genuinely flat
+controls:
+
+| path | main | candidate |
+|---|---|---|
+| cached hit, same scope | 181.7 ns | 152.7 ns |
+| cached hit, cross-scope | 232.4 ns | 202.9 ns |
+| depth-3 uncached | 588 ns | 554 ns |
+| CONTROL `resolve_provider` | — | ±0.7 ns |
+
+Roughly **-30 ns on every by-type resolve**, ~-60 ns on 3.10, and ~-83 ns per
+resolve under 4-thread free-threading. An audit of all 13 sibling integration
+wheels found **zero** `Container` subclasses and **zero** `resolve_provider`
+overrides, so the interception-point argument that killed the `_scope_map`
+inlining (see
+[`../decisions/2026-08-01-scope-map-inline-declined.md`](../decisions/2026-08-01-scope-map-inline-declined.md))
+does not bite here in practice today.
+
+It is not shippable as submitted:
+
+- **`just test-ci` fails on CPython 3.10**, a real CI matrix cell:
+  `modern_di/container.py` drops 100.00% → 99.98%, with
+  `_handle_recursion_error`'s call site in `resolve_provider`'s `except`
+  uncovered, reproduced 5/5. 3.11 through 3.14t stay at 100%. The fix is known:
+  add a test that reaches that handler **by reference** rather than through
+  `resolve()`, restoring coverage at a clean call boundary instead of relying on
+  near-limit cycle unwinds where 3.10 suspends the trace function. Worth noting
+  the prototyper *did* run 3.10 — without coverage — which is exactly why it
+  missed this.
+- Two `architecture/` pages state the now-false singular and would need editing:
+  `containers.md` and `validation.md` each name only `resolve_provider` as the
+  path that compiles and dispatches.
+- Two invariant shifts to disclose: recursion headroom moves by one frame (the
+  smallest working limit for a 25-node by-type chain goes 105 → 104, the benign
+  direction), and every exception raised through `resolve()` loses one traceback
+  frame.
+
+**The standing cost is the judgement call, not the measurement**: it creates a
+genuinely duplicated ~8-line body that must be edited in lockstep with
+`resolve_provider`, permanently, in exchange for ~30 ns. That is the trade to
+rule on. A working prototype is preserved at `prototype-resolve-inline.diff` in
+this session's workflow transcript directory.
+
+## Revisit trigger
+
+`resolve_provider`'s `RecursionError` handler gains a by-reference test so 3.10
+coverage holds, **and** a maintainer accepts the duplicated body as a standing
+maintenance cost. Alternatively, the by-type path shows up as a measurable
+bottleneck in a real integration profile, which would settle the trade on its
+own.

--- a/planning/deferred/2026-08-01-resolver-memo-publication-race.md
+++ b/planning/deferred/2026-08-01-resolver-memo-publication-race.md
@@ -1,0 +1,68 @@
+---
+summary: ProvidersRegistry.resolver_for compiles outside the lock and stores the memo after, so a registration landing in that window clears a memo the resolver has not entered yet and the stale resolver is then written in and never dropped — verifiable by reading, out of contract today, and a hard blocker on alias source binding.
+---
+
+# Resolver-memo publication race in `ProvidersRegistry.resolver_for`
+
+`resolver_for` compiles a resolver **outside** `self._lock` and writes it to the
+memo **after** compiling:
+
+```python
+building.add(pid)
+try:
+    resolver = compile_resolver(provider, self)  # outside _lock
+finally:
+    building.discard(pid)
+self._resolvers[pid] = resolver  # store after, also outside _lock
+```
+
+`register()` and `add_providers()` hold `_lock` and call `_invalidate()`, which
+does `self._resolvers.clear()`. A compile that began before an `_invalidate()`
+therefore stores its result *after* the clear. The stored resolver was compiled
+against the pre-registration registry — its dependency resolvers, its wiring plan
+and its captured scope all predate the new provider — and nothing will ever drop
+it, because the invalidation it needed has already happened.
+
+## Why it is open
+
+**What is confirmed:** the code shape, by reading. `_invalidate()`'s own
+docstring says it is "called under `self._lock` by every mutation", and the memo
+write in `resolver_for` is not. The ordering hazard is not in dispute.
+
+**What is not confirmed:** that it is reachable in practice. An adversarial
+reviewer reported 375/400 trials producing a permanently-stale optional `Factory`
+dependency under plain threads. **That figure was not reproduced.** Two direct
+attempts here found 0/200 and 0/150 — the first with a small graph, where the
+window between `compile_resolver` returning and the memo store is a couple of
+bytecodes; the second with a deliberately widened window, which was itself
+invalid (the constructed graph raised `ArgumentResolutionError` and never
+exercised the path). Treat the frequency as unverified and the shape as real.
+
+**Why it is out of contract today.** `add_providers`'s docstring calls
+registration "a startup-time operation: concurrent calls on the same root are not
+coordinated beyond the registry's internal lock", and
+[`architecture/concurrency.md`](../../architecture/concurrency.md) defines the
+configure phase as single-threaded. Registering concurrently with resolution is
+therefore unsupported, which is what keeps this latent rather than live. It is
+recorded because "unsupported" and "silently wrong" are different things, and
+this fails silently and permanently rather than raising.
+
+**Why it matters beyond itself.** It is a hard blocker on
+[`2026-08-01-alias-source-binding.md`](2026-08-01-alias-source-binding.md): the
+alias candidate's licensing invariant is that a source registered after compile
+is picked up via `_invalidate()`, and this window makes that false. Today's alias
+is accidentally immune only because it re-looks-up its source on every resolve.
+
+**The proposed fix is small**: a generation counter on the registry, bumped by
+`_invalidate()`, read before `compile_resolver`, and — under `_lock` — used to
+store the memo only if the generation is unchanged. It costs one integer compare
+on the compile path, which is cold, and nothing on the warm path.
+
+## Revisit trigger
+
+Any of: a decision to support registration concurrent with resolution (which
+would make this live rather than latent); picking up alias source binding, which
+cannot proceed without it; or a reproduction of the stale-resolver failure that
+survives scrutiny, which would reclassify this as a bug to fix now rather than a
+hazard to record. Fixing it on its own merits is also reasonable — the fix is
+cheap and the failure mode is silent.


### PR DESCRIPTION
## Why

Two multi-agent inventories of the resolve hot path produced a shipped optimisation (#409) and a correctness fix (#407). Everything else they found — including two rejected alternatives with real measured wins, and a latent registry defect — existed only in transcript files under `/private/tmp` and a workflow journal.

This is exactly the failure the repo has already had once. The previous research effort on this same topic produced a 2101-line report in #393; #394 deleted it when `audits/` was dropped, without migrating its three unresolved rows. Recovering that reasoning from `841a5d8` cost the first hour of this session, and `planning/README.md` is explicit that a rejected alternative "leaves no trace in a diff... Without a home it gets re-proposed."

## Design

Seven records, sorted by what they are rather than where they came from.

**`decisions/` — rejected, each on an invariant rather than a number**, so the measurement alone can't resurrect them:

| Record | Measured | Killed by |
|---|---|---|
| ContextProvider resolver inlining | -37 ns direct | Froze `cp.scope` against a then-live mutation; **0 ns** on the factory-dependency path integrations actually take; dominated by the one-liner that shipped as #408 |
| `_scope_map` inlining | **-24%** cross-scope | Bypasses `find_container`, a blessed extension point that [`2026-07-15-provider-facing-seam-declined.md`](planning/decisions/2026-07-15-provider-facing-seam-declined.md) rests on; silently relocates cached-singleton and finalizer ownership for a `Container` subclass |

**`deferred/` — real prizes, concrete blockers, each with a revisit trigger:**

| Record | Measured | Blocked on |
|---|---|---|
| Context-kwarg inlining | ~-28% | A ruling that a `ContextProvider`'s scope **and** `context_type` are fixed at registration. Its part (i) is unblocked and is a small PR on its own |
| Arity-specialised creator call | ~-30% transient chains | A ruling on transient finalization order, which reverses below 3.12; plus an arity-aware frame-budget constant |
| Alias source binding | **-36%** per alias resolve | Eager compilation escaping the override front-guard (+404% cold for the `modern-di-pytest` mock pattern), and the memo race below |
| By-type resolve inlining | ~-30 ns, ~-60 on 3.10 | A 3.10 coverage-gate failure, and accepting a permanently duplicated 8-line body |
| Resolver-memo publication race | — | Nothing; it is a latent defect, recorded for a ruling |

## The record I want read most carefully

`2026-08-01-resolver-memo-publication-race.md` deliberately separates what is confirmed from what is not.

**Confirmed by reading:** `resolver_for` compiles outside `_lock` and writes the memo after, while `_invalidate()` clears `_resolvers` under `_lock`. A compile that began before an invalidation stores its result after the clear, and nothing will ever drop it.

**Not confirmed:** a reviewer reported 375/400 trials producing a permanently-stale `Factory` dependency. I could not reproduce it — 0/200 with a small graph, and a second attempt with a deliberately widened window was itself invalid (it raised `ArgumentResolutionError` and never exercised the path). The record says so plainly and marks the frequency unverified rather than repeating it as fact.

It is **out of contract today**: `add_providers` documents registration as a startup-time operation and `architecture/concurrency.md` defines the configure phase as single-threaded. It is recorded anyway because "unsupported" and "silently wrong" are different things, and this fails silently and permanently rather than raising. The proposed fix is a generation counter, costing one integer compare on a cold path.

## Non-goals

- **Ships no code.** Records only.
- **Does not rule on anything.** Every deferred item names the decision it needs and leaves it to you; none pre-empts your call.
- **Does not restore `planning/audits/`.** These are `decisions/` and `deferred/` entries under the current convention, which is the point — the last report was deleted precisely because it lived in a directory the convention dropped.

## Verification

- `just check-planning` — `planning: OK` (frontmatter and naming validated for all seven).
- `just check-links` — `links: OK`.
- `just lint-ci` — clean. Note `ruff format` reformats Python inside markdown fences, and did reformat the code block in the memo-race record.
- `just test-ci` — 458 passed, 100% coverage. `just docs-build` — clean.
- `just index` renders all seven in the listing.

Working prototypes for the two deferred candidates that have them (`alias-bind`, `resolve-inline`) are preserved beside the workflow journal and referenced from their records, so whoever picks them up starts from running code rather than a description.
