### PR TITLE
docs: fix the dependency-injector integration and license cells

### DIFF
--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -35,9 +35,9 @@ Flask, gRPC, Celery, arq, taskiq, and aiogram.**
 | Scopes | APP→…→STEP + any IntEnum | RUNTIME→…→STEP (+ custom) | lifetimes (Singleton/Factory/Resource) | Singleton / Thread / None | request only |
 | Resolution | sync (async finalizers supported) | sync + async | sync + async | sync | async |
 | First-party pytest plugin | ✅ | ✘ | ✘ | ✘ | n/a |
-| Integrations | 12 official frameworks (aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask, gRPC, Litestar, Starlette, taskiq, Typer) + a pytest plugin | 13 official frameworks + ~10 community-maintained | FastAPI, Flask, … | Flask (1st-party), FastAPI (3rd-party) | n/a |
+| Integrations | 12 official frameworks (aiogram, aiohttp, arq, Celery, FastAPI, FastStream, Flask, gRPC, Litestar, Starlette, taskiq, Typer) + a pytest plugin | 13 official frameworks + ~10 community-maintained | aiohttp, Flask, Starlette; FastAPI via wiring | Flask (1st-party), FastAPI (3rd-party) | n/a |
 | Typed resolution | ✅ | ✅ | partial | ✅ | callable-keyed |
-| License | MIT | Apache-2.0 | BSD-3 | BSD | — |
+| License | MIT | Apache-2.0 | BSD-3 | BSD-3 | — |
 | Adoption | newest, very active | established, large community | most popular, mature | mature | built into FastAPI |
 
 On the **typed-resolution** row: modern-di keeps the concrete static type end to


### PR DESCRIPTION
## Summary

Follow-up to #458, which corrected the Dishka claims in `docs/introduction/comparison.md`. That issue (#457) explicitly left the `dependency-injector`, `injector` and framework-native sections unaudited:

> The rest of `comparison.md`: the dependency-injector, injector and framework-native sections were not audited in this pass.

This PR is that audit. It arrives separately because #458 merged before the audit was finished.

Two claims were wrong, both in the landscape table. Everything else held.

## Changes

- **`dependency-injector` integrations read "FastAPI, Flask, …".** Its bundled `ext/` modules are **aiohttp, Flask, Starlette** — there is no `ext/fastapi`. FastAPI is supported through wiring (`@inject` plus `Provide` inside `Depends`), documented in `wiring.rst` with dedicated examples, but it isn't a bundled integration module. Naming FastAPI first while omitting the two that do ship was the same unpinned-claim shape #458 fixed for Dishka. Now reads `aiohttp, Flask, Starlette; FastAPI via wiring`.
- **`injector` license read "BSD".** It is BSD-3-Clause, same as `dependency-injector`, whose cell already said `BSD-3`.

## What was checked and held

Verified against current upstream, so a future reader knows this pass happened and what it covered:

| Claim | Verdict |
|---|---|
| dependency-injector "most popular" | ✅ 8.3M downloads/mo vs svcs 5.6M, injector 4.2M, dishka 755K, wireup 79K, that-depends 41K; 4.9k stars |
| dependency-injector "Cython-accelerated" | ✅ `.pyx` sources, `cythonize()` in `setup.py` |
| dependency-injector "actively maintained again after an earlier hiatus" | ✅ 4.49.1 released 2026-06-18, pushed 2026-09-01 |
| dependency-injector has no pytest plugin (table ✘) | ✅ no `entry_points` in `setup.py` |
| dependency-injector "declarative style using `Provide[...]` and `@inject`" | ✅ per `wiring.rst` |
| injector "no async support" | ✅ no `async`/`await` anywhere in `injector/__init__.py` |
| injector scopes "Singleton / Thread / None" | ✅ `SingletonScope`, `ThreadLocalScope`, `NoScope` |
| injector "Flask (1st-party), FastAPI (3rd-party)" | ✅ `python-injector/flask_injector` is same-org; no first-party FastAPI adapter |
| injector lacks resource finalization | ✅ no close/teardown/finalize/dispose in core |
| that-depends row (5 cells) | ✅ `AsyncFactory` + `await resolve`, class-level resolution, `ContextResource`, bundled `integrations/{fastapi,faststream}.py` |
| Vocabulary table, dependency-injector column | ✅ `Singleton`, `Factory`, `Resource`, `Closing` marker, `Configuration.from_value()`, `AbstractFactory`, `provider.override()` → `OverridingContext` |
| Vocabulary table, dishka column | ✅ incl. "no dedicated API" for test override — no `override` on `Container`; their docs say a container "cannot be adjusted after creation" |
| Vocabulary table, wireup column | ✅ `injectable(lifetime="singleton")` default, `"scoped"`/`"transient"`, `as_type=`, `container.override.injectable()` contextmanager |
| Vocabulary table, svcs column | ✅ `Registry.register_factory`/`register_value`, per-`Container` instances, `close()` |

The framework-native section is argument rather than fact, so there was nothing in it to verify.

## Note for the reviewer

The `dependency-injector` and `injector` cells still carry no official/community qualifier, unlike the modern-di and Dishka cells that #458 changed. That's deliberate — their integration stories don't split that way — but it does mean the `Integrations` row mixes two shapes of answer. Say the word if you'd rather it were uniform.

## Checklist

- [x] Lint and format pass (`ruff`)
- [x] Type check passes (`ty`)
- [x] Tests pass and new behavior is covered — 512 passed; docs-only change, no new behavior to cover
- [x] `just docs-build` passes (mkdocs `--strict`)
- [ ] Build succeeds (`uv build`) if packaging or build config changed — n/a
- [ ] Repo metadata stays consistent across the three surfaces — n/a
