### PR TITLE
chore(context7): drop the stale planning/ exclusion

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,4 @@
 {
   "url": "https://context7.com/modern-python/modern-di",
-  "public_key": "pk_sIP7B0JWZxstxUZb8L28N",
-  "excludeFolders": ["planning"]
+  "public_key": "pk_sIP7B0JWZxstxUZb8L28N"
 }


### PR DESCRIPTION
`context7.json` excludes a `planning/` directory that no longer exists. This repo migrated off the `planning/` convention over five PRs, and the exclusion has been a dead entry since — it was left behind because it sat outside that migration's recipe, so removing it is an independent call rather than migration fallout. Part of the cleanup around modern-python/.github#67.

## Why drop the key rather than leave an empty list

Checked against Context7's published schema (https://context7.com/schema/context7.json) rather than assumed:

- the schema declares no root `required` array, so every property is optional;
- `excludeFolders` carries `"default": []` and no `minItems`.

An absent key and `[]` are therefore equivalent to Context7. Absent is what the repos that never carried the line already look like (`eof-fixer`, `faststream-concurrent-aiokafka`), so dropping it converges the org on one shape.

## Non-goals

No other exclusion is touched — this repo excluded only `planning`, so there is no partial-list edit. Indexing behaviour is unchanged, since the excluded path does not exist.

`docs/context7.json`, the second Context7 config in this repo, is deliberately untouched: it carries only `url` and `public_key` and never had an `excludeFolders` key.

## Verification

- `git ls-tree -d origin/main planning` returns nothing: the directory is genuinely absent at `main`, not merely absent from the working tree.
- `just lint-ci` clean.