### PR TITLE
docs(release): note the DependencyPathMixin __slots__ removal in 3.4.0

### DIFF
--- a/planning/releases/3.4.0.md
+++ b/planning/releases/3.4.0.md
@@ -26,6 +26,12 @@ internals or assign to `provider.scope`. Resolving a `ContextProvider` directly 
   `GroupScopeConflictError` and `ProviderScopeFrozenError` fire on exactly the same
   inputs as before.
 
+- **`DependencyPathMixin` drops its empty `__slots__`.** The line asserted the class had
+  no instance attributes while its own `__init__` set two, which `ty` 0.0.74 began
+  reporting. Removing it lets the mixing-in classes' declarations stand on their own and
+  leaves `__dict__` empty after `__init__`, at the cost of 16 bytes per instance on the
+  nine mixin users, on the error path only. No behavior change.
+
 ## Performance
 
 Measured on an Apple M2 / CPython 3.14.7, `min` of 11 timing repeats, averaged across


### PR DESCRIPTION
The 3.4.0 notes were written at #426. `cec6f48` (#428) landed in `modern_di/`
afterwards with no entry under **Internal refactors**, which claims to cover the
release. Invisible to users, but 3.4.0 is the last curated release body this
project ships, so it should be complete.

https://claude.ai/code/session_01FdBFyAZ6nntxXwPjy6Xm7p