### PR TITLE
docs: cut duplicated comparative figures from ROADMAP and repoint the SLF001 note

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,34 +44,16 @@ Strawberry, Quart, RQ, APScheduler, Jobify, Flet, ag2.
 - **Dependency-graph export** (Mermaid / Graphviz) for debugging and docs.
 
 ### Trust & observability
-- **Public, reproducible benchmark suite** with neutral methodology —
-  shipped; see [Performance](https://modern-di.modern-python.org/introduction/performance/).
 - **Optional OpenTelemetry instrumentation** of resolution and finalization.
-- **Trim the warm-singleton path (C2)** — the published scenario where modern-di
-  trails by the widest margin, now 2.94x dependency-injector and 2.13x
-  that-depends. Two Python method calls that were pure indirection on a warm hit
-  — `ProvidersRegistry.resolver_for` on every top-level resolve and
-  `CacheRegistry.fetch_cache_item` inside the compiled resolver — are inlined on
-  their dict-lookup hit paths, with the method called only on a miss, keeping the
-  cycle-safe compilation thunk and the shared-item guarantee intact;
-  **shipped in 3.1.2**. The guard tier measured a ~25% faster warm hit
-  (170 → 128 ns), and the published cell moved from 3.88x to 2.94x against
-  dependency-injector and 2.80x to 2.13x against that-depends, with both rivals'
-  absolutes unchanged — the check that the movement is modern-di's and not
-  measurement drift. The bound stated when this was planned held: it trimmed the
-  cell, it did not close it. dependency-injector's ~48 ns is a C-level slot read
-  on a Cython core, which pure Python does not reach.
-  A third step remains open and is tracked in
-  [issue #434](https://github.com/modern-python/modern-di/issues/434): an
-  APP-scoped resolver could close over its `CacheItem` and reach ~16 ns, but the
-  target is only invariant because one registry belongs to one root, so the
-  registry would have to reference its root — the container reference cycle
-  removed in 3.1.1. That needs a weakref and a proof, for ~30 ns.
+- **Warm-singleton resolve headroom (C2)** — the scenario where modern-di trails
+  the slot-memoized frameworks on by-reference resolution. One direction remains
+  open and is gated on a reported bottleneck:
+  [issue #434](https://github.com/modern-python/modern-di/issues/434). For where
+  the cell actually stands, read
+  [Performance](https://modern-di.modern-python.org/introduction/performance/),
+  the only place these figures live.
 
 ### Docs & ecosystem
-- **Canonical on-ramp per integration** — every official integration ships a
-  runnable `examples/` app plus a normalized README `Usage example:` link, so a
-  newcomer can adopt it in one sitting; **shipped**.
 - More recipes; comparison and migration guides.
 
 ## Explicitly not planned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,9 @@ isort.no-lines-before = ["standard-library", "local-folder"]
 [tool.ruff.lint.per-file-ignores]
 # The single resolve path compiles closures over provider internals: reading `Factory._creator`
 # and friends is the design, not an incident, and every compiled resolver returns `typing.Any`.
-# Suppressed per-file rather than on 31 individual lines. Growing this coupling is the revisit
-# trigger on https://github.com/modern-python/modern-di/issues/436.
+# Suppressed per-file rather than line by line. Handing the compiler a compile-spec instead was
+# declined in docs/adr/0014-per-provider-compile-seam-declined.md; its revisit trigger is a second
+# consumer of these privates, not a count of them.
 "modern_di/resolver_compiler.py" = ["SLF001", "ANN401"]
 # White-box tests assert on container and registry internals; that is what they are for.
 "tests/**" = ["SLF001"]


### PR DESCRIPTION
## Why

The comparative benchmark ratios have exactly one home — `docs/introduction/performance.md`. `just bench-report` prints markdown to stdout and writes no file, and `benchmarks/README.md` sets the policy that generated result files are never committed. Every other copy is a hand-maintained snapshot with no mechanism keeping it honest.

Four copies existed. `ROADMAP.md` froze at the 3.1.2 measurement and drifted into asserting figures that are now wrong, in the present tense, in a root-level file making named claims about competitors:

| Claim | `ROADMAP.md` | `performance.md` (3.3.0) |
|---|---|---|
| C2 vs dependency-injector | "**now** 2.94x" | **2.64** |
| C2 vs that-depends | "**now** 2.13x" | **1.90** |

Issue #434 carried two more (`~1.06x` against dishka, a `~48 ns` rival absolute) plus a back-reference asserting that `ROADMAP.md` also records the open direction — the pointer half of a two-homes-for-one-fact loop, where each side named the other.

Separately, `pyproject.toml`'s `SLF001` per-file-ignore note pointed at issue #436 as its revisit trigger. That issue is now closed as already decided by [ADR 0014](docs/adr/0014-per-provider-compile-seam-declined.md), which names the compile-spec variant specifically. The note also carried a "31 individual lines" count that agreed with nothing: ADR 0014 says ~16, issue #436 said 22, the code has 32 across 14 distinct attribute names — and the issue's framing was wrong in kind too, describing them as *provider* internals when the largest single reach is `container._prepare` (9 of 32), which no compile-spec on a provider class would remove.

## Design

`ROADMAP.md` keeps its curated narrative — it is written for a reader evaluating the library, not a contributor picking up work — but stops restating what other files own. The warm-singleton entry becomes a pointer: what is still open, a link to #434, and a link to the Performance page for the figures. No ratio or absolute survives anywhere in the file.

The three `shipped` markers leave `## Under consideration`, which is either a list of open direction or it is mislabelled. They are **removed rather than relocated**: completed work is already owned by `docs/changelog.md` and `planning/releases/`, so a "Shipped" section here would recreate the exact duplication this PR removes. The integrations `Already shipped:` inventory stays — it is the context establishing what the remaining gap is, not a roadmap entry.

The `SLF001` note points at ADR 0014 and drops the count entirely. ADR 0014's revisit trigger is structural — a second consumer of provider compile-time privates, or an open provider-type set — so a number was never what it turned on, and maintaining a fifth copy of a figure that has already drifted four times is the failure mode this PR is about.

#434's body loses its two comparative snapshots and the `ROADMAP.md` back-reference. Its existing "read `performance.md`, not a snapshot here" disclaimer stays and is now true of the whole issue.

## Non-goals

- **No staleness check.** Declined at triage on #437 — not in `lint-ci`/`_checks.yml` (they gate every PR, and the window between a tag and the republish legitimately exists for days), not in `scheduled.yml`, not in `release.yml`. That decision is recorded on #437, not here, and this PR does not revisit it.
- **The page's own currency disclosure is #437**, still open. `performance.md` continues to imply its numbers are current; this PR only removes the copies of them.
- **No re-measurement.** No benchmark was run and no published figure changes. The mechanism claims that survive (dependency-injector's C-level slot read on a Cython core, that-depends' lock-free slot) are durable; the numbers attached to them were not.
- **No new ADR.** Nothing is rejected here that is not already written down — ADR 0014 covers the compile-spec, ADRs 0015 and 0017 cover the warm-singleton levers.
- **`## Guiding principles`, `## Explicitly not planned`, and `## Feedback & contributions` are untouched.** None duplicated anything.

## Verification

Docs and one comment only; no runtime code changed, so no test was added.

- `just lint-ci` — passes (`eof-fixer`, `ruff format --check`, `ruff check --no-fix`, `ty check`, and the repo-wide link check). The link check is the gate that matters here: `ROADMAP.md` sits outside `docs_dir`, so `mkdocs --strict` never sees it, and both new links in it are relative-checked by `planning/links.py`.
- `just test-ci` — 512 passed, 100.00% line coverage (6030/6030), the enforced gate.
- `grep -nE '[0-9]+(\.[0-9]+)?x[[:space:]]|[0-9]+ ns|[0-9]+%' ROADMAP.md` — no matches.
- `grep -n shipped ROADMAP.md` — one match, the integrations inventory.
- `ruff check` still clean on `modern_di/resolver_compiler.py`, confirming the per-file ignore is unchanged in effect; only its comment moved.

## Issue linkage

Deliberately no closing keyword. This PR removes `ROADMAP.md`'s copies of the comparative ratios and its restatement of #434; neither issue is fully discharged by that on its own, and the boundary between them is still being drawn:

- **#437** owns the Performance page itself, which this PR does not touch. That page still presents its numbers as current when they are a snapshot of one release.
- **#438** owns the ROADMAP-to-issue-queue duplication. Whether the stale-figures half of this change belongs to it or to #437 is a scope call to make on the issues, not by an auto-close on merge.

Close by hand after merge, once that call is made.

https://claude.ai/code/session_01FBic7HFGR6sdRfSW3cGEv2
