### PR TITLE
docs(deferred): the resolve-by-type 3.10 blocker is verified fixable

### DIFF
--- a/planning/deferred/2026-08-01-resolve-by-type-inline.md
+++ b/planning/deferred/2026-08-01-resolve-by-type-inline.md
@@ -1,5 +1,5 @@
 ---
-summary: Inlining find_provider and resolve_provider into Container.resolve is a reproduced flat ~30 ns per by-type resolve (~60 ns on 3.10), held back by a CPython 3.10 coverage-gate failure and an 8-line duplicated body that must be edited in lockstep with resolve_provider.
+summary: Inlining find_provider and resolve_provider into Container.resolve is a reproduced flat ~30 ns per by-type resolve (~60 ns on 3.10), held back solely by an 8-line duplicated body that must be edited in lockstep with resolve_provider -- the CPython 3.10 coverage-gate blocker is verified fixable in ~10 lines of test.
 ---
 
 # Inline the by-type resolve entry point
@@ -42,6 +42,17 @@ It is not shippable as submitted:
   near-limit cycle unwinds where 3.10 suspends the trace function. Worth noting
   the prototyper *did* run 3.10 — without coverage — which is exactly why it
   missed this.
+
+  **The fix is verified (2026-08-03), not just plausible.** A by-reference cycle
+  (`container.resolve_provider(provider)` on a mutual `Factory` cycle) records
+  `container.py:229` on 3.10, 5 runs out of 5. The mechanism is confirmed and
+  general: a `RecursionError` tears down the trace function, and below 3.12 —
+  where coverage traces instead of using `sys.monitoring` — anything executing
+  after the unwind in the *same* frame goes unrecorded. The same effect hit
+  `tests/providers/test_alias.py` in 3.2.0 and was fixed there by asserting
+  through `pytest.raises(match=)` so no line follows the recursion. So this
+  bullet costs roughly ten lines of test, and **the duplicated body below is the
+  only real blocker left.**
 - Two `architecture/` pages state the now-false singular and would need editing:
   `containers.md` and `validation.md` each name only `resolve_provider` as the
   path that compiles and dispatches.
@@ -58,8 +69,8 @@ this session's workflow transcript directory.
 
 ## Revisit trigger
 
-`resolve_provider`'s `RecursionError` handler gains a by-reference test so 3.10
-coverage holds, **and** a maintainer accepts the duplicated body as a standing
-maintenance cost. Alternatively, the by-type path shows up as a measurable
+A maintainer accepts the duplicated body as a standing maintenance cost — that
+is now the sole gate, since the 3.10 coverage fix is verified to work and is
+~10 lines of test. Alternatively, the by-type path shows up as a measurable
 bottleneck in a real integration profile, which would settle the trade on its
 own.


### PR DESCRIPTION
## Why

`planning/deferred/2026-08-01-resolve-by-type-inline.md` listed two blockers. One of them -- the CPython 3.10 coverage-gate failure -- was described with the right mechanism and a prescribed fix, but nobody had checked that the prescription works. Leaving that unverified means the eventual ruling has to re-derive it.

## Design

Documentation only; no code. Records the verification and narrows the revisit trigger.

The item prescribed "add a test that reaches that handler by reference rather than through `resolve()`". Tested on CPython 3.10 with coverage: a by-reference cycle (`container.resolve_provider(provider)` on a mutual `Factory` cycle) records `container.py:229`, **5 runs out of 5**. The prescription works.

The mechanism is now stated as general rather than local to this item, because it bit twice: a `RecursionError` tears down the trace function, so below 3.12 -- where coverage traces instead of using `sys.monitoring` -- anything executing after the unwind in the same frame goes unrecorded. The same effect hit `tests/providers/test_alias.py` during 3.2.0 and was fixed there by asserting through `pytest.raises(match=)` so no line follows the recursion.

Net effect: that bullet costs ~10 lines of test, and the item reduces to its one real question -- whether a duplicated 8-line body is an acceptable standing maintenance cost for ~30 ns per by-type resolve. The revisit trigger now names that as the sole gate.

## Non-goals

- **Does not implement the inline.** The remaining blocker is your judgement call, not a defect I can clear.
- **Does not add the by-reference test to the suite.** It only earns its place alongside the inline it protects; adding it now would be a test for a line already covered by other means.

## Verification

`just lint-ci`: clean, including the planning frontmatter validator and the Markdown link checker. `just index` renders the revised summary.

---

### Before merging

- [x] **Behaviour changed?** No code in this PR.
- [x] **Rejected an alternative?** None.
- [x] **Found real work you are not doing now?** Already filed -- this PR sharpens that filing.
- [x] `just lint-ci` passes; `just test-ci` unaffected (docs only).