### PR TITLE
chore(ruff): converge on the standard's ruff block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,21 +57,19 @@ exclude = ["benchmarks/comparative"]
 fix = true
 unsafe-fixes = true
 line-length = 120
-target-version = "py310"
 extend-exclude = ["docs", "benchmarks/comparative"]
 
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    "D1",     # allow missing docstrings
-    "S101",   # allow asserts
-    "TCH",    # ignore flake8-type-checking
-    "FBT",    # allow boolean args
-    "D203",   # "one-blank-line-before-class" conflicting with D211
-    "D213",   # "multi-line-summary-second-line" conflicting with D212
-    "COM812", # flake8-commas "Trailing comma missing"
-    "ISC001", # flake8-implicit-str-concat
+    "D1",     # docstrings are not forced; a docstring exists when it says something
+    "D203",   # conflicts with D211
+    "D213",   # conflicts with D212
+    "COM812", # conflicts with the formatter
+    "ISC001", # conflicts with the formatter
     "CPY001", # no per-file copyright header
+    "FBT",    # boolean positional arguments are fine
+    "TCH",    # imports stay real; TYPE_CHECKING-only imports break runtime introspection
 ]
 isort.lines-after-imports = 2
 isort.no-lines-before = ["standard-library", "local-folder"]
@@ -81,7 +79,9 @@ isort.no-lines-before = ["standard-library", "local-folder"]
 # set), and every resolver returns `typing.Any`.
 "modern_di/resolver_compiler.py" = ["SLF001", "ANN401"]
 # White-box tests assert on container and registry internals; that is what they are for.
-"tests/**" = ["SLF001"]
+"tests/**" = ["S101", "SLF001"]
+# Guard-tier benchmarks are pytest tests too: they assert on the measured ratios.
+"benchmarks/**" = ["S101"]
 
 [tool.pytest.ini_options]
 addopts = ""


### PR DESCRIPTION
## Summary

Converges `[tool.ruff]` on the block in the [modern-python standard](https://modern-python.org/standard/#3-ruff). Configuration only; no behaviour change in the package.

## Changes

- `fix = true`, and `target-version` removed: ruff derives it from `requires-python`.
- The `ignore` list is the standard's eight entries, each with its one-line reason. Ignores measured to suppress nothing across the org are gone (`G004`, `TRY003`, `EM102` where present). Repo-specific ignores the standard allows are kept, with a reason.
- `S101` moves from a global ignore to `"tests/**"`: assert is the test idiom, and in library code it is a finding. There were no package-side hits to fix.

- `benchmarks/**` gains `S101` per-file: the guard-tier benchmarks are pytest tests that assert on ratios.

## Checklist

- [x] Lint and format pass (`just lint-ci`)
- [x] Type check passes (`ty`, part of `lint-ci`)
- [x] Tests pass and new behavior is covered — no behaviour change; CI runs the suite
- [x] Build succeeds — no packaging change
- [x] Repo metadata stays consistent across the three surfaces — untouched
