### PR TITLE
fix: draw the redirect chain on validate() scope violations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,12 @@ _Avoid_: service, dependency
 One band in the container hierarchy.
 _Avoid_: lifetime, layer
 
+**Effective scope**:
+The band a provider actually resolves in, once any redirection to another provider is followed. The
+same as the provider's own scope unless it redirects, where the provider at the end of the chain
+governs.
+_Avoid_: terminal scope
+
 **Group**:
 A non-instantiable namespace class declaring providers.
 _Avoid_: module

--- a/docs/adr/0029-scope-violations-draw-the-redirect-chain.md
+++ b/docs/adr/0029-scope-violations-draw-the-redirect-chain.md
@@ -1,0 +1,57 @@
+# A scope violation draws the chain that reached it, at effective scope
+
+**Decision:** `InvalidScopeDependencyError` renders the same arrow tree as every other chain-shaped
+error, and each redirect hop in that tree is drawn at the scope it **resolves** at, not the scope the
+provider object reports. The redirect walk moves to one module-level `terminal_chain()` in
+`dependency_graph.py`; `.dep_chain` joins the public attribute surface, with `.dep_provider` and
+`.dep_terminal` as its two ends.
+
+**The blind spot was specific to redirects, and `Alias` is how abstract-to-implementation binding is
+spelled.** `_walk_errors` compared `terminal_scope(dep)` against `terminal_scope(parent)`, then built
+a message naming `dep.display_name` — the alias's bound type — beside a scope belonging to the
+provider at the far end of the chain. Two facts about two objects, presented as one edge, with the
+terminal named nowhere. A three-hop `Protocol` chain reported `provider of IA at deeper scope
+REQUEST` where `IA` declares no scope at all and `Impl`, the provider to change, never appeared. The
+source was not recoverable programmatically either: `.dep_provider` was the alias, and its source
+type is private.
+
+**Its sibling out of the same walk already did this right.** A cycle through the same alias drew
+every hop with definition sites via `_render_chain`, because `build_cycle_error` keeps the providers
+it walked. Two errors from one `validate()` call, one drawing the chain and one printing a line, is
+the drift [0009](0009-error-text-is-not-a-contract.md) unified the drawers to prevent — and 0009 is
+also what licenses changing this text with no deprecation cycle. The tree pays even with no alias
+present: the old message carried no `module:line` for either provider.
+
+**Effective scope, not declared scope, and not a blank.** `Alias` sets `_takes_group_scope = False`
+and passes `scope=UNSET`, so `AbstractProvider.scope` returns the `Scope.APP` default for every
+alias. Three renderings were compared on a three-hop chain. Drawing `provider.scope` (the shipped
+behaviour, and still what the cycle renderer did) prints `APP APP APP REQUEST`, which reads as "the
+aliases are fine, only the source is deep" and points at the wrong fix. Blanking the column for
+providers with no scope of their own is honest but supplies nothing: the reader still scans to the
+bottom. Drawing each hop at its terminal's scope puts the APP/REQUEST boundary on the offending edge,
+which is the fix the reader is looking for. `Alias.scope` keeps returning `APP` — scope ordering
+depends on it — so this is a rendering rule, deliberately not a change to the provider.
+
+**The walk moved rather than being copied.** `Alias` cannot import `dependency_graph`
+(`dependency_graph` → `providers.abstract` → `providers/__init__` → `alias`), so a container-aware
+step on the provider would have re-hand-rolled the chain walk that
+[0007](0007-unify-graph-traversal.md) deleted. `resolver_compiler` has no such cycle, so the alias
+resolver builds its step through `redirect_step()` and `Alias._resolution_step` is gone. That keeps
+0007 intact: the walk stays in the traversal module and providers still expose only the generic
+`redirect_target` hook. Cost is off the hot path — the step is built inside `except`, and the
+compiled closure binds nothing new.
+
+**`RegistrationError` stays the base**, though nothing registers when this fires and the error is
+aggregated into a `ContainerError`. Under 0009 the hierarchy *is* the contract: reparenting would
+silently break a caller catching `RegistrationError`, to fix a misfiling that costs nobody anything.
+
+Pinned by `test_validate_and_runtime_name_the_same_chain_for_one_scope_violation` (the two detectors
+must agree, which is the defect stated as a property),
+`test_alias_scope_violation_names_the_source_behind_the_alias` (the terminal is recoverable without
+parsing the message) and `test_invalid_scope_dependency_error_draws_the_chain_that_reached_the_terminal`
+(the alias hop draws REQUEST while its own `.scope` is APP).
+
+**Revisit trigger:** a second provider type implements `redirect_target`. Effective-scope rendering
+assumes a redirect is a pure forward with no lifetime of its own, which is true of `Alias` and was
+never true of anything else; a redirect that *does* own a scope would make the terminal's scope the
+wrong thing to draw, and the column would need the hop's own band back.

--- a/docs/providers/alias.md
+++ b/docs/providers/alias.md
@@ -110,4 +110,6 @@ assert container.resolve(Repository) is mock_for_source
     depends — via an alias — on a deeper-scoped source is flagged with `InvalidScopeDependencyError`
     at validation time — the same [scope dependency rule](scopes.md#the-scope-dependency-rule)
     enforced everywhere else, applied through the alias's source chain instead of letting it surface
-    as `ScopeNotInitializedError` at runtime.
+    as `ScopeNotInitializedError` at runtime. The error names every hop of that chain and its
+    terminal source, since the alias's own type carries no scope to point at; see
+    [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md#when-the-dependency-is-reached-through-an-alias).

--- a/docs/providers/errors-and-exceptions.md
+++ b/docs/providers/errors-and-exceptions.md
@@ -160,7 +160,9 @@ Catch `RegistrationError` for declaration- and registration-time problems.
   [Troubleshooting: UnsupportedCreatorParameterError](../troubleshooting/unsupported-creator-parameter-error.md).
 - **`InvalidScopeDependencyError`** — raised when a provider depends on another provider bound to a
   *deeper* scope than its own (a longer-lived provider depending on a shorter-lived one). Surfaced by
-  `validate()`. See [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md).
+  `validate()`. Renders the chain from the depender to the provider that supplies the dependency;
+  `.dep_chain` carries that chain, with `.dep_provider` and `.dep_terminal` as its ends. See
+  [Troubleshooting: Scope chain](../troubleshooting/scope-chain.md).
 
 ## Direct `ModernDIError` subclasses
 

--- a/docs/troubleshooting/scope-chain.md
+++ b/docs/troubleshooting/scope-chain.md
@@ -10,12 +10,30 @@ You'll see something like:
 Container.validate() found 1 issue(s): InvalidScopeDependencyError
 
 InvalidScopeDependencyError (1):
-  - Provider UserCache (scope APP) declares parameter 'session' typed as a provider of Session at deeper scope REQUEST. A provider cannot depend on a deeper-scoped provider.
+  - Provider at a deeper scope reached through this chain:
+      APP      UserCache (myapp.providers:10)
+      REQUEST  └─> Session (myapp.providers:4)
+      caused by: UserCache (scope APP) declares parameter 'session' typed as a provider of Session at deeper scope REQUEST. A provider cannot depend on a deeper-scoped provider.
 ```
 
 The fix is always to make the depender's scope equal to or shorter than the dependee's. In the example above, `UserCache` should be REQUEST-scoped, not APP-scoped.
 
-This particular message is a single static check with no chain attached; if the same violation instead surfaces at runtime as `ScopeNotInitializedError` or `ScopeSkippedError`, their breadcrumb lines may end with a pointer to where the offending provider was declared (module and line number).
+The chain is the same arrow tree `ScopeNotInitializedError` and `ScopeSkippedError` draw at runtime, so the same violation reads identically whether you find it with `validate()` or by resolving.
+
+### When the dependency is reached through an alias
+
+An [`Alias`](../providers/alias.md) declares no scope of its own, so the type on the parameter is not the type that owns the offending scope. The chain names every hop and draws each one at the scope it actually resolves at:
+
+```
+InvalidScopeDependencyError (1):
+  - Provider at a deeper scope reached through this chain:
+      APP      UserCache (myapp.providers:10)
+      REQUEST  └─> Repository
+      REQUEST      └─> Session (myapp.providers:4)
+      caused by: UserCache (scope APP) declares parameter 'session' typed as a provider of Session at deeper scope REQUEST. A provider cannot depend on a deeper-scoped provider.
+```
+
+`Repository` is the alias and `Session` is what supplies it. Programmatically, `.dep_provider` is the alias, `.dep_terminal` is the source, and `.dep_chain` is every hop between them.
 
 ## Common cases
 

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -15,6 +15,8 @@ from modern_di.dependency_graph import (
     Edge,
     NodeEntered,
     build_cycle_error,
+    effective_scope,
+    terminal_chain,
 )
 from modern_di.group import Group
 from modern_di.providers.abstract import AbstractProvider
@@ -44,7 +46,7 @@ def _handle_recursion_error(
     cycle = DependencyGraph().find_cycle_from(provider, container)
     if cycle is None:
         raise exc
-    raise build_cycle_error(cycle) from exc
+    raise build_cycle_error(cycle, container) from exc
 
 
 # Trailing separator included: without it the prefix test also swallows sibling packages
@@ -256,18 +258,17 @@ class Container:
                 case DependenciesError(_, error):
                     errors.append(error)
                 case Edge(parent, name, dep):
-                    dep_scope = graph.terminal_scope(dep, self)
-                    if dep_scope > graph.terminal_scope(parent, self):
+                    dep_chain = terminal_chain(dep, self)
+                    if dep_chain[-1].scope > effective_scope(parent, self):
                         errors.append(
                             exceptions.InvalidScopeDependencyError(
                                 provider=parent,
                                 parameter_name=name,
-                                dep_provider=dep,
-                                dep_scope=dep_scope,
+                                dep_chain=dep_chain,
                             )
                         )
                 case Cycle(providers):
-                    errors.append(build_cycle_error(providers))
+                    errors.append(build_cycle_error(providers, self))
         return errors
 
     def validate(self) -> None:

--- a/modern_di/dependency_graph.py
+++ b/modern_di/dependency_graph.py
@@ -56,8 +56,49 @@ class DependenciesError(NamedTuple):
 Event = NodeEntered | Edge | Cycle | DependenciesError
 
 
+def terminal_chain(
+    provider: "AbstractProvider[typing.Any]", container: "Container"
+) -> "list[AbstractProvider[typing.Any]]":
+    """Follow ``redirect_target`` hops from ``provider``, returning every provider passed through.
+
+    The single home of the redirect walk: ``validate()``, the compiled alias resolver and the cycle
+    renderer all read a redirect's terminal from here. Element 0 is always ``provider``; a provider
+    that redirects nowhere yields a one-element chain. A redirect cycle is broken via the ``seen``
+    guard, ending the chain on the starting provider rather than looping forever; ``walk()`` reports
+    that cycle separately.
+    """
+    chain = [provider]
+    seen: set[int] = set()
+    while (nxt := provider.redirect_target(container)) is not None:
+        if provider.provider_id in seen:
+            return [provider]
+        seen.add(provider.provider_id)
+        provider = nxt
+        chain.append(provider)
+    return chain
+
+
+def effective_scope(provider: "AbstractProvider[typing.Any]", container: "Container") -> enum.IntEnum:
+    """Return the scope a provider actually resolves at: its terminal's, once redirects are followed."""
+    return terminal_chain(provider, container)[-1].scope
+
+
+def redirect_step(provider: "AbstractProvider[typing.Any]", container: "Container") -> "exceptions.ResolutionStep":
+    """Draw a chain step for a provider that may redirect, at the scope it actually resolves at.
+
+    A redirect declares no scope of its own — ``Alias`` reports the ``Scope.APP`` default — so
+    rendering ``provider.scope`` would put a band on the chain that nothing in the graph chose.
+    """
+    return exceptions.ResolutionStep(
+        scope=effective_scope(provider, container),
+        name=provider.display_name,
+        location=provider.definition_site,
+    )
+
+
 def build_cycle_error(
     providers: "list[AbstractProvider[typing.Any]]",
+    container: "Container",
 ) -> "exceptions.CircularDependencyError":
     """Build a ``CircularDependencyError`` from a cycle's providers (first node repeated last).
 
@@ -72,7 +113,10 @@ def build_cycle_error(
     canonical = [*rotated, rotated[0]]  # re-close the ring on the lead node
     return exceptions.CircularDependencyError(
         steps=[
-            exceptions.ResolutionStep(scope=p.scope, name=p.display_name, location=p.definition_site) for p in canonical
+            exceptions.ResolutionStep(
+                scope=effective_scope(p, container), name=p.display_name, location=p.definition_site
+            )
+            for p in canonical
         ]
     )
 
@@ -110,20 +154,6 @@ class DependencyGraph:
             if isinstance(event, Cycle):
                 return event.providers
         return None
-
-    def terminal_scope(self, provider: "AbstractProvider[typing.Any]", container: "Container") -> enum.IntEnum:
-        """Follow ``redirect_target`` hops to the terminal provider and return its scope.
-
-        A redirect cycle is broken via the ``seen`` guard, falling back to the starting
-        provider's own scope instead of looping forever; ``walk()`` reports that cycle separately.
-        """
-        seen: set[int] = set()
-        while (nxt := provider.redirect_target(container)) is not None:
-            if provider.provider_id in seen:
-                break
-            seen.add(provider.provider_id)
-            provider = nxt
-        return provider.scope
 
     def _walk_from(
         self,

--- a/modern_di/exceptions.py
+++ b/modern_di/exceptions.py
@@ -625,30 +625,63 @@ class UnsupportedCreatorParameterError(RegistrationError):
 
 
 class InvalidScopeDependencyError(RegistrationError):
-    """A provider depends on a deeper-scoped one. Inspect ``.provider``, ``.parameter_name``, ``.dep_provider``."""
+    """A provider depends on a deeper-scoped one. Inspect ``.provider``, ``.parameter_name``, ``.dep_chain``.
+
+    ``dep_chain`` runs from the declared dependency to the provider that actually supplies it,
+    following redirects; ``.dep_provider`` and ``.dep_terminal`` are its ends. The two differ only
+    when the dependency is reached through an ``Alias``, which is also the case where the declared
+    type alone cannot tell a reader which provider owns the offending scope.
+    """
 
     docs_slug = "scope-chain"
 
-    __slots__ = ("dep_provider", "parameter_name", "provider")
+    __slots__ = ("dep_chain", "parameter_name", "provider")
 
     def __init__(
         self,
         *,
         provider: "AbstractProvider[typing.Any]",
         parameter_name: str,
-        dep_provider: "AbstractProvider[typing.Any]",
-        dep_scope: enum.IntEnum | None = None,
+        dep_chain: "list[AbstractProvider[typing.Any]]",
     ) -> None:
         self.provider = provider
         self.parameter_name = parameter_name
-        self.dep_provider = dep_provider
-        provider_name = provider.display_name
-        dep_name = dep_provider.display_name
+        self.dep_chain = dep_chain
         super().__init__(
-            f"Provider {provider_name} (scope {provider.scope.name}) declares parameter "
-            f"{parameter_name!r} typed as a provider of {dep_name} at deeper scope "
-            f"{(dep_scope or dep_provider.scope).name}. A provider cannot depend on a deeper-scoped provider."
+            f"{provider.display_name} (scope {provider.scope.name}) declares parameter "
+            f"{parameter_name!r} typed as a provider of {self.dep_terminal.display_name} at deeper "
+            f"scope {self.dep_terminal.scope.name}. A provider cannot depend on a deeper-scoped provider."
         )
+
+    @property
+    def dep_provider(self) -> "AbstractProvider[typing.Any]":
+        """The dependency as declared: the type the parameter is annotated with."""
+        return self.dep_chain[0]
+
+    @property
+    def dep_terminal(self) -> "AbstractProvider[typing.Any]":
+        """The provider that actually supplies the dependency, once redirects are followed."""
+        return self.dep_chain[-1]
+
+    def _render_body(self) -> str:
+        terminal_scope = self.dep_terminal.scope
+        steps = [
+            ResolutionStep(
+                scope=self.provider.scope, name=self.provider.display_name, location=self.provider.definition_site
+            ),
+            # Every hop before the terminal is a redirect, so its own `scope` is a default it never
+            # declared; the scope it resolves at is the terminal's.
+            *(
+                ResolutionStep(scope=terminal_scope, name=p.display_name, location=p.definition_site)
+                for p in self.dep_chain
+            ),
+        ]
+        lines = [
+            "Provider at a deeper scope reached through this chain:",
+            *_render_chain(steps),
+            f"  caused by: {RuntimeError.__str__(self)}",
+        ]
+        return "\n".join(lines)
 
 
 class ValidationFailedError(ContainerError):

--- a/modern_di/providers/alias.py
+++ b/modern_di/providers/alias.py
@@ -33,9 +33,6 @@ class Alias(AbstractProvider[types.T_co]):
             raise exceptions.AliasSourceNotRegisteredError(source_type=self._source_type)
         return source
 
-    def _resolution_step(self) -> "exceptions.ResolutionStep":
-        return exceptions.ResolutionStep(scope=self.scope, name=self.display_name)
-
     def get_dependencies(self, container: "Container") -> dict[str, "AbstractProvider[typing.Any]"]:
         return {"source": self._find_source(container)}
 

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -12,6 +12,7 @@ import functools
 import typing
 
 from modern_di import exceptions, types
+from modern_di.dependency_graph import redirect_step
 from modern_di.providers.abstract import AbstractProvider
 from modern_di.providers.alias import Alias
 from modern_di.providers.container_provider import container_provider
@@ -387,7 +388,6 @@ def _compile_alias(a: "Alias[typing.Any]") -> "typing.Callable[[Container], typi
     """
     pid = a.provider_id
     source_type = a._source_type
-    resolution_step = a._resolution_step
     find_source = a._find_source
 
     def resolve(container: "Container") -> typing.Any:
@@ -406,7 +406,7 @@ def _compile_alias(a: "Alias[typing.Any]") -> "typing.Callable[[Container], typi
                 source_resolver = registry.resolver_for(source)
             return source_resolver(container)
         except _STEP_ERRORS as exc:
-            exc.prepend_step(resolution_step())
+            exc.prepend_step(redirect_step(a, container))
             raise
 
     return resolve

--- a/tests/providers/test_alias.py
+++ b/tests/providers/test_alias.py
@@ -4,7 +4,7 @@ import enum
 import pytest
 
 from modern_di import Container, Group, Scope, exceptions, providers
-from modern_di.dependency_graph import DependencyGraph
+from modern_di.dependency_graph import terminal_chain
 from modern_di.exceptions import (
     AliasSourceNotRegisteredError,
     CircularDependencyError,
@@ -303,6 +303,24 @@ def test_validate_flags_shallow_caller_depending_through_alias_on_deeper_source(
     assert "REQUEST" in str(exc_info.value)
 
 
+def test_alias_scope_violation_names_the_source_behind_the_alias() -> None:
+    """INVARIANT: the provider owning the offending scope is recoverable without parsing the message.
+
+    Broken by reporting the edge in terms of the bound type alone. Through an alias the declared
+    type carries no scope of its own, so a consumer left with only `.dep_provider` would have to
+    read the source type back out of a repr to learn which declaration to change.
+    """
+    container = Container(scope=Scope.APP, groups=[_XfourGroup])
+    with pytest.raises(exceptions.ValidationFailedError) as exc_info:
+        container.validate()
+
+    (issue,) = [e for e in exc_info.value.errors if isinstance(e, exceptions.InvalidScopeDependencyError)]
+    assert issue.dep_provider is _XfourGroup.iface
+    assert issue.dep_terminal is _XfourGroup.deep
+    assert issue.dep_chain == [_XfourGroup.iface, _XfourGroup.deep]
+    assert _XfourDeep.__name__ in str(issue)
+
+
 class _OkDeep: ...
 
 
@@ -365,10 +383,10 @@ class _MutualAliasGroup(Group):
     b = providers.Alias(source_type=_MutualA, bound_type=_MutualB)
 
 
-def test_terminal_scope_handles_mutual_alias_cycle() -> None:
-    # Mutual aliases: terminal_scope must terminate via the `seen` guard and fall back to `a`'s own scope.
+def test_terminal_chain_handles_mutual_alias_cycle() -> None:
+    # Mutual aliases: the walk must terminate via the `seen` guard and fall back to `a` itself.
     container = Container(scope=Scope.APP, groups=[_MutualAliasGroup])
-    assert DependencyGraph().terminal_scope(_MutualAliasGroup.a, container) is _MutualAliasGroup.a.scope
+    assert terminal_chain(_MutualAliasGroup.a, container) == [_MutualAliasGroup.a]
     # validate() also reports the cycle separately.
     with pytest.raises(exceptions.ValidationFailedError) as exc_info:
         container.validate()

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -8,6 +8,8 @@ from modern_di.dependency_graph import (
     Edge,
     NodeEntered,
     build_cycle_error,
+    effective_scope,
+    terminal_chain,
 )
 from modern_di.group import Group
 from modern_di.providers import Alias, Factory
@@ -136,7 +138,7 @@ def test_find_cycle_from_returns_loop() -> None:
     assert cycle == [G.a, G.b, G.a]
 
 
-def test_terminal_scope_follows_alias_chain() -> None:
+def test_terminal_chain_follows_every_alias_hop() -> None:
     class ChainTerminal: ...
 
     class ChainMid: ...
@@ -149,10 +151,11 @@ def test_terminal_scope_follows_alias_chain() -> None:
         top = Alias(source_type=ChainMid, bound_type=ChainTop)
 
     c = Container(scope=Scope.APP, groups=[G])
-    assert DependencyGraph().terminal_scope(G.top, c) == Scope.REQUEST
+    assert terminal_chain(G.top, c) == [G.top, G.mid, G.terminal]
+    assert effective_scope(G.top, c) == Scope.REQUEST
 
 
-def test_terminal_scope_alias_cycle_falls_back_to_self_scope() -> None:
+def test_terminal_chain_alias_cycle_falls_back_to_the_starting_provider() -> None:
     class MutualX: ...
 
     class MutualY: ...
@@ -162,7 +165,8 @@ def test_terminal_scope_alias_cycle_falls_back_to_self_scope() -> None:
         b = Alias(source_type=MutualX, bound_type=MutualY)
 
     c = Container(scope=Scope.APP, groups=[G])
-    assert DependencyGraph().terminal_scope(G.a, c) == G.a.scope
+    assert terminal_chain(G.a, c) == [G.a]
+    assert effective_scope(G.a, c) == G.a.scope
 
 
 def test_walk_dangling_dep_emits_dependencies_error() -> None:
@@ -225,7 +229,7 @@ def test_build_cycle_error_rotates_to_minimum_provider_id() -> None:
 
     # Seed the ring at the higher-id node, closing back to itself last -- the shape `Cycle.providers`
     # is in (first node repeated last), regardless of which provider the walk happened to start from.
-    error = build_cycle_error([second, first, second])
+    error = build_cycle_error([second, first, second], Container(scope=Scope.APP))
 
     # Rotated to the minimum-provider_id node (`first`), not left seeded at `second`.
     assert error.cycle_path == ["RingFirst", "RingSecond", "RingFirst"]

--- a/tests/test_dependency_path.py
+++ b/tests/test_dependency_path.py
@@ -181,3 +181,54 @@ def test_breadcrumb_line_carries_definition_site() -> None:
         container.resolve(_Anchored)
     lineno = inspect.getsourcelines(_Anchored)[1]
     assert f"({_Anchored.__module__}:{lineno})" in str(exc_info.value)
+
+
+class _Deep:
+    pass
+
+
+class _MidIface:
+    pass
+
+
+class _TopIface:
+    pass
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class _Captor:
+    svc: _TopIface
+
+
+class _AliasScopeViolationGroup(Group):
+    deep = providers.Factory(scope=Scope.REQUEST, creator=_Deep)
+    mid = providers.Alias(source_type=_Deep, bound_type=_MidIface)
+    top = providers.Alias(source_type=_MidIface, bound_type=_TopIface)
+    captor = providers.Factory(scope=Scope.APP, creator=_Captor)
+
+
+def _validate_chain_names() -> list[str]:
+    container = Container(groups=[_AliasScopeViolationGroup])
+    with pytest.raises(exceptions.ValidationFailedError) as exc_info:
+        container.validate()
+    (issue,) = [e for e in exc_info.value.errors if isinstance(e, exceptions.InvalidScopeDependencyError)]
+    return [issue.provider.display_name, *(p.display_name for p in issue.dep_chain)]
+
+
+def _runtime_chain_names() -> list[str]:
+    container = Container(groups=[_AliasScopeViolationGroup])
+    container.open()
+    with pytest.raises(ScopeNotInitializedError) as exc_info:
+        container.resolve(_Captor)
+    return [step.name for step in exc_info.value.dependency_path]
+
+
+def test_validate_and_runtime_name_the_same_chain_for_one_scope_violation() -> None:
+    """INVARIANT: both detectors of a scope violation name the same provider chain.
+
+    Broken by any error that reports a redirect-mediated violation from only one end of the
+    chain: naming the bound type without its terminal, or the terminal without the hops that
+    reached it. The two paths share `_render_chain` precisely so a reader who hits one and
+    then the other is not told two different stories about the same graph.
+    """
+    assert _validate_chain_names() == _runtime_chain_names()

--- a/tests/test_error_rendering.py
+++ b/tests/test_error_rendering.py
@@ -1,6 +1,8 @@
+import inspect
+
 import pytest
 
-from modern_di import Scope, exceptions, suggester
+from modern_di import Scope, exceptions, providers, suggester
 
 
 def _step(name: str, scope: Scope = Scope.APP, location: str | None = None) -> exceptions.ResolutionStep:
@@ -162,4 +164,37 @@ def test_context_value_not_set_error_message_and_hierarchy() -> None:
         "No context value is set for <class 'str'> (scope APP). "
         "Pass context={...} to the container or call set_context().\n"
         "See: https://modern-di.modern-python.org/troubleshooting/context-not-set/"
+    )
+
+
+class _RenderTerminal: ...
+
+
+class _RenderIface: ...
+
+
+class _RenderCaptor: ...
+
+
+def test_invalid_scope_dependency_error_draws_the_chain_that_reached_the_terminal() -> None:
+    terminal = providers.Factory(scope=Scope.REQUEST, creator=_RenderTerminal)
+    iface = providers.Alias(source_type=_RenderTerminal, bound_type=_RenderIface)
+    captor = providers.Factory(scope=Scope.APP, creator=_RenderCaptor)
+
+    error = exceptions.InvalidScopeDependencyError(provider=captor, parameter_name="dep", dep_chain=[iface, terminal])
+
+    captor_at = f"{__name__}:{inspect.getsourcelines(_RenderCaptor)[1]}"
+    terminal_at = f"{__name__}:{inspect.getsourcelines(_RenderTerminal)[1]}"
+    assert error.dep_provider is iface
+    assert error.dep_terminal is terminal
+    # The alias hop draws at REQUEST, the scope it resolves at, not the APP its own `.scope` reports.
+    assert iface.scope is Scope.APP
+    assert str(error) == (
+        "Provider at a deeper scope reached through this chain:\n"
+        f"  APP      _RenderCaptor ({captor_at})\n"
+        "  REQUEST  └─> _RenderIface\n"
+        f"  REQUEST      └─> _RenderTerminal ({terminal_at})\n"
+        "  caused by: _RenderCaptor (scope APP) declares parameter 'dep' typed as a provider of "
+        "_RenderTerminal at deeper scope REQUEST. A provider cannot depend on a deeper-scoped provider.\n"
+        "See: https://modern-di.modern-python.org/troubleshooting/scope-chain/"
     )


### PR DESCRIPTION
Closes #444.

## What was wrong

`validate()`'s scope check follows redirects to decide whether an edge is inverted, then builds a
message naming the *declared* dependency beside the *terminal's* scope and throws the hops away.
Through an `Alias` — how an abstract base or `Protocol` is bound to an implementation — those are
two different providers, and the one you have to change is named nowhere:

```
- Provider Handler (scope APP) declares parameter 'svc' typed as a provider
  of IA at deeper scope REQUEST.

+ Provider at a deeper scope reached through this chain:
+     APP      Handler (app:8)
+     REQUEST  └─> IA
+     REQUEST      └─> IB
+     REQUEST          └─> IC
+     REQUEST              └─> Impl (app:7)
+     caused by: Handler (scope APP) declares parameter 'svc' typed as a
+     provider of Impl at deeper scope REQUEST.
```

`IA` is the Protocol and declares no scope at all; `REQUEST` belongs to `Impl`. `Impl` was not
recoverable in code either — `.dep_provider` is the alias and its source type is private — so the
fact was absent from the message *and* from the attribute surface.

Per [ADR 0009](../blob/main/docs/adr/0009-error-text-is-not-a-contract.md) awkward wording is not by
itself a defect. Three things put this past that bar:

1. A sibling out of the same `_walk_errors` loop already did it right: a cycle through the same alias
   drew the full tree with declaration sites. One `validate()` call, two chain-shaped errors, only
   one drawing the chain — the drift the shared `_render_chain` exists to prevent.
2. The missing fact was structural, not textual. That is ADR 0009's own revisit trigger one step
   earlier: nothing to parse out of `str(exc)`, because the terminal was not in the string.
3. Even with no alias in sight, this error carried no `module:line` for either provider, while every
   other chain-shaped error does. `validate()`, whose only job is diagnosis, printed strictly less
   than the crash it exists to prevent.

## What changed

- `terminal_chain()` in `dependency_graph.py` keeps the providers the redirect walk passes through
  instead of discarding them to return a scope. `DependencyGraph.terminal_scope` is gone;
  `effective_scope()` and `redirect_step()` sit on top of the chain.
- `InvalidScopeDependencyError` takes `dep_chain`, renders through `_render_chain`, and exposes
  `.dep_provider` / `.dep_terminal` as its ends. All formatting stayed in `exceptions.py`.
- Redirect hops draw at the scope they *resolve* at, so the APP/REQUEST boundary lands on the
  offending edge. `Alias.scope` still returns `APP` — scope ordering depends on it — so this is a
  rendering rule, not a change to the provider.

## Deliberate collateral

`CircularDependencyError` and the runtime `ScopeNotInitializedError` printed the same `APP` fiction
for alias hops, because `Alias` sets `_takes_group_scope = False` and passes `scope=UNSET`. They read
through the same drawer, so they are fixed here rather than left to drift. ADR 0009 licenses both
message changes without a deprecation cycle.

`Alias` cannot import `dependency_graph` (`dependency_graph` → `providers.abstract` →
`providers/__init__` → `alias`), so the alias resolver builds its step via `redirect_step()` in
`resolver_compiler` and `Alias._resolution_step` is deleted. That avoids re-hand-rolling the chain
walk [ADR 0007](../blob/main/docs/adr/0007-unify-graph-traversal.md) removed. The step is built
inside `except`, so nothing lands on the hot path.

`RegistrationError` stays the base class. Nothing registers when this fires, but under ADR 0009 the
hierarchy is the contract and reparenting would silently break a caller catching it, to fix a
misfiling that costs nobody anything.

## Guards

- `test_validate_and_runtime_name_the_same_chain_for_one_scope_violation` — the two detectors must
  agree, which is the defect stated as a property. Message shape can then change freely.
- `test_alias_scope_violation_names_the_source_behind_the_alias` — the terminal is recoverable
  without parsing the message.
- `test_invalid_scope_dependency_error_draws_the_chain_that_reached_the_terminal` — the alias hop
  draws `REQUEST` while its own `.scope` is `APP`.

514 tests pass, `just lint` (ruff + ty) clean, `mkdocs build --strict` clean. Recorded as ADR 0029,
with a revisit trigger on a second provider type implementing `redirect_target`: effective-scope
rendering assumes a redirect owns no lifetime of its own, true of `Alias` and nothing else.

`CONTEXT.md` gains **Effective scope**, since the bug was exactly the gap between that and a
provider's declared scope.
