### PR TITLE
chore: rename CLAUDE.md to AGENTS.md and Justfile to justfile

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,7 @@ effect. State the numbers, not "benchmarked".
 - [ ] **Behaviour changed?** If a wrong change here could pass silently, pin it with
       a test whose name is the claim and whose docstring opens `INVARIANT:` and says
       what breaks it. Do **not** write prose about mechanism — there is no page for
-      it. See the "Where a fact goes" section of [`CLAUDE.md`](../CLAUDE.md).
+      it. See the "Where a fact goes" section of [`AGENTS.md`](../AGENTS.md).
 - [ ] **Adding a fact anywhere?** Run the admission check: derivable from
       `modern_di/` → don't write it; enforceable → a test; a user needs it →
       `docs/`; otherwise it does not get written.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -11,7 +11,7 @@ repository** and ships as a separate PyPI package, `modern-di-pytest` included.
 
 ## Commands
 
-`just` (task runner) and `uv` (package manager). The [`Justfile`](justfile) is the source of truth —
+`just` (task runner) and `uv` (package manager). The [`justfile`](justfile) is the source of truth —
 `just --list`, or read it; every recipe carries its intent as a comment. The one thing it does not
 say: nothing validates Markdown links outside `docs/`. `just docs-build` runs `mkdocs --strict` over
 the site only, and root Markdown, `.github/`, and `docs/agents/` are unchecked.

--- a/docs/adr/0011-fold-context-registry-declined.md
+++ b/docs/adr/0011-fold-context-registry-declined.md
@@ -8,7 +8,7 @@ It is the shallowest of the four registries — ~18 lines, a `dict[type, Any]` b
 and `set_context` — and the deletion test on the *code* passes: fold it, and `Container` gains a
 `self._context` dict plus a `find_context` method for the two touch points. What the deletion test
 misses is that the conceptual slot does not vanish. The four registries are organised by a real
-axis, stated in `CLAUDE.md`'s registries entry: shared tree-wide (`providers_registry`,
+axis, stated in `AGENTS.md`'s registries entry: shared tree-wide (`providers_registry`,
 `overrides_registry`) versus per-container (`cache_registry`, `context_registry`). `ContextRegistry`
 sits symmetric with `CacheRegistry`; its shallowness in line count reflects having less mechanism,
 not a broken abstraction. Folding trades a uniform 2×2 model for ~18 fewer lines and grows the

--- a/docs/integrations/writing-integrations.md
+++ b/docs/integrations/writing-integrations.md
@@ -400,7 +400,7 @@ Each official integration is its own repository and PyPI package, mirroring the
   genuinely unreachable boot line (`if __name__ == "__main__"` / server-run).
   Link it from the README with a `Usage example: [examples/](./examples)` line
   directly under `Full guide:`.
-- **Mirror `modern-di`'s** `CLAUDE.md` and `Justfile`. Keep behavioural invariants
+- **Mirror `modern-di`'s** `AGENTS.md` and `justfile`. Keep behavioural invariants
   in named tests rather than in a prose truth home, and record rejected
   alternatives as ADRs under `docs/adr/`. Keep resolution sync-only and add no
   runtime dependency beyond the framework and `modern-di`. `ruff` is unpinned and
@@ -465,4 +465,4 @@ Each official integration is its own repository and PyPI package, mirroring the
 - [ ] `examples/app.py` (+ smoke test asserting real injected output, 100%
       coverage, no `omit`) and a README `Usage example: [examples/](./examples)`
       line.
-- [ ] `CLAUDE.md` and `Justfile` mirrored; invariants pinned by named tests.
+- [ ] `AGENTS.md` and `justfile` mirrored; invariants pinned by named tests.


### PR DESCRIPTION
## Summary

Renames the agent-instructions file to the cross-agent name, and the justfile to lowercase.

`AGENTS.md` is the filename other coding agents look for; until now these instructions were
visible only to Claude Code. Claude Code discovers `AGENTS.md` natively (verified against
2.1.261), so this is a plain rename — **no `CLAUDE.md` symlink or stub**, which also avoids
the Windows `core.symlinks` caveat and the risk of a tool replacing the file and silently
breaking the link.

The `Justfile` → `justfile` rename brings this repo in line with `modern-di`,
`faststream-outbox`, `chat-app` and `compose2pod`, which already use the lowercase name.
`just` resolves either casing, so nothing changes operationally.

Part of modern-python/.github#51.

## Changes

- `git mv CLAUDE.md AGENTS.md` — recorded as a rename, so `git log --follow` keeps the history.
- `git mv Justfile justfile` — likewise.
- Updated **live** references to both names.

## Historical records deliberately untouched

References inside `planning/changes/`, `planning/releases/`, `planning/retros/` and
`planning/audits/` are **not** rewritten. Those files narrate what was done at the time,
when the files genuinely were called `CLAUDE.md` and `Justfile`; rewriting them would
falsify the record. Live pointers — the instructions file itself, `README`, `.github/`,
`docs/` (including ADRs), `architecture/`, `planning/deferred.md`, `planning/decisions/`,
source and tests — are updated.
