### PR TITLE
docs(release): 3.3.0 notes

### DIFF
--- a/planning/releases/3.3.0.md
+++ b/planning/releases/3.3.0.md
@@ -1,0 +1,99 @@
+# modern-di 3.3.0 — four frames off the resolve path
+
+Every entry point into resolution got cheaper: a by-type resolve, a context-backed
+parameter, a hop through an `Alias`, and the creator call itself. No API changed.
+Two documented contracts narrowed, both stated rather than enforced — see
+**Behaviour contracts** before upgrading if you subclass `Container`.
+
+## Performance
+
+Measured on an Apple M4 / CPython 3.14.6 with the repo's A/B/A harness, each change
+against its own immediate baseline rather than cumulatively.
+
+| Path | Before | After | |
+|---|---|---|---|
+| transient resolve | 353.6 ns | **236.9 ns** | −33.0% |
+| deep chain (depth 6) | 940.6 ns | **676.7 ns** | −28.1% |
+| by-type `resolve(T)` | 193 ns | **155 ns** | −19.7% |
+| wide fan-out (10 deps) | 1661 ns | **1321 ns** | −20.5% |
+| context kwarg | ~707 ns | **~665 ns** | −6.1% |
+
+- **The positional creator call is arity-specialised.** A factory with 0 or 1
+  provider dependencies now compiles to a closure that names its argument and calls
+  the creator directly — no intermediate list, no `CALL_FUNCTION_EX` unpack, and
+  below 3.12 no comprehension frame either. Arity 2+ keeps the generic star-call.
+  The ladder stops at 1 on evidence: a 0–3 version was built and measured first and
+  bought nothing beyond arity 1, because leaves are arity 0 and chain nodes are
+  arity 1. Wide graphs improve anyway — their leaves take the ladder even when the
+  root does not.
+
+- **`Container.resolve(SomeType)` no longer delegates to `resolve_provider`.** It
+  carries its own copy of that body, so the by-type path — what every `@inject`
+  marker and framework integration uses — pays one frame fewer.
+
+- **A context-backed parameter costs three Python frames instead of five.** The
+  binding (`provider_id`, scope, `context_type`, absent-disposition) is folded into
+  the compiled closure, and the scope hop is an int compare when the resolving
+  container is already at the provider's scope. The *value* is still read live on
+  every resolve; only the binding is fixed.
+
+- **An `Alias` hop costs one Python frame instead of four** (3.2.0 shipped this;
+  it now has a guard scenario, G18, at ~225 ns against G2's ~155 ns).
+
+## Behaviour contracts
+
+Neither is enforced in code. Both are stated so that a future optimisation is a
+performance change rather than a breaking one.
+
+- **`resolve_provider` is not an interception seam.** A `Container` subclass that
+  overrides it is no longer consulted for by-type resolves. In practice this
+  narrows nothing that worked: since the compiled resolvers landed in 2.29.0 an
+  override has only ever seen *top-level* calls — measured at 1 call while
+  resolving a 4-node chain — because resolvers call each other directly. An audit
+  of all 13 sibling integration wheels found zero `Container` subclasses and zero
+  overrides. Full reasoning in
+  [`planning/decisions/2026-08-03-resolve-provider-not-a-seam.md`](../decisions/2026-08-03-resolve-provider-not-a-seam.md).
+  `find_container` is unaffected and remains a blessed extension point.
+
+- **A `ContextProvider`'s identity is fixed once something resolves through it.**
+  Its `scope` and `context_type` are read when a consumer's resolver compiles and
+  folded into that closure. `ProviderScopeFrozenError` enforces the scope half for
+  *registered* providers only; `context_type` is contract-only, as is `scope` for a
+  provider passed solely via `Factory(kwargs={...})`. Rebinding either on a provider
+  already in use is unsupported — construct a second provider instead.
+
+- **An exception raised through `resolve()` carries one traceback frame fewer**
+  (`resolve_provider` no longer appears).
+
+## What did not change
+
+Resolution stays sync-only. Overrides, caching, scope transparency, validation, and
+every error type and breadcrumb are untouched — the compiled closures were verified
+byte-identical against the paths they replaced across 110 differential cases (22
+creator kinds × 5 scenarios × 2 interpreters). Teardown order of transient
+dependencies is unchanged on every supported interpreter, verified main-vs-release
+at arities 1–3 on 3.10 and 3.14.
+
+## Internals
+
+- 502 tests, 100% line coverage, Python 3.10–3.14 including free-threaded 3.14t;
+  `ruff`, `ty` clean.
+- **The guard tier is pinned.** The 11 scenarios under ~2 µs now run at fixed
+  `rounds × iterations`, so their medians no longer sit on the platform timer's
+  ~41 ns grid (which was 23% of the smallest scenario). The CI alert threshold drops
+  150% → 120%, and the stored baseline was reset because the reported statistic
+  changed to a median of per-round means. Expect one-off apparent gains across that
+  boundary: the by-type scenario moved 250 → 168 ns purely by coming off the grid,
+  before any of this release's work.
+- Two guard scenarios added: **G8b**, a `cache=True` sibling of G8 that gives the
+  cached cold-miss builders their own signal (28.0 µs against G8's 21.9 µs), and
+  **G18** for the alias hop.
+- `docs/introduction/performance.md`'s comparative table still reports 3.2.0 and
+  predates this release's work.
+
+## Downstream
+
+**No action needed.** No API changed, and integrations pick the improvements up on
+upgrade. The two contracts above are worth a glance only if you subclass `Container`
+or mutate a provider after registering it — neither is a pattern any sibling
+integration uses.


### PR DESCRIPTION
Release notes for 3.3.0, to land before the tag.

## Why

Seven commits since `3.2.0`, including four measured resolve-path wins. The library on PyPI is meaningfully slower than `main`.

## Design

Notes only -- `planning/releases/3.3.0.md`, used verbatim as the GitHub Release body. Minor rather than patch because two documented contracts narrow: `resolve_provider` is not an interception seam, and a `ContextProvider` identity is fixed once something resolves through it. Neither is enforced in code; both are stated so a future optimisation is a performance change rather than a breaking one.

Every figure is quoted from the measurement recorded in its originating PR, each against its own immediate baseline rather than compounded. The guard-tier numbers were re-taken on this checkout.

## Non-goals

Does not regenerate `docs/introduction/performance.md`, which still reports 3.2.0 and predates this work -- that table is generated by `just bench-report` with the rival deps installed and is its own PR. The notes say so under Internals rather than leaving it silent.

## Verification

`just test-ci`: 502 passed, 100%% coverage on 3.14 and 3.10. `just lint-ci`: clean, including the planning validator and link checker. Guard tier: 25 scenarios pass.

---

### Before merging

- [x] **Behaviour changed?** No code in this PR.
- [x] **Rejected an alternative?** None.
- [x] **Found real work you are not doing now?** The stale comparative table, stated under Non-goals and in the notes.
- [x] `just lint-ci` and `just test-ci` pass.