### PR TITLE
docs: correct the Dishka comparison's integration claims

### DIFF
--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -35,7 +35,7 @@ Flask, gRPC, Celery, arq, taskiq, and aiogram.**
 | Scopes | APP→…→STEP + any IntEnum | RUNTIME→…→STEP (+ custom) | lifetimes (Singleton/Factory/Resource) | Singleton / Thread / None | request only |
 | Resolution | sync (async finalizers supported) | sync + async | sync + async | sync | async |
 | First-party pytest plugin | ✅ | ✘ | ✘ | ✘ | n/a |
-| Official integrations | 13 (aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask, gRPC, Litestar, Starlette, taskiq, Typer, pytest) | ~20+ | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
+| Integrations | 13 official (aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask, gRPC, Litestar, Starlette, taskiq, Typer, pytest) | 13 official + ~10 community-maintained | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
 | Typed resolution | ✅ | ✅ | partial | ✅ | callable-keyed |
 | License | MIT | Apache-2.0 | BSD-3 | BSD | — |
 | Adoption | newest, very active | established, large community | most popular, mature | mature | built into FastAPI |
@@ -56,15 +56,22 @@ type-checker plugin to hold — see the
 ### vs Dishka
 
 Dishka is the closest library to modern-di — also typed, also scopes-first, also
-integrating with FastAPI/Litestar/FastStream — and it's more established, with
-many more integrations and a larger community. If you need **arbitrary *named*
-scopes**, **async resolution**, or an integration modern-di doesn't have yet
-(aiogram, Taskiq, gRPC, …), Dishka is an excellent choice.
+integrating with FastAPI and Litestar — and it's more established, with a larger
+community and a wider integration surface: 13 official integrations, plus the
+~10 community-maintained ones it links from its own docs. Its FastStream support
+is one of those community packages,
+[`dishka-faststream`](https://github.com/faststream-community/dishka-faststream);
+the bundled `dishka.integrations.faststream` is deprecated in favour of it. If
+you need **arbitrary *named* scopes**, **async resolution**, or an integration
+modern-di doesn't have yet — official: aiogram-dialog, Click, Sanic, telebot;
+community: Pyramid, Quart, RQ, Strawberry, APScheduler, … — Dishka is an
+excellent choice.
 
 modern-di's deliberate differences:
 
 - **A first-party pytest plugin** (`modern-di-pytest`) that turns any dependency
-  into a fixture — Dishka has no built-in pytest integration yet.
+  into a fixture — Dishka ships no pytest *plugin*, documenting a hand-written
+  fixtures recipe instead.
 - **Sync-only *resolution* (async finalizers still supported) and a small,
   built-in scope chain you can still extend with any `IntEnum`** — a simpler
   model. Dishka's own docs note that custom scopes are "hardly ever needed,"

--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -35,7 +35,7 @@ Flask, gRPC, Celery, arq, taskiq, and aiogram.**
 | Scopes | APP→…→STEP + any IntEnum | RUNTIME→…→STEP (+ custom) | lifetimes (Singleton/Factory/Resource) | Singleton / Thread / None | request only |
 | Resolution | sync (async finalizers supported) | sync + async | sync + async | sync | async |
 | First-party pytest plugin | ✅ | ✘ | ✘ | ✘ | n/a |
-| Integrations | 13 official (aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask, gRPC, Litestar, Starlette, taskiq, Typer, pytest) | 13 official + ~10 community-maintained | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
+| Integrations | 12 official frameworks (aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask, gRPC, Litestar, Starlette, taskiq, Typer) + a pytest plugin | 13 official frameworks + ~10 community-maintained | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
 | Typed resolution | ✅ | ✅ | partial | ✅ | callable-keyed |
 | License | MIT | Apache-2.0 | BSD-3 | BSD | — |
 | Adoption | newest, very active | established, large community | most popular, mature | mature | built into FastAPI |
@@ -57,15 +57,16 @@ type-checker plugin to hold — see the
 
 Dishka is the closest library to modern-di — also typed, also scopes-first, also
 integrating with FastAPI and Litestar — and it's more established, with a larger
-community and a wider integration surface: 13 official integrations, plus the
-~10 community-maintained ones it links from its own docs. Its FastStream support
-is one of those community packages,
-[`dishka-faststream`](https://github.com/faststream-community/dishka-faststream);
-the bundled `dishka.integrations.faststream` is deprecated in favour of it. If
-you need **arbitrary *named* scopes**, **async resolution**, or an integration
-modern-di doesn't have yet — official: aiogram-dialog, Click, Sanic, telebot;
-community: Pyramid, Quart, RQ, Strawberry, APScheduler, … — Dishka is an
-excellent choice.
+community and a wider integration surface: 13 official framework integrations,
+plus the ~10 community-maintained ones it links from its own docs. Its FastStream
+and Starlette support are two of those community packages
+([`dishka-faststream`](https://github.com/faststream-community/dishka-faststream)
+and [`starlette-dishka`](https://github.com/reagento/starlette-dishka)); the
+bundled `dishka.integrations` modules for both are deprecated in favor of them.
+If you need **arbitrary *named* scopes** or **async resolution**, Dishka is an
+excellent choice — as it is if you need an integration modern-di doesn't have
+yet: aiogram-dialog, Click, Sanic and telebot officially, or Pyramid, Quart, RQ,
+Strawberry and APScheduler from the community.
 
 modern-di's deliberate differences:
 


### PR DESCRIPTION
## Summary

`docs/introduction/comparison.md` steered readers to Dishka for aiogram, Taskiq and gRPC — three integrations modern-di has shipped since that sentence was written — and stated integration counts that weren't pinned to any definition. This is a factual correction; the comparison's argument, voice and ordering are unchanged.

Closes #457

## Changes

- **The stale parenthetical.** Re-derived the genuine Dishka-only set from Dishka 1.10.1's `docs/integrations/index.rst` and `src/dishka/integrations/`, rather than from the issue's own list: **aiogram-dialog, Click, Sanic, telebot** officially, plus **Pyramid, Quart, RQ, Strawberry, APScheduler** from the community. The issue suggested Airflow and FastMCP too; both are `develop`-only and absent from 1.10.1, so they're left out.
- **The counts.** The table cell said a bare `~20+` and the prose said "many more integrations", neither saying what it counted. Both now count *official framework integrations* under one definition: modern-di 12 frameworks plus a pytest plugin, Dishka 13 frameworks plus ~10 community-maintained.
- **FastStream and Starlette.** Both are marked community-supported in Dishka's own table, and both bundled `dishka.integrations` modules emit a `DeprecationWarning` pointing at `dishka-faststream` / `starlette-dishka`. The page now says so, which also stops "also integrating with FastAPI/Litestar/FastStream" from implying in-library parity.
- **The pytest bullet** is narrowed to a *plugin* claim rather than deleted — Dishka documents a hand-written fixtures recipe under `docs/advanced/testing/`, so "no built-in pytest integration" overstated it. The "hardly ever needed" custom-scopes quote is untouched; it's still current.

## Two decisions worth a reviewer's eye

**The table row was renamed `Official integrations` → `Integrations`.** Not requested by the issue, but the Dishka cell now carries a community count, and the old label would have contradicted it. Side effect: the `dependency-injector` and `injector` cells sit under a header implying an official/community split they don't label. Those columns were explicitly out of scope for this pass, so I left them.

**Counting Dishka at 13 treats the deprecated bundled `starlette` and `faststream` modules as community, not official.** That follows Dishka's own table and their deprecation warnings, and the prose explains it — but a count of module files under `src/dishka/integrations/` would say 15. Flagging the judgement rather than burying it.

## Why this rotted, and what would stop it

A claim about what *another* project has that we lack has no local signal when it goes false: nothing in this repo breaks when modern-di ships the integration that made the sentence true. Same failure mode as the launch copy in modern-python/.github#78. A docs assertion that fails when the integration list changes would catch it, but that's separate work.

## Checklist

- [x] Lint and format pass (`ruff`)
- [x] Type check passes (`ty`)
- [x] Tests pass and new behavior is covered — 512 passed; docs-only change, no new behavior to cover
- [x] `just docs-build` passes (mkdocs `--strict`)
- [ ] Build succeeds (`uv build`) if packaging or build config changed — n/a
- [ ] Repo metadata stays consistent across the three surfaces — n/a

---

*Note: a follow-up PR carries the audit of the `dependency-injector` / `injector` sections, which was requested after this PR had already merged.*
