### PR TITLE
test(benchmarks): cover concurrent first-resolve in sibling children

### DIFF
--- a/benchmarks/test_guard_concurrency.py
+++ b/benchmarks/test_guard_concurrency.py
@@ -110,3 +110,40 @@ def test_g15_concurrent_first_resolve(benchmark, n_threads):
         _run_parallel(_worker, n_threads)
 
     benchmark.pedantic(_batch, setup=_setup, rounds=120, iterations=1)
+
+
+# --- G15b: concurrent first-resolve in sibling children ---------------------
+_REQUEST_TYPES = [type(f"ReqCold{i}", (), {}) for i in range(_K_COLD)]
+_REQUEST_GROUP = type(
+    "RequestColdGroup",
+    (Group,),
+    {f"r{i}": providers.Factory(creator=t, scope=Scope.REQUEST, cache=True) for i, t in enumerate(_REQUEST_TYPES)},
+)
+_REQUEST_PROVIDERS = [getattr(_REQUEST_GROUP, f"r{i}") for i in range(_K_COLD)]
+
+
+@pytest.mark.parametrize("n_threads", _THREAD_COUNTS)
+def test_g15b_concurrent_first_resolve_sibling_children(benchmark, n_threads):
+    # Each thread builds its OWN REQUEST child and first-resolves K cached providers in it, so
+    # every creation is a cold miss in a container no other thread touches. With a lock per
+    # container these creations never contend; with one lock per tree they serialize. This is the
+    # scenario G15 does not cover -- G15 races on one root, whose lock is shared either way.
+    check = Container(scope=Scope.APP, groups=[_REQUEST_GROUP])
+    check.open()
+    probe = check.build_child_container(scope=Scope.REQUEST)
+    assert all(probe.resolve_provider(p) is not None for p in _REQUEST_PROVIDERS)
+
+    def _setup() -> "tuple[tuple[Container], dict[str, object]]":
+        container = Container(scope=Scope.APP, groups=[_REQUEST_GROUP])
+        container.open()
+        return (container,), {}
+
+    def _batch(container) -> None:
+        def _worker() -> None:
+            child = container.build_child_container(scope=Scope.REQUEST)
+            for provider in _REQUEST_PROVIDERS:
+                child.resolve_provider(provider)
+
+        _run_parallel(_worker, n_threads)
+
+    benchmark.pedantic(_batch, setup=_setup, rounds=120, iterations=1)


### PR DESCRIPTION
Adds `test_g15b_concurrent_first_resolve_sibling_children` to the guard-tier concurrency suite. Benchmark coverage only: no source change, no behaviour change.

## Why G15 does not already cover this

G15 races N threads on a single **root** container resolving APP-scoped cached providers. Those cache items live on the root, so `CacheItem.get_or_create` takes the root's lock on every thread regardless of how locks are allocated across the tree. G15 therefore measures contention on one lock that is one lock under any design.

The case it leaves uncovered is the opposite shape: concurrent cold misses in **sibling children**, where per-container locks never contend at all. Nothing in the suite exercised it.

## What G15b does

Each thread builds its own REQUEST child from a shared root and first-resolves the same 50 REQUEST-scoped cached providers in it. Every creation is a cold miss in a container no other thread touches, so the scenario is contention-free by construction when each container owns its lock, and serialized when they share one.

Same harness, parametrization and round count as G15 (`_run_parallel`, threads `{1, 2, 4}`, 120 rounds, fresh root per round via untimed setup) so the two read side by side.

## Caveat worth knowing when reading it

The creators are trivial classes, so lock hold time is near-minimal. Contention cost scales with creation cost, which means G15b understates it for a graph whose singletons do real work on construction. It is a floor, not an estimate.

## Context

Extracted from the measurement on #478, which is where this gap surfaced: a change to lock allocation showed nothing on G15 by construction. The coverage is worth having independently of that issue's outcome, so it ships on its own. Full paired numbers are in the #478 comment; none of them are asserted here.

Verified on CPython 3.14.7 and 3.14.7t: 9 passed in the concurrency file, `just lint` clean.