### PR TITLE
fix(agents): external-PR filter used a gh field that does not exist

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -21,7 +21,12 @@ Infer the repo from `git remote -v`; `gh` does this automatically when run insid
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **List external PRs for triage**: `gh pr list --json` has no `authorAssociation` field, so the association has to come from the REST API, where it is `author_association` (snake_case):
+  ```
+  gh api "repos/{owner}/{repo}/pulls?state=open&per_page=100" \
+    --jq '.[] | select(.author_association | IN("CONTRIBUTOR","FIRST_TIME_CONTRIBUTOR","NONE")) | {number, title, author: .user.login}'
+  ```
+  That keeps only external authors; `OWNER`, `MEMBER` and `COLLABORATOR` are dropped. `gh api` substitutes `{owner}`/`{repo}` from the current clone.
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.


### PR DESCRIPTION
## Summary

`docs/agents/issue-tracker.md` documented the external-PR triage filter as a `gh pr list --json`
call including `authorAssociation`. That field does not exist on `gh pr list` (or `gh pr view`) —
`gh` 2.98.0 rejects it outright:

```
Unknown JSON field: "authorAssociation"
```

So the documented command fails rather than returning a filtered list. It came in with the stock
setup template and is latent today, since this repo has **PRs as a request surface: no** — but it
would fail the moment anyone flipped that flag.

## Changes

Replaced the line with a REST-API call, where the field exists as `author_association` (snake_case):

```
gh api "repos/{owner}/{repo}/pulls?state=open&per_page=100" \
  --jq '.[] | select(.author_association | IN("CONTRIBUTOR","FIRST_TIME_CONTRIBUTOR","NONE")) | {number, title, author: .user.login}'
```

## Verification

Run against this repo: `gh api` substitutes `{owner}`/`{repo}` from the clone, returns
`author_association`, and the filter correctly yields nothing here — every open PR is authored by a
`MEMBER`. Dropping the filter returns those rows, confirming the query itself is sound rather than
silently empty.

Same fix applied across the repos carrying this file. `chat-app` is unaffected — it uses a
local-markdown tracker with no PR section.
