### PR TITLE
feat: generate Factory resolvers from a source template; compile overrides in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,12 @@ the site only, and root Markdown, `.github/`, and `docs/agents/` are unchecked.
 Every module under `modern_di/` is named for what it does; read it. What a single-file read will
 **not** tell you:
 
-- `resolver_compiler.py` is the **single resolve path**, one flat closure compiled per provider. A new
-  provider type must add a branch here or `compile_resolver` raises. Never extract a helper from those
-  closures — the per-node frame budget is the point, and
-  `test_resolve_costs_exactly_one_resolver_frame_per_node` says why.
+- `resolver_compiler.py` is the **single resolve path**. A `Factory` resolver is generated from a source
+  template per resolver shape and `exec`'d with the factory's constants as globals; the other provider
+  types compile to closures. A new provider type must add a branch here or `compile_resolver` raises.
+  Nothing in the template calls a helper on the hot path: the per-node frame budget is the point, and
+  `test_resolve_costs_exactly_one_resolver_frame_per_node` says why. Overrides are compiled in
+  (`docs/adr/0030-exec-template-resolver.md`): an override change drops the compiled resolvers.
 - `exceptions.py` owns **every message and every glyph**. A raise site passes structured facts, never
   formatting; the class renders its own f-string and sets a `docs_slug` (its page under
   `docs/troubleshooting/`, enforced by `tests/test_docs_slug_census.py`). Add a message, a glyph, or a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,11 @@ _Avoid_: registered type, return type
 The partition of a creator's parameters by how each is satisfied.
 _Avoid_: compiled kwargs
 
+**Resolver shape**:
+The parts of a Factory that decide its generated resolver source: arity or kwarg names, static
+kwargs, context kwargs, cached. Factories of one shape share a code object.
+_Avoid_: template (that is the source the shape is rendered into), signature
+
 **Finalizer**:
 A cleanup callback on a cached provider, run LIFO at close.
 _Avoid_: teardown, destructor

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,11 +19,11 @@ cost. Runs in CI (informational, non-gating) and locally via `just bench`.
 | G7 | Full lifecycle batch: K=100 x (build REQUEST -> sync-init cached resolve -> `await close_async()`) | real per-request cost incl. async teardown |
 | G7c | Control: K=100 empty awaits in one loop entry | residual event-loop floor inside G7 |
 | G8 | Cold first-resolve: build root container + compile + resolve, depth 6 | construction + first-compile cost |
-| G8b | G8 with every provider `cache=True` | `_compile_cached_factory`'s cold-miss builders, read against G8 |
+| G8b | G8 with every provider `cache=True` | the cached template's cold-miss `build`/`create`, read against G8 |
 | G9 | Context resolve: request value by type + APP dep, warm child | non-pure context-folding path |
 | G10 | `validate()` on a depth-6 chain (isolated via `pedantic`) | graph-validation traversal, deep |
 | G11 | `validate()` on a wide 10-sibling graph (isolated via `pedantic`) | graph-validation traversal, fan-out |
-| G12 | Resolve a depth-6 chain with one unrelated override active | override front-guard (`fetch_override`) tax |
+| G12 | Resolve a depth-6 chain with one unrelated override active | that an active override costs the unrelated chain nothing |
 | G13 | Per-request cycle finalizing 10 cached resources (`close_sync`) | LIFO teardown at scale |
 | G14 | Concurrent cached-hit throughput, N threads (lock-free read) | free-threaded read scaling |
 | G15 | Concurrent first-resolve, N threads (double-checked creation lock) | free-threaded creation-lock contention |

--- a/benchmarks/test_guard_cold.py
+++ b/benchmarks/test_guard_cold.py
@@ -85,8 +85,8 @@ def _cold_build_and_resolve_cached() -> C0:
 
 
 def test_g8b_cold_first_resolve_cached(benchmark):
-    # G8's `cache=True` sibling. G8 is all-transient, so it never reaches
-    # `_compile_cached_factory`'s cold-miss builders (`build_cold` / `create_cold`); the only
+    # G8's `cache=True` sibling. G8 is all-transient, so it never reaches the cached
+    # template's cold-miss `build` / `create` functions; the only
     # other coverage is incidental inside G15, which batches 50 misses into one timed call and
     # dilutes a single builder ~50x. This times six of them against G8 as the control, so a
     # regression confined to the cached cold path is readable as the G8b/G8 difference.

--- a/benchmarks/test_guard_resolve.py
+++ b/benchmarks/test_guard_resolve.py
@@ -274,8 +274,8 @@ class OverrideChainGroup(Group):
 
 
 def test_g12_override_active_resolve(benchmark):
-    # Override front-guard tax: an UNRELATED override flips has_overrides True, so every node in the
-    # depth-6 chain pays a fetch_override lookup per resolve (the path a test suite with mocks hits).
+    # An UNRELATED override is active. Overrides are compiled in, so every node in the depth-6
+    # chain should cost exactly what it costs in G3; a gap between G12 and G3 is a regression.
     container = Container(scope=Scope.APP, groups=[OverrideChainGroup])
     container.open()
     container.override(OverrideChainGroup.sentinel, Sentinel())

--- a/docs/adr/0017-exec-hot-path-declined.md
+++ b/docs/adr/0017-exec-hot-path-declined.md
@@ -1,5 +1,9 @@
 # Re-decline `exec` codegen on the resolve hot path
 
+> **Superseded by [ADR-0030](0030-exec-template-resolver.md).** The measurement below compared
+> `exec` against the closures as an optimisation; 0030 adopts it to remove the closures' duplication
+> and records that the warm path is not slower.
+
 **Decision:** the shipped closure-compiled resolver stays the single resolve path. No `exec`-based
 source-generation codegen, additive or otherwise.
 

--- a/docs/adr/0030-exec-template-resolver.md
+++ b/docs/adr/0030-exec-template-resolver.md
@@ -1,0 +1,78 @@
+# Generate `Factory` resolvers from a source template; compile overrides in
+
+**Decision:** a `Factory` resolver is generated from a source template, specialised to the
+factory's *resolver shape* (arity or kwarg names, static kwargs, context kwargs, cached) and
+`exec`'d with the factory's constants as the function's globals. One code object is compiled per
+shape and shared by every factory of that shape. Overrides are compiled in: an overridden provider
+compiles to `return value`, and any override change drops the compiled resolvers so the next
+resolve recompiles. Nothing on the resolve path consults the overrides registry. `Container.resolve`
+memoizes type → resolver directly. Supersedes [ADR-0017](0017-exec-hot-path-declined.md).
+
+**The motive is readability, and 0017 measured the wrong comparison.** The closure compiler held
+seven near-identical closures (an arity ladder of three plus a kwargs path for transient factories,
+three more for cached ones) with the context-fold loop copied verbatim twice, and a comment on
+every copy explaining why it could not be shared. 0017 compared `exec` against those closures as an
+*optimisation* and found 0-4%; it did not ask what the closures cost to read. Every all-Python
+single-copy design was built and measured before this one, and every one pays:
+
+| Design | G1 transient | G3 chain depth 6 | G4 wide | Why |
+|---|---|---|---|---|
+| Arity ladder folded into one closure with branches | +31% | +26% | +35% | closure size: every *untaken* branch costs (bisected: +7%, +12%, +20%, +27% as branches accumulate) |
+| Shared `build()` helper, call inline | +66% | +47% | +47% | one frame per node |
+| Shared `build()` and `call()` helpers | +79% | +62% | +58% | two frames per node |
+| Template, one code object per **provider** | −2% | −21% | −30% | monomorphic call sites; `compile()` ≈ 70 µs per provider (G8 cold +1850%) |
+| **Template, one code object per shape** (this ADR) | **−5%** | **+4%** | **−13%** | cold first-resolve +55% (≈ 2 µs per provider, once per registry) |
+
+Warm paths are at baseline or better; the frame-per-node invariant
+(`test_resolve_costs_exactly_one_resolver_frame_per_node`) holds by construction, since generated
+functions have no free variables at all. Unrolling every arity (no list build, no `CALL_FUNCTION_EX`)
+is what pays for G4.
+
+**Two facts the closures were hiding.** On CPython 3.14 a closure's *size* costs on every call,
+not only its frames: the bisect above added branches that never executed. And code objects
+shared across providers turn every call site polymorphic for the specialising interpreter; the
+per-provider row is 20-30% faster on chains for that reason alone. This ADR takes the per-shape
+setting because a pytest suite building a container per test would pay the per-provider
+`compile()` per test; per-provider stays available as a later opt-in.
+
+**Overrides compiled in.** The front-guard (`has_overrides`, `fetch_override`) ran at the top of
+every resolver on every resolve, so that a test could swap a value under a compiled graph. The
+registry already drops every compiled resolver on mutation; treating an override as a mutation
+reuses that path and removes the guard from all five resolver kinds. Measured against the template
+with the guard: G1 −7%, G3 −6%, G16 −5%, and G12 (a chain resolved while an unrelated override is
+active) −32%, which is the path every test using `override()` takes. All override behaviours
+(handles, nesting, prior restore, propagation through an alias, scope bypass) pass unchanged. A
+reset that changes nothing drops nothing, so `close()` on a root does not churn the memo.
+
+**Shipped together, against `main` on the same machine** (CPython 3.14, medians): G1 transient −10%,
+G2 cached −11%, G3 chain −3%, G4 wide −19%, G5 cross-scope −7%, G9 context −16%, G12 override-active
+−30%, G16/G17 by-type −23%, G18 alias −12%, G7 request lifecycle −6%; G8 cold first-resolve +12%,
+G8b cold cached +1%, child build unchanged.
+
+**Accepted costs**, disclosed:
+
+- The hot path is a string: no `ruff`, no `ty`, no syntax highlighting, whitespace by hand. The
+  template is complete functions (`resolve`, and `build`/`create` for the cached form), never
+  fragments, so it reads as the resolver one would write. The template and its namespace are
+  coupled by name; `test_every_resolver_shape_compiles_and_resolves` enumerates every shape so a
+  mismatch is a test failure, not a `NameError` in a user's application.
+- Coverage cannot see generated lines. The behavioural suite covers them; the 100% line gate now
+  measures the generator, not the resolver.
+- `exec` (`S102`) appears once. Kwarg names enter the source only as `repr` string keys in a dict
+  literal, never as identifiers; `test_kwarg_names_that_are_not_identifiers_are_quoted_into_the_source`
+  pins it with a key containing a quote and a hyphen.
+- Tracebacks: generated source is registered in `linecache` per shape, so a creator's exception shows
+  the resolver's line. `__qualname__` is `resolve[<display name>]` for profilers.
+- Cold first-resolve is ≈ 2 µs per provider slower (G8 +55%); the shape cache is bounded by the
+  number of distinct shapes, at worst one per provider.
+- An override change recompiles lazily: ≈ 2-5 µs per provider actually resolved afterwards. Overriding
+  is a test-time operation and is not coordinated with concurrent resolves on other threads, which
+  the `Container.override` docstring now says.
+- 0017's free-threading concern (generated-module globals instead of closure cells) does not
+  apply as stated: each resolver's namespace dict is written once by `exec` and read-only after,
+  the same immutability cells had. `tests/test_free_threading.py` passes; a free-threaded build has
+  not been run.
+
+**Revisit trigger:** a measured cold-start or per-test regression attributable to `compile()`,
+which is the per-provider code-object question above; or a CPython release where the per-shape and
+per-provider rows converge, at which point the shape cache is complexity without a payoff.

--- a/docs/introduction/performance.md
+++ b/docs/introduction/performance.md
@@ -2,10 +2,11 @@
 
 This page compares modern-di's resolution performance against four other Python
 DI frameworks, states the method, and gives a command to reproduce the numbers.
-modern-di has no runtime dependencies and generates no code. The comparison set
-includes two frameworks that use `exec` codegen (dishka, wireup), one with a
-Cython-compiled core (dependency-injector), and one pure-Python framework
-(that-depends).
+modern-di has no runtime dependencies; each `Factory` resolver is generated from a
+source template (`docs/adr/0030-exec-template-resolver.md` in the repository records
+why and the measurements). The comparison set includes two other frameworks that use
+`exec` codegen (dishka, wireup), one with a Cython-compiled core (dependency-injector),
+and one pure-Python framework (that-depends).
 
 > Absolute timings depend on the machine and CPython build and will differ on
 > yours. The ratios between frameworks are more portable across machines, so the
@@ -303,5 +304,4 @@ across machines than the absolute times.
 ## See also
 
 - [Comparison](comparison.md) — how modern-di compares on features.
-- [Design decisions](design-decisions.md) — why resolution is sync-only and why
-  `exec` codegen is a non-goal.
+- [Design decisions](design-decisions.md) — why resolution is sync-only.

--- a/modern_di/container.py
+++ b/modern_di/container.py
@@ -7,7 +7,7 @@ import typing
 import warnings
 from types import FrameType
 
-from modern_di import exceptions, suggester, types
+from modern_di import exceptions, types
 from modern_di.dependency_graph import (
     Cycle,
     DependenciesError,
@@ -140,7 +140,7 @@ class Container:
         else:
             self.providers_registry = ProvidersRegistry()
             self.providers_registry.register(Container, container_provider)
-            self.overrides_registry = OverridesRegistry()
+            self.overrides_registry = self.providers_registry.overrides
         if groups:
             all_providers: list[AbstractProvider[typing.Any]] = []
             for one_group in groups:
@@ -193,28 +193,17 @@ class Container:
         return self._lock
 
     def resolve(self, dependency_type: type[types.T]) -> types.T:
-        """Resolve a dependency by its type.
-
-        Carries its own copy of `resolve_provider`'s body rather than calling it: the extra
-        frame is ~19% of a by-type resolve. The duplication is deliberate and the two must be
-        edited together -- see docs/adr/0026-resolve-provider-not-a-seam.md.
-        """
+        """Resolve a dependency by its type."""
         registry = self.providers_registry
-        provider = registry._providers.get(dependency_type)  # noqa: SLF001
-        if provider is None:
-            raise exceptions.ProviderNotRegisteredError(
-                provider_type=dependency_type,
-                suggestions=suggester.suggest(dependency_type, registry),
-            )
-        if self.closed:
-            self._prepare()
         try:
-            resolver = registry._resolvers.get(provider.provider_id)  # noqa: SLF001
+            resolver = registry._resolvers_by_type.get(dependency_type)  # noqa: SLF001
             if resolver is None:
-                resolver = registry.resolver_for(provider)
+                resolver = registry.resolver_for_type(dependency_type)
+            if self.closed:
+                self._prepare()
             return resolver(self)
         except RecursionError as exc:
-            _handle_recursion_error(provider, self, exc)
+            _handle_recursion_error(registry._providers[dependency_type], self, exc)  # noqa: SLF001
 
     def resolve_dependency(self, dependency: "AbstractProvider[types.T] | type[types.T]") -> types.T:
         """Resolve a provider reference or a type — the marker-dispatch entry point for integrations.
@@ -228,16 +217,10 @@ class Container:
         return self.resolve(dependency)
 
     def resolve_provider(self, provider: "AbstractProvider[types.T]") -> types.T:
-        """Resolve a specific provider by reference via its compiled resolver.
-
-        `resolve` holds a copy of this body; any change here belongs there too.
-        """
+        """Resolve a specific provider by reference via its compiled resolver."""
         if self.closed:
             self._prepare()
         try:
-            # Inlined memo hit; `resolver_for` is called only on a miss, where it owns the cycle
-            # guard and the memo write (see test_resolve_costs_exactly_one_resolver_frame_per_node).
-            # Inside the try so a RecursionError while compiling still becomes CircularDependencyError.
             registry = self.providers_registry
             resolver = registry._resolvers.get(provider.provider_id)  # noqa: SLF001
             if resolver is None:
@@ -320,9 +303,12 @@ class Container:
             self.closed = True
 
     def override(self, provider: AbstractProvider[types.T], override_object: types.T) -> OverrideHandle[types.T]:
-        """Apply an override immediately.
+        """Apply an override immediately, tree-wide.
 
-        Use the returned handle as a context manager to auto-restore the prior state.
+        Use the returned handle as a context manager to auto-restore the prior state. An override
+        is compiled in: applying or resetting one drops the compiled resolvers, and the next
+        resolve recompiles. Overriding is a test-time operation, not coordinated with concurrent
+        resolves on other threads.
         """
         prior = self.overrides_registry.fetch_override(provider.provider_id)
         self.overrides_registry.override(provider.provider_id, override_object)

--- a/modern_di/providers/factory.py
+++ b/modern_di/providers/factory.py
@@ -183,14 +183,3 @@ class Factory(AbstractProvider[types.T_co]):
         plan = self._plan(container)
         for name, item in plan.unwireable:
             yield self._argument_resolution_error(arg_name=name, item=item, registry=container.providers_registry)
-
-    def _call_creator(self, resolved_kwargs: dict[str, typing.Any]) -> types.T_co:
-        try:
-            return self._creator(**resolved_kwargs)
-        except TypeError as exc:
-            error = exceptions.CreatorCallError.from_type_error(
-                creator=self._creator, exc=exc, resolution_step=self._resolution_step
-            )
-            if error is None:
-                raise
-            raise error from exc

--- a/modern_di/registries/overrides_registry.py
+++ b/modern_di/registries/overrides_registry.py
@@ -7,25 +7,30 @@ from modern_di import types
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class OverridesRegistry:
+    """Test-time replacement values by provider id.
+
+    Overrides are applied at compile time: every change calls ``on_change`` so the owning
+    providers registry drops its compiled resolvers, and the next resolve recompiles with the
+    override baked in. Nothing consults this registry on the resolve path.
+    """
+
+    on_change: typing.Callable[[], None]
     _overrides: dict[int, typing.Any] = dataclasses.field(init=False, default_factory=dict)
-    # default_factory (not default): a slots=True dataclass strips the class-level default of an
-    # init=False field, so a plain `default=False` never lands on the instance. `bool()` is False.
-    has_overrides: bool = dataclasses.field(init=False, default_factory=bool)
 
     def override(self, provider_id: int, override_object: object) -> None:
         self._overrides[provider_id] = override_object
-        self.has_overrides = True
+        self.on_change()
 
     def reset_override(self, provider_id: int | None = None) -> None:
         if provider_id is None:
+            if not self._overrides:
+                return
             self._overrides.clear()
-        else:
-            self._overrides.pop(provider_id, None)
-        self.has_overrides = bool(self._overrides)
+        elif self._overrides.pop(provider_id, types.UNSET) is types.UNSET:
+            return
+        self.on_change()
 
     def fetch_override(self, provider_id: int) -> object:
-        if not self._overrides:
-            return types.UNSET
         return self._overrides.get(provider_id, types.UNSET)
 
 

--- a/modern_di/registries/providers_registry.py
+++ b/modern_di/registries/providers_registry.py
@@ -1,8 +1,9 @@
 import threading
 import typing
 
-from modern_di import exceptions, types
+from modern_di import exceptions, suggester, types
 from modern_di.providers.abstract import AbstractProvider
+from modern_di.registries.overrides_registry import OverridesRegistry
 from modern_di.resolver_compiler import compile_resolver
 from modern_di.wiring import WiringPlan
 
@@ -14,13 +15,25 @@ if typing.TYPE_CHECKING:
 
 
 class ProvidersRegistry:
-    __slots__ = ("_building", "_generation", "_lock", "_plans", "_providers", "_resolvers", "_validated")
+    __slots__ = (
+        "_building",
+        "_generation",
+        "_lock",
+        "_plans",
+        "_providers",
+        "_resolvers",
+        "_resolvers_by_type",
+        "_validated",
+        "overrides",
+    )
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._providers: dict[type, AbstractProvider[typing.Any]] = {}
         self._plans: dict[int, WiringPlan] = {}
         self._resolvers: dict[int, typing.Callable[[Container], typing.Any]] = {}
+        self._resolvers_by_type: dict[type, typing.Callable[[Container], typing.Any]] = {}
+        self.overrides = OverridesRegistry(on_change=self.drop_resolvers)
         self._building = threading.local()  # per-thread compile-in-flight set; the cycle guard is per-call-stack
         self._validated = False
         self._generation = 0
@@ -108,6 +121,33 @@ class ProvidersRegistry:
                 self._resolvers[pid] = resolver
         return resolver
 
+    def resolver_for_type(self, dependency_type: type) -> "typing.Callable[[Container], typing.Any]":
+        """Return the memoized resolver for the provider bound to `dependency_type`, compiling it on a miss.
+
+        Raises `ProviderNotRegisteredError` (with did-you-mean suggestions) when nothing is bound.
+        """
+        generation = self._generation
+        provider = self._providers.get(dependency_type)
+        if provider is None:
+            raise exceptions.ProviderNotRegisteredError(
+                provider_type=dependency_type, suggestions=suggester.suggest(dependency_type, self)
+            )
+        resolver = self.resolver_for(provider)
+        with self._lock:
+            if self._generation == generation:
+                self._resolvers_by_type[dependency_type] = resolver
+        return resolver
+
+    def drop_resolvers(self) -> None:
+        """Drop the compiled resolvers so the next resolve recompiles — the overrides changed.
+
+        Plans and the validation flag survive: overrides alter neither the wiring nor the static graph.
+        """
+        with self._lock:
+            self._resolvers.clear()
+            self._resolvers_by_type.clear()
+            self._generation += 1
+
     def register(self, provider_type: type, provider: AbstractProvider[typing.Any]) -> None:
         with self._lock:
             if provider_type in self._providers:
@@ -146,5 +186,6 @@ class ProvidersRegistry:
         """
         self._plans.clear()
         self._resolvers.clear()
+        self._resolvers_by_type.clear()
         self._validated = False
         self._generation += 1

--- a/modern_di/resolver_compiler.py
+++ b/modern_di/resolver_compiler.py
@@ -1,14 +1,16 @@
-"""Compile one flat closure resolver per provider (the single resolve path).
+"""Compile one resolver per provider: the single resolve path.
 
-Each resolver front-guards its own override, navigates its target once (same-scope deps skip
-the navigation via an int compare), inlines the kwargs build and creator call, and calls its
-dependencies' resolvers by reference. Behavior-sensitive helpers (`_resolution_step`,
-`prepend_step`) are reused, not reimplemented. Context kwargs are folded at compile time --
-`ContextProvider.scope` and `.context_type` are fixed once registered, so the whole context
-lookup is inline here and owns its behaviour (see test_same_scope_context_hop_does_not_call_find_container).
+A ``Factory`` resolver is generated from a source template, specialised to the factory's
+:class:`_Shape`, and ``exec``'d with the factory's constants as its globals. Every other provider
+type compiles to a small closure. An overridden provider compiles to its override value, so the
+resolvers never consult the overrides registry; applying an override drops the compiled
+resolvers instead (see ``ProvidersRegistry.drop_resolvers``).
 """
 
+import dataclasses
 import functools
+import itertools
+import linecache
 import typing
 
 from modern_di import exceptions, types
@@ -22,353 +24,222 @@ from modern_di.wiring import _Absent, absent_disposition
 
 
 if typing.TYPE_CHECKING:
+    from types import CodeType
+
     from modern_di import Container
     from modern_di.registries.providers_registry import ProvidersRegistry
-    from modern_di.types_parser import SignatureItem
     from modern_di.wiring import WiringPlan
 
-    _ProvResolvers: typing.TypeAlias = tuple[tuple[str, typing.Callable[[Container], typing.Any]], ...]
-    #: name, ContextProvider.provider_id, its scope, its context_type, absent disposition, item.
-    #: Folded at compile time; the identity of a registered ContextProvider does not change.
-    _CtxBindings: typing.TypeAlias = tuple[tuple[str, int, typing.Any, type, _Absent, SignatureItem], ...]
+    Resolver: typing.TypeAlias = typing.Callable[[Container], typing.Any]
 
 _SCOPE_ERRORS = (exceptions.ScopeNotInitializedError, exceptions.ScopeSkippedError)
 _STEP_ERRORS = (exceptions.ResolutionError, *_SCOPE_ERRORS)
 
 
-def _can_call_positionally(f: "Factory[typing.Any]", plan: "WiringPlan") -> bool:
-    """Whether `f`'s creator can be called positionally instead of with `**kwargs`.
-
-    Eligible only when every parsed parameter is a positional-or-keyword provider dependency, in
-    signature order, with nothing omitted (no static, no context, no default-omitted, no
-    keyword-only, no kwargs-overlay extra). Exactly this graph gets the positional call; anything
-    else keeps `creator(**kwargs)`. When in doubt, exclude.
-    """
-    if not plan.pure_provider:  # pure_provider already means no static and no context kwargs
-        return False
-    names = tuple(f._parsed_kwargs)
-    if tuple(plan.provider_kwargs) != names:
-        return False  # a param was omitted/reordered, or a kwargs-overlay added an extra -> not a clean prefix
-    if any(item.is_keyword_only for item in f._parsed_kwargs.values()):
-        return False
-    # A positional-only param is dropped from _parsed_kwargs by the parser, so the remaining names
-    # can look like a clean prefix while a positional call would bind them to the wrong slots.
-    return not (names and f._has_positional_only_gap)
-
-
-def compile_resolver(
-    provider: "AbstractProvider[typing.Any]", registry: "ProvidersRegistry"
-) -> "typing.Callable[[Container], typing.Any]":
-    """Return `provider`'s compiled resolver. All provider types compile; no interpreted fallback ships."""
+def compile_resolver(provider: "AbstractProvider[typing.Any]", registry: "ProvidersRegistry") -> "Resolver":
+    """Return `provider`'s compiled resolver; an overridden provider resolves to its override value."""
+    override = registry.overrides.fetch_override(provider.provider_id)
+    if override is not types.UNSET:
+        return _compile_constant(override)
     if type(provider) is Factory:
-        if provider.cache_settings is None:
-            return _compile_transient_factory(provider, registry)
-        return _compile_cached_factory(provider, registry)
+        return _compile_factory(provider, registry)
     if type(provider) is Alias:
         return _compile_alias(provider)
     if provider is container_provider:
-        return _compile_container_provider()
+        return _resolve_to_container
     if type(provider) is ContextProvider:
         return _compile_context_provider(provider)
     msg = f"no compiled resolver for provider type {type(provider).__name__}"
-    raise TypeError(msg)  # every provider type is compiled; a new type must add a branch here
+    raise TypeError(msg)
 
 
-def _compile_transient_factory(  # noqa: C901, PLR0915 (two hot-path closures: positional + kwargs, each flat to hold the per-node frame at 1)
-    f: "Factory[typing.Any]", registry: "ProvidersRegistry"
-) -> "typing.Callable[[Container], typing.Any]":
+def _can_call_positionally(f: "Factory[typing.Any]", plan: "WiringPlan") -> bool:
+    """Whether `f`'s creator can be called positionally.
+
+    True when every parsed parameter is a positional-or-keyword provider dependency, in signature
+    order, with nothing omitted, added, keyword-only or positional-only.
+    """
+    if not plan.pure_provider:
+        return False
+    names = tuple(f._parsed_kwargs)
+    if tuple(plan.provider_kwargs) != names:
+        return False
+    if any(item.is_keyword_only for item in f._parsed_kwargs.values()):
+        return False
+    return not (names and f._has_positional_only_gap)
+
+
+_TRANSIENT = """\
+def resolve(container):
+    target = container if container.scope == scope else _navigate(container, scope, resolution_step)
+    if target.closed:
+        target._prepare()
+    try:
+{build}
+    except _STEP_ERRORS as exc:
+        exc.prepend_step(resolution_step())
+        raise
+    try:
+        return creator({args})
+    except TypeError as exc:
+        error = CreatorCallError.from_type_error(creator=creator, exc=exc, resolution_step=resolution_step)
+        if error is None:
+            raise
+        raise error from exc
+"""
+
+_CACHED = """\
+def build(target):
+    try:
+{build}
+    except _STEP_ERRORS as exc:
+        exc.prepend_step(resolution_step())
+        raise
+    return {built}
+
+def create(built):
+    try:
+        return creator({star}built)
+    except TypeError as exc:
+        error = CreatorCallError.from_type_error(creator=creator, exc=exc, resolution_step=resolution_step)
+        if error is None:
+            raise
+        raise error from exc
+
+def resolve(container):
+    target = container if container.scope == scope else _navigate(container, scope, resolution_step)
+    if target.closed:
+        target._prepare()
+    cache_registry = target.cache_registry
+    cache_item = cache_registry._items.get(pid)
+    if cache_item is None:
+        cache_item = cache_registry.fetch_cache_item(provider)
+    cached = cache_item.cache
+    if cached is not UNSET:
+        return cached
+    value, created = cache_item.get_or_create(target._lock, resolve=partial(build, target), create=create)
+    if created:
+        cache_registry.mark_created(cache_item)
+    return value
+"""
+
+_CONTEXT_FOLD = """\
+        for name, context_scope, context_type, disposition, item in context:
+            holder = target if target.scope == context_scope else target.find_container(context_scope)
+            if holder.closed:
+                holder._prepare()
+            value = holder.context_registry.find_context(context_type)
+            if value is not UNSET:
+                kwargs[name] = value
+            elif disposition is NULL:
+                kwargs[name] = None
+            elif disposition is not OMIT:
+                raise build_arg_error(arg_name=name, item=item)
+"""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Shape:
+    """The parts of a Factory that decide its generated source; factories of one shape share a code object."""
+
+    arity: int
+    names: tuple[str, ...] | None
+    static: bool
+    context: bool
+    cached: bool
+
+    def source(self) -> str:
+        if self.names is None:
+            build = "\n".join(f"        a{i} = r{i}(target)" for i in range(self.arity)) or "        pass"
+            args = ", ".join(f"a{i}" for i in range(self.arity))
+            built = "(" + "".join(f"a{i}, " for i in range(self.arity)) + ")"
+            star = "*"
+        else:
+            build = (
+                "        kwargs = {" + ", ".join(f"{name!r}: r{i}(target)" for i, name in enumerate(self.names)) + "}"
+            )
+            if self.static:
+                build += "\n        kwargs.update(static)"
+            if self.context:
+                build += "\n" + _CONTEXT_FOLD.rstrip("\n")
+            args, built, star = "**kwargs", "kwargs", "**"
+        if self.cached:
+            return _CACHED.format(build=build, built=built, star=star)
+        return _TRANSIENT.format(build=build, args=args)
+
+
+_shape_ids = itertools.count()
+
+
+@functools.cache
+def _code(shape: _Shape) -> "CodeType":
+    source = shape.source()
+    filename = f"<modern_di resolver shape {next(_shape_ids)}>"
+    linecache.cache[filename] = (len(source), None, source.splitlines(keepends=True), filename)
+    return compile(source, filename, "exec")
+
+
+def _compile_factory(f: "Factory[typing.Any]", registry: "ProvidersRegistry") -> "Resolver":
     plan = registry.plan_for(f, f._parsed_kwargs, f._kwargs)
     if plan.unwireable:
         return _compile_unwireable_factory(f, plan)
-    prov: _ProvResolvers = tuple((name, registry.resolver_for(p)) for name, p in plan.provider_kwargs.items())
-    static = plan.static_kwargs
-    ctx: _CtxBindings = tuple(
-        (name, cp.provider_id, cp.scope, cp.context_type, absent_disposition(item), item)
-        for name, (cp, item) in plan.context_kwargs.items()
-    )
-    pure = plan.pure_provider
-    scope = f.scope
-    pid = f.provider_id
-    resolution_step = f._resolution_step
-    build_arg_error = f._argument_resolution_error
-    creator = f._creator
-
-    if _can_call_positionally(f, plan):
-        # Positional fast path; `pure` is True here, so no static/context folding runs.
-        # Measured: creator(**kwargs) costs 4-6x this path -- do not simplify it away.
-        # See test_resolve_costs_exactly_one_resolver_frame_per_node.
-        pos = tuple(r for _name, r in prov)
-
-        # Arity ladder. `len(pos)` is fixed at compile time, so 0 and 1 deps get a closure that
-        # names its argument and calls the creator directly -- no list build, no
-        # CALL_FUNCTION_EX unpack, and below 3.12 no comprehension frame either. Each rung is a
-        # full copy for the same reason the rest of this module is: a shared helper would cost a
-        # frame per node -- which is also why the ladder stops at 1. Every measured win lives at
-        # arity 0 and 1 (leaves and chains); rungs beyond that duplicate the closure's whole
-        # branch set for a gain no scenario in `benchmarks/` shows. Arity 2+ falls through to the
-        # generic star-call below.
-        if len(pos) == 0:
-
-            def resolve_arity0(container: "Container") -> typing.Any:
-                overrides = container.overrides_registry
-                if overrides.has_overrides:
-                    override = overrides.fetch_override(pid)
-                    if override is not types.UNSET:
-                        return override
-                target = container if container.scope == scope else _navigate(container, scope, resolution_step)
-                if target.closed:
-                    target._prepare()
-                try:
-                    return creator()
-                except TypeError as exc:
-                    error = exceptions.CreatorCallError.from_type_error(
-                        creator=creator, exc=exc, resolution_step=resolution_step
-                    )
-                    if error is None:
-                        raise
-                    raise error from exc
-
-            return resolve_arity0
-
-        if len(pos) == 1:
-            (r0,) = pos
-
-            def resolve_arity1(container: "Container") -> typing.Any:
-                overrides = container.overrides_registry
-                if overrides.has_overrides:
-                    override = overrides.fetch_override(pid)
-                    if override is not types.UNSET:
-                        return override
-                target = container if container.scope == scope else _navigate(container, scope, resolution_step)
-                if target.closed:
-                    target._prepare()
-                try:
-                    a0 = r0(target)
-                except _STEP_ERRORS as exc:
-                    exc.prepend_step(resolution_step())
-                    raise
-                try:
-                    return creator(a0)
-                except TypeError as exc:
-                    error = exceptions.CreatorCallError.from_type_error(
-                        creator=creator, exc=exc, resolution_step=resolution_step
-                    )
-                    if error is None:
-                        raise
-                    raise error from exc
-
-            return resolve_arity1
-
-        def resolve_positional(container: "Container") -> typing.Any:
-            # Inlined per closure, not extracted: frame budget -- see
-            # test_resolve_costs_exactly_one_resolver_frame_per_node.
-            overrides = container.overrides_registry
-            if overrides.has_overrides:
-                override = overrides.fetch_override(pid)
-                if override is not types.UNSET:
-                    return override
-            target = container if container.scope == scope else _navigate(container, scope, resolution_step)
-            if target.closed:
-                target._prepare()
-            try:  # build the positional args from the dependency resolvers (a dependency can raise ResolutionError)
-                args = [r(target) for r in pos]
-            except _STEP_ERRORS as exc:
-                exc.prepend_step(resolution_step())
-                raise
-            try:  # inlined Factory._call_creator, positional
-                return creator(*args)
-            except TypeError as exc:
-                error = exceptions.CreatorCallError.from_type_error(
-                    creator=creator, exc=exc, resolution_step=resolution_step
-                )
-                if error is None:
-                    raise
-                raise error from exc
-
-        return resolve_positional
-
-    # The folded context lookup is inline by design: extracting it would cost a Python frame
-    # per context kwarg, which is the budget this module exists to hold.
-    def resolve(container: "Container") -> typing.Any:  # noqa: C901, PLR0912
-        overrides = container.overrides_registry
-        if overrides.has_overrides:
-            override = overrides.fetch_override(pid)
-            if override is not types.UNSET:
-                return override
-        target = container if container.scope == scope else _navigate(container, scope, resolution_step)
-        if target.closed:
-            target._prepare()
-        try:  # build the kwargs dict from provider/static/context bindings
-            kwargs = {name: r(target) for name, r in prov}
-            if not pure:
-                kwargs.update(static)
-                # `find_container`, never `_navigate`: that helper prepends a resolution step and
-                # the `except` below prepends this factory's own, rendering the caller twice.
-                for name, cpid, cscope, ctype, disp, item in ctx:
-                    if overrides.has_overrides:
-                        override = overrides.fetch_override(cpid)
-                        if override is not types.UNSET:
-                            kwargs[name] = override
-                            continue
-                    holder = target if target.scope == cscope else target.find_container(cscope)
-                    if holder.closed:
-                        holder._prepare()
-                    value = holder.context_registry.find_context(ctype)
-                    if value is not types.UNSET:
-                        kwargs[name] = value
-                    elif disp is _Absent.NULL:
-                        kwargs[name] = None
-                    elif disp is not _Absent.OMIT:
-                        raise build_arg_error(arg_name=name, item=item)
-        except _STEP_ERRORS as exc:
-            exc.prepend_step(resolution_step())
-            raise
-        try:  # inlined Factory._call_creator
-            return creator(**kwargs)
-        except TypeError as exc:
-            error = exceptions.CreatorCallError.from_type_error(
-                creator=creator, exc=exc, resolution_step=resolution_step
+    static = dict(plan.static_kwargs)
+    context: list[tuple[typing.Any, ...]] = []
+    for name, (context_provider, item) in plan.context_kwargs.items():
+        override = registry.overrides.fetch_override(context_provider.provider_id)
+        if override is not types.UNSET:
+            static[name] = override
+        else:
+            context.append(
+                (name, context_provider.scope, context_provider.context_type, absent_disposition(item), item)
             )
-            if error is None:
-                raise
-            raise error from exc
-
+    positional = _can_call_positionally(f, plan)
+    shape = _Shape(
+        arity=len(plan.provider_kwargs),
+        names=None if positional else tuple(plan.provider_kwargs),
+        static=bool(static),
+        context=bool(context),
+        cached=f.cache_settings is not None,
+    )
+    namespace: dict[str, typing.Any] = {
+        "provider": f,
+        "pid": f.provider_id,
+        "scope": f.scope,
+        "creator": f._creator,
+        "resolution_step": f._resolution_step,
+        "build_arg_error": f._argument_resolution_error,
+        "static": static,
+        "context": tuple(context),
+        "UNSET": types.UNSET,
+        "NULL": _Absent.NULL,
+        "OMIT": _Absent.OMIT,
+        "partial": functools.partial,
+        "_navigate": _navigate,
+        "_STEP_ERRORS": _STEP_ERRORS,
+        "CreatorCallError": exceptions.CreatorCallError,
+        **{f"r{i}": registry.resolver_for(p) for i, p in enumerate(plan.provider_kwargs.values())},
+    }
+    exec(_code(shape), namespace)  # noqa: S102  # the source is a fixed template; user data enters only via `namespace`
+    resolve = namespace["resolve"]
+    resolve.__qualname__ = f"resolve[{f.display_name}]"
     return resolve
 
 
-def _compile_cached_factory(  # noqa: C901, PLR0915 (cold-miss builder pair: positional + kwargs, plus the warm-hit resolve closure)
-    f: "Factory[typing.Any]", registry: "ProvidersRegistry"
-) -> "typing.Callable[[Container], typing.Any]":
-    plan = registry.plan_for(f, f._parsed_kwargs, f._kwargs)
-    if plan.unwireable:
-        return _compile_unwireable_factory(f, plan)
-    prov: _ProvResolvers = tuple((name, registry.resolver_for(p)) for name, p in plan.provider_kwargs.items())
-    static = plan.static_kwargs
-    ctx: _CtxBindings = tuple(
-        (name, cp.provider_id, cp.scope, cp.context_type, absent_disposition(item), item)
-        for name, (cp, item) in plan.context_kwargs.items()
-    )
-    pure = plan.pure_provider
-    scope = f.scope
-    pid = f.provider_id
-    resolution_step = f._resolution_step
-    build_arg_error = f._argument_resolution_error
-    creator = f._creator  # cold-miss only (not hot)
-    call_creator = f._call_creator  # cold-miss only; reused (not hot)
-
-    # Cold-miss builder + creator call, positional or kwargs. Both share the two-phase error handling.
-    if _can_call_positionally(f, plan):
-        pos = tuple(r for _name, r in prov)
-
-        def build_args(target: "Container") -> list[typing.Any]:
-            try:
-                return [r(target) for r in pos]
-            except _STEP_ERRORS as exc:
-                exc.prepend_step(resolution_step())
-                raise
-
-        def create_positional(args: list[typing.Any]) -> typing.Any:
-            try:
-                return creator(*args)
-            except TypeError as exc:
-                error = exceptions.CreatorCallError.from_type_error(
-                    creator=creator, exc=exc, resolution_step=resolution_step
-                )
-                if error is None:
-                    raise
-                raise error from exc
-
-        build_cold = build_args
-        create_cold = create_positional
-    else:
-
-        def build_kwargs(target: "Container") -> dict[str, typing.Any]:
-            try:
-                kwargs = {name: r(target) for name, r in prov}
-                if not pure:
-                    kwargs.update(static)
-                    overrides = target.overrides_registry
-                    # `find_container`, never `_navigate` -- see the transient copy above.
-                    for name, cpid, cscope, ctype, disp, item in ctx:
-                        if overrides.has_overrides:
-                            override = overrides.fetch_override(cpid)
-                            if override is not types.UNSET:
-                                kwargs[name] = override
-                                continue
-                        holder = target if target.scope == cscope else target.find_container(cscope)
-                        if holder.closed:
-                            holder._prepare()
-                        value = holder.context_registry.find_context(ctype)
-                        if value is not types.UNSET:
-                            kwargs[name] = value
-                        elif disp is _Absent.NULL:
-                            kwargs[name] = None
-                        elif disp is not _Absent.OMIT:
-                            raise build_arg_error(arg_name=name, item=item)
-            except _STEP_ERRORS as exc:
-                exc.prepend_step(resolution_step())
-                raise
-            return kwargs
-
-        build_cold = build_kwargs
-        create_cold = call_creator
-
-    def resolve(container: "Container") -> typing.Any:
-        overrides = container.overrides_registry
-        if overrides.has_overrides:
-            override = overrides.fetch_override(pid)
-            if override is not types.UNSET:
-                return override
-        target = container if container.scope == scope else _navigate(container, scope, resolution_step)
-        if target.closed:
-            target._prepare()
-        # Inlined memo hit; the method is called only on a miss, where its `setdefault` makes
-        # concurrent first-resolvers share one CacheItem. See test_cached_resolver_has_no_cell_on_the_warm_path.
-        cache_registry = target.cache_registry
-        cache_item = cache_registry._items.get(pid)
-        if cache_item is None:
-            cache_item = cache_registry.fetch_cache_item(f)
-        cached = cache_item.cache
-        if cached is not types.UNSET:
-            return cached
-        value, created = cache_item.get_or_create(
-            target._lock,
-            # `partial`, never a lambda closing over `target`: a closure promotes `target` to a cell,
-            # so MAKE_CELL runs in this resolver's prologue on every warm hit too. See
-            # test_cached_resolver_has_no_cell_on_the_warm_path.
-            resolve=functools.partial(build_cold, target),
-            # positional/kwargs builders have distinct arg types; get_or_create feeds each its own.
-            create=typing.cast("typing.Callable[[typing.Any], typing.Any]", create_cold),
-        )
-        if created:
-            target.cache_registry.mark_created(cache_item)
+def _compile_constant(value: typing.Any) -> "Resolver":
+    def resolve(_: "Container") -> typing.Any:
         return value
 
     return resolve
 
 
-def _compile_unwireable_factory(
-    f: "Factory[typing.Any]", plan: "WiringPlan"
-) -> "typing.Callable[[Container], typing.Any]":
-    """Compile the always-raising resolver for a Factory with an unwireable parameter.
-
-    Front-guard the override (an unwireable factory can still be overridden with a mock), navigate
-    to the scope-correct target (a scope error there wins, with its step prepended), then raise the
-    freshly built error with this factory's own resolution step. The error is built on every call
-    (never memoized) so `prepend_step`'s mutation cannot leak a breadcrumb across repeated resolves.
-    """
-    pid = f.provider_id
+def _compile_unwireable_factory(f: "Factory[typing.Any]", plan: "WiringPlan") -> "Resolver":
+    """Compile a resolver that always raises for the factory's first unwireable parameter, freshly built per call."""
     scope = f.scope
     resolution_step = f._resolution_step
     build_error = f._argument_resolution_error
     arg_name, item = plan.unwireable[0]
 
     def resolve(container: "Container") -> typing.Any:
-        overrides = container.overrides_registry
-        if overrides.has_overrides:
-            override = overrides.fetch_override(pid)
-            if override is not types.UNSET:
-                return override
         target = container if container.scope == scope else _navigate(container, scope, resolution_step)
         if target.closed:
             target._prepare()
@@ -379,28 +250,17 @@ def _compile_unwireable_factory(
     return resolve
 
 
-def _compile_alias(a: "Alias[typing.Any]") -> "typing.Callable[[Container], typing.Any]":
-    """Call the source's compiled resolver directly, wrapping scope/resolution errors with its own step.
-
-    The source lookup and its resolver memo read are inlined, and nothing is cached: a source
-    registered later is picked up on the next resolve. A single try/except covers the
-    dangling-source lookup and the forwarded resolve, so both carry this alias's resolution step.
-    """
-    pid = a.provider_id
+def _compile_alias(a: "Alias[typing.Any]") -> "Resolver":
+    """Call the source's resolver directly; a source registered later is picked up on the next resolve."""
     source_type = a._source_type
     find_source = a._find_source
 
     def resolve(container: "Container") -> typing.Any:
-        overrides = container.overrides_registry
-        if overrides.has_overrides:
-            override = overrides.fetch_override(pid)
-            if override is not types.UNSET:
-                return override
         try:
             registry = container.providers_registry
             source = registry._providers.get(source_type)
             if source is None:
-                source = find_source(container)  # raises AliasSourceNotRegisteredError
+                source = find_source(container)
             source_resolver = registry._resolvers.get(source.provider_id)
             if source_resolver is None:
                 source_resolver = registry.resolver_for(source)
@@ -412,38 +272,15 @@ def _compile_alias(a: "Alias[typing.Any]") -> "typing.Callable[[Container], typi
     return resolve
 
 
-def _compile_container_provider() -> "typing.Callable[[Container], typing.Any]":
-    """Resolve to the resolving container itself — no scope navigation."""
-    pid = container_provider.provider_id
-
-    def resolve(container: "Container") -> typing.Any:
-        overrides = container.overrides_registry
-        if overrides.has_overrides:
-            override = overrides.fetch_override(pid)
-            if override is not types.UNSET:
-                return override
-        return container
-
-    return resolve
+def _resolve_to_container(container: "Container") -> typing.Any:
+    return container
 
 
-def _compile_context_provider(cp: "ContextProvider[typing.Any]") -> "typing.Callable[[Container], typing.Any]":
-    """Front-guard the override, then inline the context lookup at this provider's fixed scope.
-
-    The same inline lookup the folded context kwargs use, with the scope read once here rather than
-    per resolve (see test_direct_context_resolve_reads_the_scope_only_at_compile_time).
-    `find_container`, never `_navigate`: nothing prepends a resolution step on the direct path.
-    """
-    pid = cp.provider_id
+def _compile_context_provider(cp: "ContextProvider[typing.Any]") -> "Resolver":
     scope = cp.scope
     context_type = cp.context_type
 
     def resolve(container: "Container") -> typing.Any:
-        overrides = container.overrides_registry
-        if overrides.has_overrides:
-            override = overrides.fetch_override(pid)
-            if override is not types.UNSET:
-                return override
         target = container if container.scope == scope else container.find_container(scope)
         if target.closed:
             target._prepare()
@@ -460,7 +297,7 @@ def _navigate(
     scope: typing.Any,
     resolution_step: "typing.Callable[[], exceptions.ResolutionStep]",
 ) -> "Container":
-    """Cross-scope target lookup; prepends the resolution step to a scope error, as the interpreted path does."""
+    """Cross-scope target lookup; a scope error carries this provider's resolution step."""
     try:
         return container.find_container(scope)
     except _SCOPE_ERRORS as exc:

--- a/tests/registries/test_providers_registry.py
+++ b/tests/registries/test_providers_registry.py
@@ -5,7 +5,7 @@ import typing
 import pytest
 
 from modern_di import Container, Group, providers, suggester
-from modern_di.exceptions import DuplicateProviderTypeError
+from modern_di.exceptions import DuplicateProviderTypeError, ProviderNotRegisteredError
 from modern_di.providers.abstract import AbstractProvider
 from modern_di.registries import providers_registry as pr_mod
 from modern_di.registries.providers_registry import ProvidersRegistry
@@ -61,6 +61,31 @@ def test_mutation_clears_the_resolver_and_plan_memos() -> None:
     registry.add_providers(providers.Factory(scope=Scope.APP, creator=_Other, bound_type=_Other))
     assert registry._resolvers == {}  # mutation cleared the memos
     assert registry._plans == {}
+
+
+def test_by_type_memo_is_filled_on_a_miss_and_cleared_by_mutation() -> None:
+    """INVARIANT: every registry mutation clears the by-type resolver memo.
+
+    `Container.resolve` reads `_resolvers_by_type` before anything else; a stale entry would keep
+    resolving a provider the registry no longer holds that way.
+    """
+
+    class _Dep: ...
+
+    registry = ProvidersRegistry()
+    dep_factory = providers.Factory(scope=Scope.APP, creator=_Dep, bound_type=_Dep)
+    registry.add_providers(dep_factory)
+    resolver = registry.resolver_for_type(_Dep)
+    assert registry._resolvers_by_type == {_Dep: resolver}
+    assert registry._resolvers[dep_factory.provider_id] is resolver
+
+    class _Other: ...
+
+    registry.add_providers(providers.Factory(scope=Scope.APP, creator=_Other, bound_type=_Other))
+    assert registry._resolvers_by_type == {}
+
+    with pytest.raises(ProviderNotRegisteredError):
+        registry.resolver_for_type(int)
 
 
 def test_providers_registry_add_provider_duplicates() -> None:

--- a/tests/test_resolver_compiler.py
+++ b/tests/test_resolver_compiler.py
@@ -1,15 +1,16 @@
-"""Direct tests for compiled-resolver path selection.
+"""Direct tests for the resolver compiler.
 
 The differential-harness suite in ``tests/providers/test_factory.py`` characterizes each
-compiled path black-box through ``resolve_provider``. These pin the three things it leaves
-unguarded: the argument-ordering invariant the positional fast path silently depends on,
-``_can_call_positionally``'s full contract (four exclusion rules plus the positive case)
-called directly, and the per-node frame budget the compiled path exists to hold.
+compiled path black-box through ``resolve_provider``. These pin what it leaves unguarded: the
+argument-ordering invariant the positional path depends on, ``_can_call_positionally``'s full
+contract, the per-node frame budget, and the contracts of the generated source (shape sharing,
+source lines in tracebacks, non-identifier kwarg names, overrides compiled as constants).
 """
 
 import dataclasses
 import inspect
 import sys
+import traceback
 import types as _pytypes
 import typing
 
@@ -113,16 +114,12 @@ class _L5:
 
 _CHAIN: tuple[type, ...] = (_L0, _L1, _L2, _L3, _L4, _L5)
 
-#: Python calls one extra chain node costs: its resolver closure, plus its creator.
+#: Python calls one extra chain node costs: its generated resolver, plus its creator.
 #: The creator is the user's own object construction and is irreducible; the **1**
 #: resolver frame is the budget this module exists to hold. Pinned below by
-#: ``test_resolve_costs_exactly_one_resolver_frame_per_node``.
-#:
-#: Version-independent because these chain nodes have arity 1, which the positional
-#: path compiles to a closure that names its argument and calls the creator directly
-#: -- no comprehension, so nothing for PEP 709 to inline or not inline. A comprehension
-#: frame survives on the arity-2+ generic star-call and on the kwargs path, where below
-#: 3.12 it still costs a third frame per node.
+#: ``test_resolve_costs_exactly_one_resolver_frame_per_node``. Version-independent: the
+#: generated source names every argument and calls the creator directly, so no
+#: comprehension frame exists to inline or not inline.
 _CALLS_PER_NODE = 2
 
 
@@ -231,20 +228,19 @@ def _arity_group(
     return _pytypes.new_class(f"_AG{arity}_{scope.name}", (Group,), exec_body=lambda ns2: ns2.update(members))
 
 
-# Each arity rung is a full copy of the closure, so every branch in it -- the override
-# front-guard, the scope hop, the closed-target reopen, and both error handlers -- exists once
-# per rung and regresses independently. These parametrize over the rungs the ladder compiles.
+# Arity 0, 1 and 2 generate different source (no argument, one, several), so each branch of
+# the template -- the scope hop, the closed-target reopen, and both error handlers -- is
+# exercised at every arity.
 
 
 @pytest.mark.parametrize("arity", [0, 1, 2])
 def test_arity_rung_front_guards_the_override(arity: int) -> None:
-    """INVARIANT: every compiled resolver checks the override registry before anything else.
+    """INVARIANT: an override wins over the compiled resolver at every arity.
 
-    The guard runs before scope navigation, before the cache and before the creator. Each arity rung
-    is a full copy of the closure, so a rung added without the guard regresses only that rung. That
-    the same guard still short-circuits an otherwise-unwireable factory is proven separately by
-    `test_unwireable_factory_override_short_circuits` in `tests/providers/test_factory.py` -- this
-    test's dependencies are all ordinarily wireable.
+    An overridden provider compiles to its override value, before scope navigation, the cache
+    and the creator. That the same rule short-circuits an otherwise-unwireable factory is proven
+    separately by `test_unwireable_factory_override_short_circuits` in
+    `tests/providers/test_factory.py` -- this test's dependencies are all ordinarily wireable.
     """
     group = _arity_group(arity)
     container = Container(scope=Scope.APP, groups=[group])
@@ -258,10 +254,10 @@ def test_arity_rung_front_guards_the_override(arity: int) -> None:
 def test_arity_rung_navigates_to_its_own_scope(arity: int) -> None:
     """INVARIANT: a resolver walks to its declared scope exactly once per resolve.
 
-    The same-scope case is an int compare, not a `find_container` call. This test pins that the rung
-    navigates at all; the wrong target is not observable here (dependencies navigate themselves), so
-    the skip-navigation mutant is killed by `test_arity_rung_reopens_a_closed_target` and
-    `test_arity_rung_prepends_its_step_to_a_dependency_error`.
+    The same-scope case is an int compare, not a `find_container` call. This test pins that the
+    resolver navigates at all; the wrong target is not observable here (dependencies navigate
+    themselves), so the skip-navigation mutant is killed by `test_arity_rung_reopens_a_closed_target`
+    and `test_arity_rung_prepends_its_step_to_a_dependency_error`.
     """
     group = _arity_group(arity)
     app = Container(scope=Scope.APP, groups=[group])
@@ -273,7 +269,7 @@ def test_arity_rung_navigates_to_its_own_scope(arity: int) -> None:
 @pytest.mark.parametrize("arity", [0, 1, 2])
 def test_arity_rung_reopens_a_closed_target(arity: int) -> None:
     # The closed target must be an ANCESTOR, not the container the call enters on: the entry
-    # `resolve_provider` reopens itself first, so only a cross-scope hop reaches the closure's
+    # `resolve_provider` reopens itself first, so only a cross-scope hop reaches the resolver's
     # own `if target.closed` guard.
     group = _arity_group(arity)
     app = Container(scope=Scope.APP, groups=[group])
@@ -287,7 +283,7 @@ def test_arity_rung_reopens_a_closed_target(arity: int) -> None:
 @pytest.mark.parametrize("arity", [0, 1, 2])
 def test_arity_rung_wraps_a_creator_type_error(arity: int) -> None:
     # A creator whose real signature needs one more argument than the parser reports: the
-    # positional call then raises TypeError, which the rung must convert to CreatorCallError.
+    # positional call then raises TypeError, which the resolver must convert to CreatorCallError.
     def _needs_one_more(*args: object, extra: object) -> _Bag:  # noqa: ARG001  # pragma: no cover
         msg = "unreachable - binding fails before the body runs; that is the point"
         raise AssertionError(msg)
@@ -312,7 +308,7 @@ def test_arity_rung_wraps_a_creator_type_error(arity: int) -> None:
 @pytest.mark.parametrize("arity", [0, 1, 2])
 def test_arity_rung_reraises_a_type_error_from_inside_the_creator(arity: int) -> None:
     # A TypeError with an inner traceback frame is the creator's own failure, not a binding one:
-    # every rung must let it through unwrapped.
+    # every arity must let it through unwrapped.
     params = ", ".join(f"p{i}: _P{i}" for i in range(arity))
     ns: dict[str, typing.Any] = {"_P0": _P0, "_P1": _P1, "_P2": _P2, "_Bag": _Bag}
     exec(f"def _c({params}) -> _Bag:\n    raise TypeError('from inside')", ns)  # noqa: S102
@@ -327,8 +323,8 @@ def test_arity_rung_reraises_a_type_error_from_inside_the_creator(arity: int) ->
 
 @pytest.mark.parametrize("arity", [1, 2])
 def test_arity_rung_prepends_its_step_to_a_dependency_error(arity: int) -> None:
-    # Arity 0 builds no arguments, so it has no argument-build `try`; 1 is the rung and 2 is the
-    # generic star-call, and each carries its own copy of the handler.
+    # Arity 0 builds no arguments, so its `try` body is empty; 1 and 2 generate one and two
+    # argument lines under the same handler.
     deps = [f"_D{i}" for i in range(arity)]
     ns: dict[str, typing.Any] = {}
     for name in deps:
@@ -504,9 +500,9 @@ def test_first_resolve_does_not_reintrospect_creator(monkeypatch: pytest.MonkeyP
 
 
 def test_resolve_costs_exactly_one_resolver_frame_per_node() -> None:
-    """INVARIANT: resolving one node costs exactly one Python frame -- its own compiled resolver.
+    """INVARIANT: resolving one node costs exactly one Python frame -- its own generated resolver.
 
-    Extracting the override guard, the scope hop, the kwargs build or the creator call into a shared
+    Moving the scope hop, the argument build or the creator call out of the template into a shared
     helper costs one frame *per resolved node* and moves the slope from 2 to 3. Measured as a
     difference between two chain depths, so the harness's fixed cost cancels.
     """
@@ -558,8 +554,8 @@ def test_alias_hop_costs_exactly_one_resolver_frame() -> None:
 def test_overridden_alias_compiles_nothing_of_its_source() -> None:
     """INVARIANT: an override short-circuits before its provider's subtree is compiled.
 
-    The front-guard runs before the alias source is looked up, so the mock pattern never pays to
-    compile a subtree it will not touch. Moving the guard below the source lookup breaks that.
+    `compile_resolver` checks the override before dispatching on the provider type, so the mock
+    pattern never pays to compile a subtree it will not touch.
     """
 
     class _Source: ...
@@ -582,7 +578,7 @@ def test_no_compiled_resolver_closes_over_its_registry() -> None:
     """INVARIANT: no compiled resolver captures its registry in a closure cell.
 
     A resolver that captures the registry forms a cycle with the memo holding it, so the registry
-    becomes reclaimable only by cyclic GC. Every closure reads its registries off the container arg.
+    becomes reclaimable only by cyclic GC. Every resolver reads its registries off the container arg.
     """
 
     class _Src: ...
@@ -607,20 +603,145 @@ def test_no_compiled_resolver_closes_over_its_registry() -> None:
     assert capturing == []
 
 
-@pytest.mark.parametrize(
-    ("arity", "expected"), [(0, "resolve_arity0"), (1, "resolve_arity1"), (2, "resolve_positional")]
-)
-def test_positional_path_selects_the_arity_specialised_closure(arity: int, expected: str) -> None:
-    """INVARIANT: arity 0 and 1 compile to their own specialised closures.
+def _shape_group(*, arity: int, positional: bool, context: bool, cached: bool) -> typing.Any:  # noqa: ANN401
+    """Group whose `target` factory has the given resolver shape; every shape is buildable."""
+    dep_types = [_P0, _P1, _P2][:arity]
+    params = [f"p{i}: _P{i}" for i in range(arity)]
+    if not positional:
+        params.append("*, req: _Req | None = None")
+    ns: dict[str, typing.Any] = {"_P0": _P0, "_P1": _P1, "_P2": _P2, "_Req": _Req, "_Bag": _Bag}
+    args = "".join(f"p{i}, " for i in range(arity)) + ("req," if not positional else "")
+    exec(f"def _c({', '.join(params)}) -> _Bag:\n    return _Bag(values=({args}))", ns)  # noqa: S102
+    members: dict[str, typing.Any] = {
+        f"p{i}": providers.Factory(creator=t, scope=Scope.APP) for i, t in enumerate(dep_types)
+    }
+    if context:
+        members["req"] = providers.ContextProvider(_Req, scope=Scope.APP)
+    members["target"] = providers.Factory(creator=ns["_c"], scope=Scope.APP, bound_type=_Bag, cache=cached)
+    return _pytypes.new_class("_ShapeGroup", (Group,), exec_body=lambda body: body.update(members))
 
-    Below 3.12 a comprehension is a separate code object, so a generic star-call costs a third frame
-    per node. Deleting a rung fails here on every interpreter; without this test only the 3.10 and
-    3.11 jobs would notice, and they would misreport it as an extracted helper.
+
+@pytest.mark.parametrize("cached", [False, True])
+@pytest.mark.parametrize("context", [False, True])
+@pytest.mark.parametrize("positional", [True, False])
+@pytest.mark.parametrize("arity", [0, 1, 2, 3])
+def test_every_resolver_shape_compiles_and_resolves(arity: int, positional: bool, context: bool, cached: bool) -> None:
+    """INVARIANT: every resolver shape generates source that compiles and resolves correctly.
+
+    The template and the namespace it runs in are coupled by name only, so a name used in one and
+    missing from the other is a `NameError` at resolve time for exactly that shape. Enumerating the
+    shapes turns that into a test failure.
     """
-    group = _arity_group(arity)
-    container = Container(scope=Scope.APP, groups=[group])
-    resolver = container.providers_registry.resolver_for(group.target)
-    assert typing.cast("_pytypes.FunctionType", resolver).__code__.co_name == expected
+    if positional and context:
+        pytest.skip("a context kwarg makes the creator call keyword-based")
+    group = _shape_group(arity=arity, positional=positional, context=context, cached=cached)
+    container = Container(scope=Scope.APP, groups=[group], context={_Req: _Req()} if context else None)
+
+    bag = container.resolve_provider(group.target)
+
+    assert [type(v) for v in bag.values[:arity]] == [_P0, _P1, _P2][:arity]
+    if not positional:
+        assert isinstance(bag.values[arity], _Req) if context else bag.values[arity] is None
+    again = container.resolve_provider(group.target)
+    assert (again is bag) is cached
+
+
+def test_factories_of_one_shape_share_a_code_object() -> None:
+    """INVARIANT: resolvers of the same shape share one code object; only their globals differ.
+
+    The shape is the cache key for `compile()`, which costs ~70 us per call. Keying on anything
+    provider-specific would pay that per provider instead of per shape.
+    """
+
+    class _G(Group):
+        left = providers.Factory(creator=_L1, scope=Scope.APP)
+        right = providers.Factory(creator=_L2, scope=Scope.APP)
+        leaf = providers.Factory(creator=_L0, scope=Scope.APP)
+
+    container = Container(scope=Scope.APP, groups=[_G])
+    left = typing.cast("_pytypes.FunctionType", container.providers_registry.resolver_for(_G.left))
+    right = typing.cast("_pytypes.FunctionType", container.providers_registry.resolver_for(_G.right))
+    leaf = typing.cast("_pytypes.FunctionType", container.providers_registry.resolver_for(_G.leaf))
+
+    assert left.__code__ is right.__code__
+    assert leaf.__code__ is not left.__code__
+    assert left.__qualname__ == "resolve[_L1]"
+
+
+def test_generated_resolver_frames_carry_source_lines() -> None:
+    """INVARIANT: a traceback through a generated resolver shows its source line.
+
+    Generated source is registered in `linecache` under the code object's filename; without that a
+    creator's exception renders the resolver frame as a bare filename with no code.
+    """
+
+    def _boom() -> _A:
+        msg = "from the creator"
+        raise ValueError(msg)
+
+    class _G(Group):
+        target = providers.Factory(creator=_boom, scope=Scope.APP)
+
+    container = Container(scope=Scope.APP, groups=[_G])
+    with pytest.raises(ValueError, match="from the creator") as exc:
+        container.resolve_provider(_G.target)
+
+    frames = traceback.extract_tb(exc.value.__traceback__)
+    generated = [f for f in frames if f.filename.startswith("<modern_di resolver")]
+    assert generated, "no generated frame in the traceback"
+    assert generated[0].line == "return creator()"
+
+
+def test_kwarg_names_that_are_not_identifiers_are_quoted_into_the_source() -> None:
+    """INVARIANT: an explicit ``kwargs={...}`` key reaches the generated source only as a string literal.
+
+    A ``**kwargs`` creator accepts any key, so a key such as ``"it's x-y"`` must be emitted with
+    `repr`, never spliced in as an identifier.
+    """
+
+    def _creator(**kwargs: object) -> _Bag:
+        return _Bag(values=tuple(kwargs.items()))
+
+    class _G(Group):
+        dep = providers.Factory(creator=_P0, scope=Scope.APP)
+        target = providers.Factory(creator=_creator, scope=Scope.APP, bound_type=_Bag, kwargs={"it's x-y": dep})
+
+    container = Container(scope=Scope.APP, groups=[_G])
+    bag = container.resolve_provider(_G.target)
+    assert bag.values[0][0] == "it's x-y"
+    assert isinstance(bag.values[0][1], _P0)
+
+
+def test_override_change_drops_compiled_resolvers_and_recompiles_to_the_constant() -> None:
+    """INVARIANT: applying or resetting an override drops every compiled resolver.
+
+    Overrides are compiled in, not checked at resolve time: a parent resolver holds its
+    dependencies' resolvers by reference, so the only way a new override reaches it is a recompile.
+    Dropping nothing on a no-op reset keeps `close()` on a root from churning the memo.
+    """
+
+    class _G(Group):
+        leaf = providers.Factory(creator=_L0, scope=Scope.APP)
+        node = providers.Factory(creator=_L1, scope=Scope.APP)
+
+    container = Container(scope=Scope.APP, groups=[_G])
+    container.resolve_provider(_G.node)
+    registry = container.providers_registry
+    assert registry._resolvers
+
+    sentinel = _L0()
+    container.override(_G.leaf, sentinel)
+    assert registry._resolvers == {}
+    assert container.resolve_provider(_G.node).dep is sentinel
+
+    container.reset_override(_G.leaf)
+    assert registry._resolvers == {}
+    assert container.resolve_provider(_G.node).dep is not sentinel
+
+    compiled = dict(registry._resolvers)
+    container.reset_override(_G.node)  # never overridden
+    container.reset_override()  # nothing overridden
+    assert registry._resolvers == compiled
 
 
 def test_cached_resolver_has_no_cell_on_the_warm_path() -> None:


### PR DESCRIPTION
## What

`resolver_compiler.py` held seven near-identical closures (an arity ladder plus a kwargs path for transient factories, three more for cached ones), the context-fold loop copied verbatim twice, and a comment on every copy explaining why it could not be shared. This replaces them with one source template per *resolver shape*, `exec`'d with the factory's constants as globals. 468 → 305 lines; every hot-path idea now appears once.

Two further changes ride along because the template made them cheap to measure:

- **Overrides are compiled in.** An overridden provider compiles to `return value`; any override change drops the compiled resolvers and the next resolve recompiles. No resolver consults the overrides registry anymore. The `override()` / handle API is unchanged and every override test passes as-is.
- **By-type memo.** `Container.resolve` goes type → resolver in one lookup, and stops being a hand-copy of `resolve_provider` (retires the duplication ADR-0026 accepted).

## Why `exec`

Every all-Python single-copy design was built and measured first, and every one pays: folding the ladder into one closure with branches +26-35% (closure *size* costs on 3.14, even for untaken branches), a shared `build()` helper +47-66%, shared `build()`+`call()` +58-79%. The template is the only design that removes the duplication without a per-node cost, and it keeps the one-frame-per-node invariant by construction (generated functions have no free variables). Full tables and the rejected designs are in `docs/adr/0030-exec-template-resolver.md`, which supersedes ADR-0017.

## Numbers (branch vs main, CPython 3.14, medians)

| scenario | main | branch | |
|---|---|---|---|
| G16 by-type | 186 ns | 144 ns | −23% |
| G12 chain with an unrelated override active | 1072 ns | 748 ns | −30% |
| G4 wide, 10 deps | 1433 ns | 1164 ns | −19% |
| G9 context | 653 ns | 548 ns | −16% |
| G1 transient | 265 ns | 237 ns | −10% |
| G2 cached warm | 166 ns | 148 ns | −11% |
| G7 request lifecycle | 254 µs | 238 µs | −6% |
| G8 cold first-resolve, 6 providers | 23.7 µs | 26.5 µs | +12% |

Cold is the one trade: `compile()` runs once per shape (28 shapes across the whole suite), ≈ 2 µs per provider on first resolve.

## Accepted costs

- The hot path is a string: no ruff/ty on the template, whitespace by hand. Templates are complete functions, never fragments. `test_every_resolver_shape_compiles_and_resolves` enumerates all 32 shapes so a template/namespace name mismatch is a test failure.
- Coverage cannot see generated lines; the behavioural suite covers them.
- One `S102` with a reason. Kwarg names enter the source only as `repr` string keys; pinned by a test with a key containing a quote and a hyphen.
- Generated source is registered in `linecache`, so tracebacks through a resolver show its line; `__qualname__` is `resolve[<name>]`.

## Tests

540 pass, 100% line coverage. Removed the three closure-name assertions; the frame-count and no-cell invariants stay and pass. Added: shape enumeration, shape code-object sharing, traceback source lines, non-identifier kwarg keys, override change drops/recompiles (including the no-op reset), by-type memo cleared on mutation.

## Before merging

- The guard-bench job gives the 3.10 and 3.11 numbers; the table above is 3.14 on one machine. Specialisation arrived in 3.11, so the older interpreters may show smaller deltas in both directions.
- Docs: `performance.md`'s opening claim ("generates no code") is corrected; the 3.2/3.3 narrative sections are left as history.
- Deliberately not in this PR: comment stripping elsewhere, `exceptions.py` split, and the 4.0 candidates from the same research (required context values, terminal `close()`).
