### PR TITLE
chore(lint): drop the empty __slots__ DependencyPathMixin was lying about

### DIFF
--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -102,13 +102,7 @@ class DependencyPathMixin:
     chain of provider names as it propagates back up to the caller. With an empty `dependency_path`
     (the error never passed through a resolution frame) `_render_body` returns the base message
     unchanged.
-
-    Empty `__slots__`: each concrete error declares the `_base_message`/`dependency_path` slots
-    itself, avoiding the `TypeError: multiple bases have instance lay-out conflict` that a slotted
-    mixin combined with an `Exception` subclass would otherwise raise.
     """
-
-    __slots__ = ()
 
     def __init__(self, message: str) -> None:
         self._base_message = message


### PR DESCRIPTION
## Why

`ty` 0.0.74 (2026-08-22) began enforcing `__slots__`, and `just lint-ci` now fails with
seven `unresolved-attribute` diagnostics in `modern_di/exceptions.py`. Bisected:

| version | result |
|---|---|
| `uvx ty@0.0.71 check` | clean |
| `uvx ty@0.0.73 check` | clean |
| `uvx ty@0.0.74 check` | 7 diagnostics |

`DependencyPathMixin` declared `__slots__ = ()` on a class whose only base is `object`,
then set `_base_message` and `dependency_path` in its own `__init__` and `args` in
`prepend_step`. The diagnostic is right, not a false positive on a legitimate mixin
pattern: `DependencyPathMixin("boom")` raises `AttributeError` today. The empty
`__slots__` asserted the class had no instance attributes while its constructor set two.

This is not confined to the Monday canary. `ci.yml` and `scheduled.yml` both call
`_checks.yml`, which runs `just install` → `uv lock --upgrade`, and `uv.lock` is
gitignored — so every lane resolves the newest `ty`. The next PR pushed to this repo goes
red on `just install lint-ci` regardless of its diff. `main` only looks green because its
last run (2026-08-22 09:30) predates the 0.0.74 release by six hours.

## Design

Delete the line. The classes that mix the breadcrumb machinery in already declare both
slots — `ResolutionError` carries `('_base_message', 'dependency_path')` for the
resolution branch, and `ScopeNotInitializedError` / `ScopeSkippedError` declare them
individually for the container branch — so nothing downstream needs to change.

The slots discipline survives: after `__init__`, a mixin user's `__dict__` is still `{}`,
so both attributes land in the inherited slot descriptors rather than a per-instance dict.
`BaseException` supplies a `__dict__` unconditionally, so these instances already had one
before this change; the empty `__slots__` was never what kept it away. Measured cost is 16
bytes per instance on the nine mixin users (e.g. `ScopeNotInitializedError` 120 → 136),
paid only on the error path.

The `Empty __slots__:` docstring paragraph goes with the line it explained. Its claim that
"each concrete error declares the `_base_message`/`dependency_path` slots itself" was also
only true for the two scope errors.

Rejected, with the reason each died:

- **Six inline `# ty: ignore[unresolved-attribute]`.** Silences a checker that is telling
  the truth. 7aed548 set the standard here — "Ruff goes quiet because the code got more
  precise, not because it was silenced."
- **A file-wide `[[tool.ty.overrides]]` for `exceptions.py`.** Same objection, and it would
  hide a genuine typo across 500 lines that are almost entirely attribute assignment.
- **Give the mixin real slots** (`__slots__ = ("_base_message", "dependency_path")`).
  Raises `TypeError: multiple bases have instance lay-out conflict` at import — 23
  collection errors. `ty` 0.0.74 diagnoses this too, as `instance-layout-conflict`.
- **Make the mixin subclass `ModernDIError`.** Types clean and passes `ty`, but breaks
  `test_dependency_path_mixin_is_not_an_exception` (the mixin must never be
  except-catchable on its own) and the `docs_slug` census, which would then demand a
  troubleshooting page for it.
- **Pin `ty<0.0.74`.** Freezes the type checker to preserve a class that was wrong, and
  leaves the canary red every Monday.

## Non-goals

- **No guard test.** `ty` runs on every PR and CI resolves it fresh; that is the gate.
  The consequence is accepted knowingly: `DependencyPathMixin` becomes the only class in
  `exceptions.py` without `__slots__`, and a contributor tidying the file may well add the
  line back. Only `ty` will catch it.
- **No `planning/decisions/` entry.** The rejected alternatives above are contingent on one
  tool release, not a standing architectural fork; entries there ("no generator creators",
  "alias binds nothing") outlive any dependency version.
- **No release note.** No behavior, API, or downstream integration is affected.
- **No upstream `ty` report.** The diagnostic is correct — the code was wrong.
- **No change to `uv lock --upgrade` in `just install`.** Every lane resolving the newest
  dependency set is intentional, and the canary/PR-lane overlap that follows from it is a
  separate question from this fix.

## Verification

`just install` first, so the local toolchain matches CI (`ty` 0.0.70 → 0.0.74, `ruff`
0.16.2 → 0.16.4).

- `just lint-ci` — passes: `eof-fixer --check`, `ruff format --check` (133 files),
  `ruff check --no-fix`, `ty check`, `planning/index.py --check`, `planning/links.py`.
- `uv run ty check --python-version 3.10` — passes, matching CI's lint interpreter
  (locally run on 3.14.7).
- `just test-ci` — 514 passed, 100.00% line coverage over 6077 statements.
- Instance size, `sys.getsizeof` on all nine mixin users: +16 bytes each. `__dict__` is
  `{}` after `__init__` both before and after this change.

No tests added or changed: no behavior changed, and the existing suite passes untouched.

Closes #427
