### PR TITLE
docs(agents): drop the fact-placement convention from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ review time.
   in 2.x), though **finalizers** may still be sync or async (`close_sync`/`close_async`); no global state
 - Docstrings: public API documents the contract; internal helpers get a one-line contract, plus at most
   1–2 lines for a genuinely non-obvious constraint. Never narrate implementation or justify code to a
-  reviewer — cross-file rationale lives in an `INVARIANT:` test docstring or an ADR under `docs/adr/`
+  reviewer — cross-file rationale lives in an `INVARIANT:` test docstring
 - `ruff` (`select = ["ALL"]`) and `ty` are configured in `pyproject.toml` and run by `just lint`
 
 ## Agent skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,6 @@ the site only, and root Markdown, `.github/`, and `docs/agents/` are unchecked.
   providers/overrides registries; cache and context are per-container. `container.validate()` (cycle +
   transitive-scope checks) is the only thing that validates.
 
-Behavior detail has no prose home — it lives in the code and its `INVARIANT:`-marked tests. Before
-writing prose about a capability, run the admission check in **Where a fact goes** below.
-
 ### Key files
 
 Every module under `modern_di/` is named for what it does; read it. What a single-file read will
@@ -56,39 +53,12 @@ mocks. Scope chains come from `build_child_container`.
 
 ## Workflow
 
-Two things outlive the PR, and there are exactly two places to put them: an
-alternative **rejected** with reasoning becomes an ADR in [`docs/adr/`](docs/adr/)
-(`NNNN-slug.md`, sequential), and real work **not scheduled** becomes a GitHub
-issue. There is no third state, and no separate truth-home directory — a
-behaviour change is reviewed with the diff, not promoted to a page.
-
-### Where a fact goes
-
-Four homes, one owner each:
-
-| Home | Holds |
-|---|---|
-| `modern_di/` | anything readable from the module — the default |
-| a named test | an **invariant**: must stay true, and a change could silently break it |
-| `docs/adr/` | a rejected alternative, with the reasoning that would otherwise be re-litigated |
-| `docs/` | anything a user needs |
-
-Before writing a line anywhere:
-
-> Can an agent get this by reading `modern_di/`? → **don't write it.**
-> Would a wrong change here fail a test? → it belongs **in the test**, not in prose.
-> Does a user need it? → **`docs/`**.
-> Otherwise it does not get written.
-
-**Prose about mechanism has no home. There is no file to add a paragraph to.** This file included:
-it is always loaded, so a line that restates a docstring, a justfile comment, or `pyproject.toml`
-costs every turn and rots in two places at once.
+Real work **not scheduled** becomes a GitHub issue.
 
 An invariant is a test whose name is the claim, with a docstring opening `INVARIANT:` and a second
 paragraph naming **what breaks it** — design rationale, not a report of what this one test catches;
 a sibling test may be the one that trips. Nothing enforces that docstring shape; it is read at
-review time. Both ADRs and `INVARIANT:` docstrings ratchet: nothing prunes a record once its call is
-settled. Keeping them lean is a standing habit.
+review time.
 
 ## Code Style
 


### PR DESCRIPTION
## Why

`AGENTS.md` carried a per-repo copy of a doc-placement convention: a four-homes table, an admission check to run "before writing a line anywhere", an ADR row prescribing `NNNN-slug.md` and revisit triggers, and a ratchet rule.

Doc placement is a domain-modeling convention. Restating it in every repo means ~25 copies that can drift from it, in a file loaded on every turn — the failure the removed text itself named: "it is always loaded, so a line that restates a docstring… costs every turn and rots in two places at once."

The local ADR rule was also weaker than the convention it duplicated: it had no reversibility gate, so any non-obvious rejected alternative qualified.

Piloted and merged in `lite-bootstrap` (#188); this applies the same cut here.

## Design

Removed:

- the `Where a fact goes` section in full — four-homes table, the "before writing a line anywhere" admission check, "prose about mechanism has no home", the ratchet rule
- `Workflow`'s "the spec for a change is its PR body" rule, the "two things outlive the PR" ADR sentence, "there is no change file and no lane to choose", and "there is no separate truth-home directory"
- `Architecture`'s "behaviour detail has no prose home… run the admission check" tail, where present

Kept:

- the `INVARIANT:` docstring shape, with its ADR and lychee clauses trimmed
- one `Workflow` fact: unscheduled work becomes a GitHub issue
- every other section, unchanged
- inline `docs/adr/` citations inside architecture prose. Those cite a specific decision at the point it is relevant; they are not the convention being dropped.

No replacement pointer is added, by design.

## Non-goals

- No ADR is changed, removed or renumbered. `docs/adr/` is untouched.
- No code or test changes.

## Verification

The remaining `docs/adr/` mentions in this file, if any, are inline citations to specific decisions, not a rule about when to write one.
