### PR TITLE
perf(context): front-guard the override lookup on the context-kwarg path

### DIFF
--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -179,9 +179,13 @@ class Factory(AbstractProvider[types.T_co]):
         Absent value falls back to the creator default (omit), ``None`` (nullable), or raises
         ``ArgumentResolutionError`` (required).
         """
-        override = container.overrides_registry.fetch_override(provider.provider_id)
-        if override is not types.UNSET:
-            return override
+        # Front-guard on `has_overrides` first, as the seven compiled closures do: `fetch_override`
+        # opens with the same emptiness check, so an ungated call costs a frame to learn nothing.
+        overrides = container.overrides_registry
+        if overrides.has_overrides:
+            override = overrides.fetch_override(provider.provider_id)
+            if override is not types.UNSET:
+                return override
         value = provider.fetch_context_value(container)
         if value is not types.UNSET:
             return value

--- a/planning/deferred/2026-08-01-context-kwarg-inline.md
+++ b/planning/deferred/2026-08-01-context-kwarg-inline.md
@@ -1,15 +1,15 @@
 ---
-summary: The context-kwarg path in the Factory closures still pays ~5 Python frames per kwarg; a narrow -9.2% variant is unrefuted, while the full -16.2% inline needs a ruling that ContextProvider.scope and context_type are frozen after registration.
+summary: The context-kwarg path in the Factory closures still pays ~4 Python frames per kwarg after the override-guard fix shipped; the remaining scope-hop and compile-time-fold parts need a ruling that ContextProvider.scope and context_type are frozen after registration.
 ---
 
 # Inline the context-kwarg path in the Factory closures
 
 A `Factory` parameter backed by a `ContextProvider` is resolved per resolve
 through `Factory._resolve_context_value`, which calls
-`overrides_registry.fetch_override`, then `ContextProvider.fetch_context_value`,
-which calls `find_container` and `ContextRegistry.find_context` — roughly five
-Python frames per context kwarg, on the path every framework integration takes
-for its per-request values.
+`ContextProvider.fetch_context_value`, which calls `find_container` and
+`ContextRegistry.find_context` — roughly four Python frames per context kwarg
+(five before the override guard shipped), on the path every framework
+integration takes for its per-request values.
 
 ## Why it is open
 
@@ -18,12 +18,11 @@ Measured on a REQUEST factory with one context kwarg: 312-329 ns → 225 ns
 splits into three parts of increasing invasiveness, and they do not stand or fall
 together:
 
-- **(i) Gate `fetch_override` on `has_overrides`.** `_resolve_context_value`
-  calls `overrides_registry.fetch_override(...)` unconditionally, while all seven
-  compiled closures gate the identical lookup behind `has_overrides` first.
-  Measured ~-41 ns (-5.3%) on every no-overrides resolve. This part was **not
-  refuted** — its invariant was verified by exhaustion — and it needs no ruling.
-  It is a small PR on its own, not a blocked item.
+- **(i) Gate `fetch_override` on `has_overrides`.** ~~`_resolve_context_value`
+  calls `overrides_registry.fetch_override(...)` unconditionally.~~ **Shipped.**
+  Measured -41.1 ns (-5.98%) on the no-overrides path, with the override-active
+  path also improving slightly (-4.4 ns). It needed no ruling and was never
+  blocked; only (ii) and (iii) below remain.
 - **(ii) Give the context hop the same-scope int-compare fast path** the Factory
   closures already have, instead of always calling `find_container`.
 - **(iii) Fold the bindings at compile time**, capturing `cp.context_type`,


### PR DESCRIPTION
## Why

`Factory._resolve_context_value` called `overrides_registry.fetch_override(...)` **unconditionally** for every context-backed parameter, on every resolve — the path every framework integration takes for its per-request values.

All seven compiled closures already gate the identical lookup behind `has_overrides` first, and `fetch_override` itself opens with the same emptiness check (`if not self._overrides: return types.UNSET`). So in the ordinary no-overrides case, the call cost a Python frame to learn nothing.

## Design

The same guard, in the same shape the closures use:

```python
overrides = container.overrides_registry
if overrides.has_overrides:
    override = overrides.fetch_override(provider.provider_id)
    if override is not types.UNSET:
        return override
```

Equivalent, not merely near-equivalent: `has_overrides` is written by both `OverridesRegistry.override()` and `reset_override()` and is exactly `bool(self._overrides)` at all times, so the gate can never skip a lookup that would have found something.

## Non-goals

- **Does not inline the context hop or fold the bindings at compile time.** Those are parts (ii) and (iii) of the same deferred record and remain blocked on a ruling about freezing `ContextProvider` identity.
- **Does not touch the compiled closures**, which already had this guard.

## Verification

Measured **interleaved in a single process** — alternating implementations and rebuilding the container after each swap, medians of 9 rounds at n=200k, CPython 3.14.6, Apple M4:

| path | main | this PR | delta |
|---|---|---|---|
| context kwarg, no overrides | 686.6 ns | 645.5 ns | **-41.1 (-5.98%)** |
| context kwarg, override live | 679.8 ns | 675.4 ns | -4.4 (-0.65%) |

No path regresses.

**Two measurement traps worth recording, because I fell into both before getting a trustworthy number:**

1. **Cross-run drift swamps a sub-1% effect.** Two stash-based A/B runs (measure branch, swap `modern_di/`, measure main) reported -11.8 ns and -16.5 ns and disagreed with each other, with absolute values shifting 663→690 ns between runs on unchanged code. Interleaving both implementations in one process removes that.
2. **An in-process harness can silently measure nothing.** The compiled closure captures `_resolve_context_value` as a **bound method at compile time**, so monkeypatching the class without rebuilding the container leaves *both* arms running identical code. My first interleaved attempt did exactly that and reported a meaningless -2.6 ns. The corrected harness rebuilds after each patch, and a spy confirms the patched method is actually reached.

Other gates:

- `just test-ci` — 458 passed, 100% line coverage. `just lint-ci` clean, `check-planning` and `check-links` OK.
- **Byte-identity**: all 33 compiled resolvers unchanged. The closures capture the method, so changing its body cannot alter them.

## Provenance

Part (i) of [`planning/deferred/2026-08-01-context-kwarg-inline.md`](planning/deferred/2026-08-01-context-kwarg-inline.md), recorded there as unblocked and needing no ruling. That record is updated in this PR to mark (i) shipped and to correct its frame count from five to four.

---

### Before merging

- [x] **Behaviour changed?** No. Same result for every input; byte-identical compiled resolvers. The override semantics are unchanged, which is what the equivalence argument above establishes.
- [x] **Rejected an alternative?** No new one — the deferred record already holds the reasoning for the parts not taken.
- [x] **Found real work you are not doing now?** Parts (ii) and (iii), already filed.
- [x] **New or sharpened domain term?** No.
- [x] `just lint-ci` and `just test-ci` pass.
