### PR TITLE
docs(agents): scaffold agent-skill conventions and move the glossary to CONTEXT.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,19 +108,23 @@ local deviation from `planning-convention` 2.2.0.
 
 ## Vocabulary
 
-A term is listed only when there is a synonym to reject, or a meaning subtle enough that code and
-docs must agree on it.
+The domain glossary lives in [`CONTEXT.md`](CONTEXT.md) at the repo root: every term, the synonyms it
+rejects, and the rule deciding what is admitted. Read it before naming a concept in code, a test
+name, or an issue title.
 
-- **Container** — owns the registries and resolves within a scope. *Avoid:* injector.
-- **Provider** — a declaration of *how to produce* a dependency; the recipe, not the value. *Avoid:* service,
-  dependency.
-- **Scope** — one band in the container hierarchy. *Avoid:* lifetime, layer.
-- **Group** — a non-instantiable namespace class declaring providers. *Avoid:* module.
-- **Resolution** — producing a value from its provider. *Avoid:* injection (reserve that for passing a resolved
-  value into a handler).
-- **Override** — a test-time replacement of a resolved value. *Avoid:* mock, patch (an override supplies a
-  concrete value; it does not wrap or spy).
-- **Bound type** — the type a provider is registered under. *Avoid:* registered type, return type.
-- **Wiring plan** — the partition of a creator's parameters by how each is satisfied. *Avoid:* compiled kwargs.
-- **Finalizer** — a cleanup callback on a cached provider, run LIFO at close. *Avoid:* teardown, destructor.
-- **Connection** — the framework object a unit of work carries. *Avoid:* request (too HTTP-specific).
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `modern-python/modern-di`, driven through the `gh` CLI; rejected enhancements are
+recorded in `docs/adr/`. See [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+The five canonical triage roles, each label string equal to its role name. See
+[`docs/agents/triage-labels.md`](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context: one root `CONTEXT.md` plus `docs/adr/`. See
+[`docs/agents/domain.md`](docs/agents/domain.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,52 @@
+# modern-di
+
+A zero-dependency Python dependency-injection framework: it wires object graphs
+from type annotations, manages lifetimes through a hierarchy of scopes, and runs
+sync or async finalizers at close.
+
+## Language
+
+A term is listed only when there is a synonym to reject, or a meaning subtle enough that code and
+docs must agree on it. General programming vocabulary does not belong here, however heavily this
+project uses it.
+
+**Container**:
+Owns the registries and resolves within a scope.
+_Avoid_: injector
+
+**Provider**:
+A declaration of *how to produce* a dependency; the recipe, not the value.
+_Avoid_: service, dependency
+
+**Scope**:
+One band in the container hierarchy.
+_Avoid_: lifetime, layer
+
+**Group**:
+A non-instantiable namespace class declaring providers.
+_Avoid_: module
+
+**Resolution**:
+Producing a value from its provider.
+_Avoid_: injection (reserve that for passing a resolved value into a handler)
+
+**Override**:
+A test-time replacement of a resolved value. An override supplies a concrete value; it does not
+wrap or spy.
+_Avoid_: mock, patch
+
+**Bound type**:
+The type a provider is registered under.
+_Avoid_: registered type, return type
+
+**Wiring plan**:
+The partition of a creator's parameters by how each is satisfied.
+_Avoid_: compiled kwargs
+
+**Finalizer**:
+A cleanup callback on a cached provider, run LIFO at close.
+_Avoid_: teardown, destructor
+
+**Connection**:
+The framework object a unit of work carries.
+_Avoid_: request (too HTTP-specific)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,55 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the
+codebase. This repo is **single-context**.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root: the domain glossary.
+- **`docs/adr/`**: read the decision records that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest
+creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions
+actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-….md
+│   └── 0002-….md
+├── modern_di/
+└── tests/
+```
+
+There is no `CONTEXT-MAP.md` and no per-package `CONTEXT.md`: one package, one context.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test
+name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly
+avoids: write `Container` and not `injector`, `Provider` and not `service`, `Resolution` and not
+`injection`.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language
+the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Link style inside `docs/`
+
+`docs/` is the MkDocs `docs_dir`, and the same files are read on GitHub. Two rules keep a link
+working in both renderings:
+
+- **Between files inside `docs/`, use a plain relative `.md` link.** MkDocs rewrites it to a site
+  URL and GitHub follows it as a file. From one ADR to another, that is `[ADR-NNNN](NNNN-slug.md)`.
+- **Never link from a file inside `docs/` to a path outside it.** It cannot resolve in both
+  renderings: MkDocs emits `links.not_found` and ships the link verbatim, so it 404s on the site.
+  Cite `modern_di/...`, `tests/...`, and root files as inline code, never as links.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing decision record, surface it explicitly rather than silently
+overriding:
+
+> _Contradicts ADR-NNNN (its title), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,55 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues on `modern-python/modern-di`. Use the `gh` CLI
+for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Rejected work: read and write `docs/adr/`, not `.out-of-scope/`
+
+Where a skill says `.out-of-scope/`, this repo means `docs/adr/`. A rejected enhancement is recorded
+there as a decision record, and the prior-rejection check during triage reads that directory. Do not
+create `.out-of-scope/`: this repo keeps one home for a rejected alternative, and a second one would
+split the corpus that the check depends on.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+
+The `wayfinder:*` labels do not exist in this repo yet. Create them the first time `/wayfinder` runs.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,20 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual
+label strings used in this repo's issue tracker. All five exist on `modern-python/modern-di`.
+
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label
+string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+The repo's `bug`, `enhancement`, and `documentation` labels are a separate *kind* vocabulary. They do
+not overlap these *state* labels, and triage leaves them alone unless it is setting the category role.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,10 @@ theme:
         icon: material/brightness-4
         name: Switch to system preference
 
+# docs/agents/ is agent configuration, not user documentation.
+exclude_docs: |
+  /agents/
+
 validation:
   omitted_files: warn
   absolute_links: warn


### PR DESCRIPTION
Closes #429.

## Why

The engineering skills (`/triage`, `/to-tickets`, `/to-spec`, `/domain-modeling`,
`/wayfinder`) each expect a small set of per-repo configuration files naming the issue
tracker, the triage label strings, and where the glossary and decision records live. None
of it exists here, so every invocation either guesses or stops to ask.

The glossary is the sharper case: it already exists, in the shape the skills want (term,
one-line definition, synonyms to reject), but it sits in `CLAUDE.md ## Vocabulary` — a file
the skills do not read. The vocabulary is written down and still not reachable by the tools
meant to enforce it.

This is the first of three PRs (#429 → #430 → #431). It is additive and mechanical.

## Design

Three configuration files under `docs/agents/`, the skills' native path, seeded from the
setup skill's templates and edited down to this repo:

- `issue-tracker.md` — GitHub Issues on `modern-python/modern-di` via `gh`. PRs are not a
  request surface; the flag stays `no`.
- `triage-labels.md` — the five canonical roles, each label string equal to its role name.
  All five already exist on the repo. The pre-existing `bug`/`enhancement`/`documentation`
  labels are a *kind* vocabulary and are untouched; they do not overlap the *state* vocabulary.
- `domain.md` — the seed template reduced to the single-context tree, plus the ADR link rules.

`.claude/` was rejected as the home: it is gitignored, so nothing there would be committed,
and `.claude/agents/` is reserved by Claude Code for subagent definitions.

`docs/` is `docs_dir` and every Markdown file under it is currently in `nav`, so three new
pages would trip `omitted_files: warn`. `mkdocs.yml` gains `exclude_docs: |` with `/agents/`.
Excluded files are, per MkDocs' release notes, "as good as nonexistent" during a build — not
copied to `site/`, so they cannot warn. `not_in_nav` was rejected here because it still
builds and publishes the page, and agent configuration is not user documentation.

The glossary moves to a root `CONTEXT.md` in the native CONTEXT format: context name,
description, then `## Language` with `**Term**:` / definition / `_Avoid_:`. All ten terms
carry over unchanged in meaning — Container, Provider, Scope, Group, Resolution, Override,
Bound type, Wiring plan, Finalizer, Connection — and the admission rule ("listed only when
there is a synonym to reject") travels with them, so the glossary does not grow into a
dictionary of general programming terms. `CLAUDE.md` keeps a one-line pointer where the
section was, and gains an `## Agent skills` block pointing at all three config files.

**One deliberate forward reference.** `/triage` writes rejected enhancements to
`.out-of-scope/` and reads it back to detect re-proposals. This repo's home for that becomes
`docs/adr/`, which #430 creates. `issue-tracker.md` states the mapping now rather than later:
left unstated, `/triage` would create a fourth decision home behind our backs. The cost is
that between this PR and #430, that mapping names a directory that does not exist yet and
`CLAUDE.md` describes two decision homes — the Workflow section still says
`planning/decisions/`. Both reviews flagged it; it is a consequence of the PR ordering, not
of the prose, and #430 is already `blocked-by` this one. Merging #430 promptly closes it.

## Non-goals

- Creating `docs/adr/` or moving any decision record — #430.
- Migrating deferred items to issues, and deleting `planning/index.py` — #430/#431.
- Any change to the `modern-python/.github` org repo. A `deferred.yml` issue template was
  rejected: issue forms only fire in the web UI and `gh issue create` bypasses them, and a
  repo-local `ISSUE_TEMPLATE/` would suppress the org's `bug_report.yml`,
  `feature_request.yml`, and `config.yml` entirely — GitHub's precedence for issue templates
  is per-directory, not per-file.
- A `deferred` label. That concept is being retired, not carried forward.
- `wayfinder:*` labels. Created if and when `/wayfinder` is first used.

## Verification

No new test seams: this is Markdown plus one MkDocs config key, and the behaviour worth
verifying is already gated. A test asserting that `CONTEXT.md` contains a particular sentence
would test the diff, not the system.

- `just lint-ci` — passes. The relevant check is `planning/links.py`, which walks every `*.md`
  in the repo and validates relative links and heading anchors under GitHub's slug algorithm;
  the new files fall under it automatically. Confirmed no remaining reference anywhere to the
  old `CLAUDE.md#vocabulary` anchor.
- `just docs-build` (`mkdocs build --strict`) — passes with zero warnings, and `site/agents/`
  is absent from the build output.
- `just test-ci` — 514 passed, 100.00% line coverage. No Python changed.
- Term-set diff between `main:CLAUDE.md ## Vocabulary` and `CONTEXT.md`: identical, same order.
- `gh label list` confirms all five triage labels exist before any skill tries to apply one.

Reviewed on both axes (`/code-review`). Four findings fixed: a two-line rationale comment in
`mkdocs.yml` cut to one; the admission rule de-duplicated to `CONTEXT.md` alone; and two
invented ADR references in `domain.md` (`0004-scope-enum.md`, `ADR-0007`) replaced with
`NNNN-slug.md` placeholders so they cannot read as real records.

---

### Before merging

- [x] **Behaviour changed?** No — documentation and one build-config key. Nothing to pin.
- [x] **Adding a fact anywhere?** Ran the admission check. The glossary moved rather than grew;
      the `docs/agents/` files are agent configuration, which is why they are excluded from the
      published site.
- [x] **Rejected an alternative?** The three that would be re-litigated (`.claude/` as the config
      home, `not_in_nav` over `exclude_docs`, a repo-local issue template) are recorded above. The
      decision corpus itself is being migrated in #430; filing new records into
      `planning/decisions/` now would add to the corpus that PR has to move.
- [x] **Found real work you are not doing now?** It is already filed — as #430 and #431.
- [x] `just lint-ci` and `just test-ci` pass.

https://claude.ai/code/session_01FBic7HFGR6sdRfSW3cGEv2
