### PR TITLE
chore(coverage): declare the gate in [tool.coverage.report] and measure only in test-ci

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,11 +25,11 @@ test *args:
 
 # The gated full run: 100% line coverage required. CI runs this.
 test-ci:
-    uv run --no-sync pytest --cov=. --cov-report term-missing --cov-report xml --cov-fail-under=100
+    uv run --no-sync pytest --cov=. --cov-report term-missing --cov-report xml
 
 # Branch-coverage run (diagnostic; line coverage is the enforced gate, not branch).
 test-branch:
-    uv run --no-sync pytest --cov=. --cov-branch --cov-fail-under=100
+    uv run --no-sync pytest --cov=. --cov-branch
 
 # Run the guard-tier benchmark suite (zero-dep; pytest-benchmark). Excludes the
 # comparative tier, whose deps live in benchmarks/comparative and are not in this env.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,4 @@ asyncio_default_fixture_loop_scope = "function"
 run.concurrency = ["thread"]
 run.omit = ["benchmarks/*"]
 report.exclude_also = ["if typing.TYPE_CHECKING:"]
+report.fail_under = 100


### PR DESCRIPTION
## Summary

Converges the coverage gate on the [modern-python standard, section 5](https://modern-python.org/standard/#5-tests-and-coverage): the 100 % gate is declared once as `[tool.coverage.report] fail_under = 100`, and coverage is measured only by `just test-ci` (and `test-branch`), never on every run through pytest `addopts`.

pytest-cov reads `fail_under` from the coverage config when no `--cov-fail-under` flag is given and applies it whenever coverage is measured, so the gate fires in `test-ci` exactly as before and a targeted `just test` run stays gate-free. coverage special-cases 100: the total must really be 100, no rounding.

## Changes

- `pyproject.toml`: `fail_under = 100` under `[tool.coverage.report]`; any `--cov*` flags removed from `addopts`.
- `justfile`: `test-ci` measures coverage and writes the XML report without the flag; `test-branch` likewise. Where `test-ci` did not exist it is added, and CI now calls it.
- `.github/workflows/_checks.yml` (where present): the pytest step runs `just test-ci`.

## Checklist

- [x] Lint and format pass (`ruff`) — config and recipes only
- [x] Type check passes (`ty`) — no Python changed
- [x] Tests pass and new behavior is covered — CI runs `just test-ci`, which is the gate
- [x] Build succeeds — no packaging change
- [x] Repo metadata stays consistent across the three surfaces — untouched
