### PR TITLE
ci: gate PRs on local links; stop publishing the ADRs

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -56,3 +56,17 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
       - run: just docs-build
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # --offline blocks network requests and excludes every external URL, so this
+      # gate is deterministic: it fails only on a relative link or file path that a
+      # diff actually broke.
+      - name: Check local links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline
+            --no-progress
+            '**/*.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,12 +119,10 @@ theme:
         icon: material/brightness-4
         name: Switch to system preference
 
-# docs/agents/ is agent configuration, not user documentation.
+# docs/agents/ is agent configuration, not user documentation; docs/adr/ is an
+# internal decision record. Neither is published.
 exclude_docs: |
   /agents/
-
-# ADRs are built (so their outgoing links are validated) but stay out of the site menu.
-not_in_nav: |
   /adr/
 
 validation:


### PR DESCRIPTION
## Why

`mkdocs build --strict` validates links **inside `docs/`** only. Root Markdown, `.github/`
and `docs/agents/` are unchecked — [`AGENTS.md`](AGENTS.md) already says so. Nothing
catches a broken relative link in `AGENTS.md`, `CONTEXT.md`, or a README.

A relative link breaks because a diff broke it. Unlike an external URL, it needs no
network and cannot flake, so it belongs on the PR that breaks it rather than in a
scheduled job.

## Design

One job in `_checks.yml`, so it runs wherever `_checks.yml` already runs.

`--offline` blocks all network requests and **excludes** external URLs rather than erroring
on them — that is what makes the gate deterministic and safe to block on. No exclusions, no
token, no schedule.

**The ADRs stop being published.** `not_in_nav` existed for exactly one reason — build them
so `--strict` validates their outgoing links. The gate does that now, from disk, for all 27
ADRs *and* for the citations to them in `AGENTS.md` and `CONTEXT.md` that `--strict` never
saw. So `/adr/` moves to `exclude_docs`.

## Non-goals

- No external link checking here. That runs weekly in `modern-python/.github` and stays
  there; sharing it across repos was considered and rejected (modern-python/.github#64).
- **`--include-fragments` stays off.** It computes GitHub-flavoured heading slugs while
  MkDocs uses python-markdown's, which collapse punctuation differently. On a sibling repo
  it produced 5 spurious `Cannot find fragment` errors for anchors that resolve correctly
  on the built site — verified by running `markdown.extensions.toc.slugify` against the
  headings involved.

## Verification

- `lychee --offline` on this tree: **565 total, 442 OK, 0 errors** — the gate lands green.
- `just docs-build` passes, and `site/adr/` is confirmed absent from the build.
- No Python changed, so `just test-ci` is untouched by this diff and I have not run it.

---

### Before merging

- [x] **Adding a fact anywhere?** No prose added; the check is executable.
- [x] **Rejected an alternative?** Recorded in modern-python/.github#64, not here.
- [ ] `just lint-ci` / `just test-ci` — not run; this diff touches only CI config and
      `mkdocs.yml`.